### PR TITLE
Log watchers

### DIFF
--- a/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
@@ -41,10 +41,12 @@ function CrowdMapCtrl($scope, $http, params, heat, $window, map, sensors, expand
 
   $scope.$watch("{location: params.get('data').location.address, counter: params.get('data').counter}",
     function(newValue) {
+    console.log("watch - {location: params.get('data').location.address, counter: params.get('data').counter}");
     map.goToAddress(newValue.location);
   }, true);
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
+    console.log("watch - sensors.selectedId()");
     if(!newValue){
       return;
     }
@@ -63,6 +65,7 @@ function CrowdMapCtrl($scope, $http, params, heat, $window, map, sensors, expand
   };
 
   $scope.$watch("params.get('data')", function(newValue, oldValue) {
+    console.log("watch - params.get('data')");
     infoWindow.hide();
     $scope.getAverages();
   }, true);

--- a/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
@@ -47,12 +47,14 @@ function FixedSessionsMapCtrl($scope, params, heat, map, sensors, expandables, s
 
   //fix for json null parsing
   $scope.$watch("params.get('data').sensorId", function(newValue) {
+    console.log("watch - params.get('data').sensorId");
     if(_(newValue).isNull()){
       params.update({data: {sensorId: ""}});
     }
   }, true);
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
+    console.log("watch - sensors.selectedId()");
     if(newValue == oldValue || !newValue){
       return;
     }
@@ -81,6 +83,7 @@ function FixedSessionsMapCtrl($scope, params, heat, map, sensors, expandables, s
   };
 
   $scope.$watch("params.get('data').heat", function(newValue, oldValue) {
+    console.log("watch - params.get('data').heat");
     if (newValue != oldValue) {
       $scope.sessions.drawSessionsInLocation();
     }
@@ -90,6 +93,7 @@ function FixedSessionsMapCtrl($scope, params, heat, map, sensors, expandables, s
     return {sensorId: sensors.anySelectedId(), sessionId: $scope.singleSession.id()};
   };
   $scope.$watch("heatUpdateCondition()", function(newValue, oldValue) {
+    console.log("watch - heatUpdateCondition()");
     if(newValue.sensorId && newValue.sessionId && !$scope.initializing){
       functionBlocker.use("sessionHeat", function(){
         $scope.singleSession.updateHeat();

--- a/app/assets/javascripts/code/controllers/flash_ctrl.js
+++ b/app/assets/javascripts/code/controllers/flash_ctrl.js
@@ -1,6 +1,7 @@
 function FlashCtrl($scope, flash,  $timeout) {
   $scope.flash = flash;
   $scope.$watch("flash.message", function(newValue){
+    console.log("watch - flash.message");
     if(newValue){
       $timeout($scope.clear, 5000);
     }

--- a/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
@@ -45,12 +45,14 @@ function MobileSessionsMapCtrl($scope, params, heat, map, sensors, expandables, 
 
   //fix for json null parsing
   $scope.$watch("params.get('data').sensorId", function(newValue) {
+    console.log("watch - params.get('data').sensorId");
     if(_(newValue).isNull()){
       params.update({data: {sensorId: ""}});
     }
   }, true);
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
+    console.log("watch - sensors.selectedId()");
     if(newValue == oldValue){
       return;
     }
@@ -63,6 +65,7 @@ function MobileSessionsMapCtrl($scope, params, heat, map, sensors, expandables, 
     return {sensorId:  sensors.anySelectedId(), sessionId: $scope.singleSession.id()};
   };
   $scope.$watch("heatUpdateCondition()", function(newValue, oldValue) {
+    console.log("watch - heatUpdateCondition()");
     if(newValue.sensorId && newValue.sessionId){
       functionBlocker.use("sessionHeat", function(){
         $scope.singleSession.updateHeat();

--- a/app/assets/javascripts/code/controllers/panel_ctrl.js
+++ b/app/assets/javascripts/code/controllers/panel_ctrl.js
@@ -34,6 +34,7 @@ function PanelCtrl($scope,  $location, expandables) {
   };
 
   $scope.$watch('$location.path()', function(newValue) {
+    console.log('watch - $location.path()');
     $scope.selectedTab = _.str.trim(newValue, "/");
   });
 

--- a/app/assets/javascripts/code/controllers/sessions_graph_ctrl.js
+++ b/app/assets/javascripts/code/controllers/sessions_graph_ctrl.js
@@ -12,14 +12,17 @@ function SessionsGraphCtrl($scope, map, graph, flash, heat, sensors,
   }
 
   $scope.$watch('sensors.anySelected()', function() {
+    console.log('watch - sensors.anySelected()');
     updateExpanded();
   });
 
   $scope.$watch('singleSession.isSingle()', function() {
+    console.log('watch - singleSession.isSingle()');
     updateExpanded();
   });
 
   $scope.$watch('singleSession.get().loaded', function() {
+    console.log('watch - singleSession.get().loaded');
     if ($scope.expanded && !_.isEmpty(singleSession.measurements())) {
       $scope.redraw();
     }
@@ -29,6 +32,7 @@ function SessionsGraphCtrl($scope, map, graph, flash, heat, sensors,
     return $scope.expanded ? "" : "collapsed";
   };
   $scope.$watch("expanded", function(expanded) {
+    console.log("watch - expanded");
     if(!expanded){
       graphHighlight.hide();
     } else {
@@ -59,6 +63,7 @@ function SessionsGraphCtrl($scope, map, graph, flash, heat, sensors,
   };
 
   $scope.$watch("heat.getValues()", function() {
+    console.log("watch - heat.getValues()");
     if($scope.shouldRedraw()){
       $scope.redraw();
     }

--- a/app/assets/javascripts/code/controllers/sessions_list_ctrl.js
+++ b/app/assets/javascripts/code/controllers/sessions_list_ctrl.js
@@ -31,15 +31,18 @@ function SessionsListCtrl($scope, params, map, sensors, storage, flash,
   };
 
   $scope.$watch("page", function() {
+    console.log("watch - page");
     sessions.fetch($scope.page);
   }, true);
 
   $scope.$watch("sessionFetchCondition()", function(newValue, oldValue) {
+    console.log("watch - sessionFetchCondition()");
     $scope.page = 0;
     sessions.fetch($scope.page);
   }, true);
 
   $scope.$watch("sensors.isEmpty()", function(newValue, oldValue) {
+    console.log("watch - sensors.isEmpty()");
     sessions.reSelectAllSessions();
   }, true);
 
@@ -60,6 +63,7 @@ function SessionsListCtrl($scope, params, map, sensors, storage, flash,
   };
 
   $scope.$watch("sessionRedrawCondition()", function(newValue) {
+    console.log("watch - sessionRedrawCondition()");
     if(singleSession.isFixed() || (!newValue.id && !newValue.heat)){
       return;
     }
@@ -71,6 +75,7 @@ function SessionsListCtrl($scope, params, map, sensors, storage, flash,
   });
 
   $scope.$watch("params.get('sessionsIds')", function(newIds, oldIds) {
+    console.log("watch - params.get('sessionsIds')");
     functionBlocker.use("sessionDialog", function(){
       if(newIds.length === 1 && !sensors.selected()) {
         var usableSensors = singleSession.availSensors();

--- a/app/assets/javascripts/code/directives/air_input.js
+++ b/app/assets/javascripts/code/directives/air_input.js
@@ -3,6 +3,7 @@ angular.module("aircasting").directive('airinput', function(){
     link: function(scope, element, attrs, ctrl) {
       var hidden = $(element).siblings(':hidden');
       scope.$watch(hidden.attr("ng-model") ,function(newValue){
+        console.log('watch - hidden.attr("ng-model")');
         $(element).val(newValue);
       });
       $(element).bind("blur", function() {

--- a/app/assets/javascripts/code/directives/heat_background.js
+++ b/app/assets/javascripts/code/directives/heat_background.js
@@ -2,6 +2,7 @@ angular.module("aircasting").directive('heatbackground', function (){
   return {
     link: function(scope, element, attrs, controller) {
       scope.$watch(attrs.heatbackground, function(newValue) {
+        console.log('watch - attrs.heatbackground');
         _(newValue).each(function(value,key){
           $(element).find("." + key).css({height: value.width });
         });

--- a/app/assets/javascripts/code/directives/range_slider.js
+++ b/app/assets/javascripts/code/directives/range_slider.js
@@ -11,18 +11,21 @@ angular.module("aircasting").directive('rangeslider', function (){
       opts.values = [opts.min, opts.max];
       $(element).slider(opts);
       scope.$watch(attrs.sliderMin, function(newValue, oldValue) {
+        console.log('watch - attrs.sliderMin');
         if(!newValue) {
           return;
         }
         $(element).slider("option", "min", newValue);
       }, true);
       scope.$watch(attrs.sliderMax, function(newValue, oldValue) {
+        console.log('watch - attrs.sliderMax');
         if(!newValue) {
           return;
         }
         $(element).slider("option", "max", newValue);
       }, true);
       scope.$watch(attrs.sliderValue, function(newValue, oldValue) {
+        console.log('watch - attrs.sliderValue');
         if(!newValue) {
           return;
         }

--- a/app/assets/javascripts/code/directives/slider.js
+++ b/app/assets/javascripts/code/directives/slider.js
@@ -10,6 +10,7 @@ angular.module("aircasting").directive('slider', function (){
       };
       $(element).slider(opts);
       scope.$watch(attrs.sliderMin, function(newValue, oldValue) {
+        console.log('watch - attrs.sliderMin');
         if(!newValue) {
           return;
         }
@@ -17,6 +18,7 @@ angular.module("aircasting").directive('slider', function (){
         $(element).slider("value", $(element).slider("value"));
       }, true);
       scope.$watch(attrs.sliderMax, function(newValue, oldValue) {
+        console.log('watch - attrs.sliderMax');
         if(!newValue) {
           return;
         }
@@ -24,6 +26,7 @@ angular.module("aircasting").directive('slider', function (){
         $(element).slider("value", $(element).slider("value"));
       }, true);
       scope.$watch(attrs.sliderValue, function(newValue, oldValue) {
+        console.log('watch - attrs.sliderValue');
         if(!newValue) {
           return;
         }

--- a/app/assets/javascripts/code/directives/spinner.js
+++ b/app/assets/javascripts/code/directives/spinner.js
@@ -15,6 +15,7 @@ angular.module("aircasting").directive('spinner', function (){
       var overlay = $("#" + attrs.spinner);
       var spinnerInst = new Spinner(spinnerOpts);
       scope.$watch("spinner.visible()", function(newValue, oldValue){
+        console.log("watch - spinner.visible()");
         if(newValue){
           spinnerInst.spin(target);
         } else {

--- a/app/assets/javascripts/code/services/heat.js
+++ b/app/assets/javascripts/code/services/heat.js
@@ -13,6 +13,7 @@ angular.module("aircasting").factory('heat', ["$rootScope", "params", "storage",
     this.scope = $rootScope.$new();
     this.scope.params = params;
     this.scope.$watch("params.get('data').heat", function(newValue, oldValue) {
+      console.log("watch - params.get('data').heat");
       if(!newValue || _(newValue).isEmpty()){
         return;
       }

--- a/app/assets/javascripts/code/services/params.js
+++ b/app/assets/javascripts/code/services/params.js
@@ -11,6 +11,7 @@ angular.module("aircasting").factory('params', ['$location', '$rootScope', 'util
   };
   Params.prototype = {
     init: function(searchData) {
+      console.log("watch - $location.search()");
       _(searchData || {}).each(function(value, key){
         searchData[key] = angular.fromJson(value);
       });

--- a/app/assets/javascripts/code/services/storage.js
+++ b/app/assets/javascripts/code/services/storage.js
@@ -8,6 +8,7 @@ angular.module("aircasting").factory('storage', ['params', '$rootScope', 'utils'
     scope.params = params;
     this.defaults = {};
     scope.$watch("params.get('data')", function(newValue, oldValue) {
+      console.log("watch - params.get('data')");
       self.extend(newValue);
     }, true);
   };


### PR DESCRIPTION
Having a log of what watchers are triggered on each interaction will hopefully help us tracking better the state changes in development.

Having `config.assets.js_compressor  = :uglifier` in environment/production.rb should strip `console.log`s from the minified js. If that's not the case I'll take action to make it happen.