### PR TITLE
Crowd map remove all from parameters and sensors

### DIFF
--- a/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
@@ -44,14 +44,7 @@ function CrowdMapCtrl($scope, $http, params, heat, $window, map, sensors, expand
     map.goToAddress(newValue.location);
   }, true);
 
-  $scope.$watch("params.get('data').sensorId", function(newValue) {
-    console.log("watch - params.get('data').sensorId - ", newValue);
-    if(sensors.sensorChangedToAll(newValue)){
-      params.update({data: {sensorId: ""}});
-    }
-
-    sensors.onSelectedSensorChange(newValue);
-  }, true);
+  $scope.$watch("params.get('data').sensorId", function(newValue) { sensors.onSelectedSensorChange(newValue); }, true);
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
     console.log("watch - sensors.selectedId()");

--- a/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
@@ -119,7 +119,9 @@ function CrowdMapCtrl($scope, $http, params, heat, $window, map, sensors, expand
     $scope.$digest();
   };
 
-  $scope.$watch("sensors.selectedParameter", function(newValue) { sensors.onSelectedParameterChange(newValue, true); }, true);
+  $scope.$watch("sensors.selectedParameter", function(newValue, oldValue) {
+    sensors.onSelectedParameterChange(newValue, oldValue, true);
+  }, true);
 
   $scope.setDefaults();
 }

--- a/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
@@ -119,7 +119,7 @@ function CrowdMapCtrl($scope, $http, params, heat, $window, map, sensors, expand
     $scope.$digest();
   };
 
-  $scope.$watch("sensors.selectedParameter", function(newValue) { sensors.onSelectedParameterChange(newValue); }, true);
+  $scope.$watch("sensors.selectedParameter", function(newValue) { sensors.onSelectedParameterChange(newValue, true); }, true);
 
   $scope.setDefaults();
 }

--- a/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/crowd_map_ctrl.js
@@ -47,17 +47,7 @@ function CrowdMapCtrl($scope, $http, params, heat, $window, map, sensors, expand
   $scope.$watch("params.get('data').sensorId", function(newValue) { sensors.onSelectedSensorChange(newValue); }, true);
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
-    console.log("watch - sensors.selectedId()");
-    if(!newValue){
-      return;
-    }
-
-    params.update({data: {sensorId: newValue}});
-
-    sensors.onSelectedSensorChange(newValue);
-
-    spinner.show();
-    $http.get('/api/thresholds/' + sensors.selected().sensor_name, {params: {unit_symbol: sensors.selected().unit_symbol}, cache: true}).success($scope.onThresholdsFetch);
+    sensors.onSensorsSelectedIdChange(newValue, oldValue, $scope.onThresholdsFetch);
   });
 
   $scope.onThresholdsFetch = function(data, status, headers, config) {

--- a/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
@@ -44,14 +44,7 @@ function FixedSessionsMapCtrl($scope, params, heat, map, sensors, expandables, s
   };
 
   //fix for json null parsing
-  $scope.$watch("params.get('data').sensorId", function(newValue) {
-    console.log("watch - params.get('data').sensorId - ", newValue);
-    if(sensors.sensorChangedToAll(newValue)){
-      params.update({data: {sensorId: ""}});
-    }
-
-    sensors.onSelectedSensorChange(newValue);
-  }, true);
+  $scope.$watch("params.get('data').sensorId", function(newValue) { sensors.onSelectedSensorChange(newValue); }, true);
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
     console.log("watch - sensors.selectedId() - ", newValue, " - ", oldValue);

--- a/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
@@ -71,7 +71,9 @@ function FixedSessionsMapCtrl($scope, params, heat, map, sensors, expandables, s
     }
   }, true);
 
-  $scope.$watch("sensors.selectedParameter", function(newValue) { sensors.onSelectedParameterChange(newValue); }, true);
+  $scope.$watch("sensors.selectedParameter", function(newValue, oldValue) {
+    sensors.onSelectedParameterChange(newValue, oldValue);
+  }, true);
 
   $scope.heatUpdateCondition = function() {
     return {sensorId: sensors.anySelectedId(), sessionId: $scope.singleSession.id()};

--- a/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
@@ -50,6 +50,7 @@ function FixedSessionsMapCtrl($scope, params, heat, map, sensors, expandables, s
 
   $scope.onThresholdsFetch = function(data, status, headers, config) {
     storage.updateDefaults({heat: heat.parse(data)});
+    // seems like there's no call to block so this function blocker is prolly not needed
     functionBlocker.use("heat", function(){
       if (!params.get('data').heat && $scope.initializing) {
         params.update({data: {heat: heat.parse(data)}});

--- a/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/fixed_sessions_map_ctrl.js
@@ -14,7 +14,6 @@ function FixedSessionsMapCtrl($scope, params, heat, map, sensors, expandables, s
     $scope.$window = $window;
     $scope.initializing = true;
 
-    functionBlocker.block("selectedId", !!params.get('data').sensorId);
     functionBlocker.block("sessionHeat", !_(params.get('sessionsIds')).isEmpty());
 
     rectangles.clear();
@@ -43,26 +42,10 @@ function FixedSessionsMapCtrl($scope, params, heat, map, sensors, expandables, s
     params.update({'didSessionsSearch': true});
   };
 
-  //fix for json null parsing
   $scope.$watch("params.get('data').sensorId", function(newValue) { sensors.onSelectedSensorChange(newValue); }, true);
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
-    console.log("watch - sensors.selectedId() - ", newValue, " - ", oldValue);
-    if(!newValue){
-      return;
-    }
-
-    params.update({data: {sensorId: newValue}});
-
-    // Possibly this is not needed
-    sensors.onSelectedSensorChange(newValue);
-
-    spinner.show();
-    $http.get('/api/thresholds/' + sensors.selected().sensor_name,
-      {params: {unit_symbol: sensors.selected().unit_symbol}, cache: true}).success($scope.onThresholdsFetch);
-    functionBlocker.use("selectedId", function(){
-      params.update({sessionsIds: []});
-    });
+    sensors.onSensorsSelectedIdChange(newValue, oldValue, $scope.onThresholdsFetch);
   }, true);
 
   $scope.onThresholdsFetch = function(data, status, headers, config) {

--- a/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
@@ -13,7 +13,6 @@ function MobileSessionsMapCtrl($scope, params, heat, map, sensors, expandables, 
     $scope.singleSession = singleMobileSession;
     $scope.$window = $window;
 
-    functionBlocker.block("selectedId", !!params.get('data').sensorId);
     functionBlocker.block("sessionHeat", !_(params.get('sessionsIds')).isEmpty());
 
     rectangles.clear();
@@ -44,23 +43,10 @@ function MobileSessionsMapCtrl($scope, params, heat, map, sensors, expandables, 
     params.update({'didSessionsSearch': true});
   };
 
-  //fix for json null parsing
   $scope.$watch("params.get('data').sensorId", function(newValue) { sensors.onSelectedSensorChange(newValue); }, true);
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
-    console.log("watch - sensors.selectedId() - ", newValue, " - ", oldValue);
-    if(!newValue){
-      return;
-    }
-
-    params.update({data: {sensorId: newValue}});
-
-    // Possibly this is not needed
-    sensors.onSelectedSensorChange(newValue);
-
-    functionBlocker.use("selectedId", function(){
-      params.update({sessionsIds: []});
-    });
+    sensors.onSensorsSelectedIdChange(newValue, oldValue);
   }, true);
 
   $scope.heatUpdateCondition = function() {

--- a/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
@@ -45,14 +45,7 @@ function MobileSessionsMapCtrl($scope, params, heat, map, sensors, expandables, 
   };
 
   //fix for json null parsing
-  $scope.$watch("params.get('data').sensorId", function(newValue) {
-    console.log("watch - params.get('data').sensorId - ", newValue);
-    if(sensors.sensorChangedToAll(newValue)){
-      params.update({data: {sensorId: ""}});
-    }
-
-    sensors.onSelectedSensorChange(newValue);
-  }, true);
+  $scope.$watch("params.get('data').sensorId", function(newValue) { sensors.onSelectedSensorChange(newValue); }, true);
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
     console.log("watch - sensors.selectedId() - ", newValue, " - ", oldValue);

--- a/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
@@ -61,7 +61,9 @@ function MobileSessionsMapCtrl($scope, params, heat, map, sensors, expandables, 
     }
    }, true);
 
-  $scope.$watch("sensors.selectedParameter", function(newValue) { sensors.onSelectedParameterChange(newValue); }, true);
+  $scope.$watch("sensors.selectedParameter", function(newValue, oldValue) {
+    sensors.onSelectedParameterChange(newValue, oldValue);
+  }, true);
 
   $scope.setDefaults();
 }

--- a/app/assets/javascripts/code/services/sensors.js
+++ b/app/assets/javascripts/code/services/sensors.js
@@ -143,6 +143,24 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
     buildSensorId: function(sensor) {
       return sensor.measurement_type + "-" + sensor.sensor_name + " (" + sensor.unit_symbol + ")";
     },
+    onSensorsSelectedIdChange: function(newValue, oldValue, callback = null) {
+      console.log("onSensorsSelectedIdChange - ", newValue, " - ", oldValue);
+
+      if(!newValue) return; // selectedId === 'all'
+
+      if (callback) {
+        spinner.show();
+        $http.get( '/api/thresholds/' + this.selected().sensor_name, {
+          params: { unit_symbol: this.selected().unit_symbol },
+          cache: true
+        }).success(callback);
+      }
+
+      if (newValue === oldValue) return; // first run
+
+      params.update({data: {sensorId: newValue}});
+      params.update({sessionsIds: []});
+    }
   };
   return new Sensors();
 }]);

--- a/app/assets/javascripts/code/services/sensors.js
+++ b/app/assets/javascripts/code/services/sensors.js
@@ -128,16 +128,16 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
     },
     onSelectedParameterChange: function(selectedParameter, oldValue, onChangeSelectSensorWithMostSessions = false) {
       console.log('onSelectedParameterChange() - ', selectedParameter)
-      if (selectedParameter === oldValue) return; // first run
-      if (selectedParameter) { // not 'all'
+      if (selectedParameter === oldValue) return; // first angular watch run
+      if (sensorChangedToAll(selectedParameter)) {
+        this.availableSensors = this.sensors;
+        this.setAllSensors();
+      } else {
         this.availableSensors = _(this.sensors).filter(function(sensor) { return sensor["measurement_type"] == selectedParameter["id"]})
         if (onChangeSelectSensorWithMostSessions) {
           var sensor = max(function(sensor) { return sensor.session_count; }, this.availableSensors) || { id: null };
           params.update({data: {sensorId: sensor.id}});
         }
-      } else { // 'all'
-        this.availableSensors = this.sensors;
-        this.setAllSensors();
       }
     },
     onSelectedSensorChange: function(newSensorId) {
@@ -155,7 +155,7 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
     onSensorsSelectedIdChange: function(newValue, oldValue, callback = null) {
       console.log("onSensorsSelectedIdChange - ", newValue, " - ", oldValue);
 
-      if(!newValue) return; // selectedId === 'all'
+      if(sensorChangedToAll(newValue)) return;
 
       if (callback) {
         spinner.show();
@@ -165,7 +165,7 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
         }).success(callback);
       }
 
-      if (newValue === oldValue) return; // first run
+      if (newValue === oldValue) return; // first angular watch run
 
       params.update({data: {sensorId: newValue}});
       params.update({sessionsIds: []});

--- a/app/assets/javascripts/code/services/sensors.js
+++ b/app/assets/javascripts/code/services/sensors.js
@@ -2,6 +2,10 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
   function sensorChangedToAll(newValue) {
     return !newValue;
   }
+  function max(valueOf, xs) {
+    var reducer = function(acc, x) { return valueOf(x) > valueOf(acc) ? x : acc };
+    return xs.reduce(reducer, xs[0]);
+  }
 
   var Sensors = function() {
     spinner.show();
@@ -122,12 +126,15 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
         return this.sensors;
       }
     },
-    onSelectedParameterChange: function(selectedParameter, oldValue, onChangeSelectFirstSensor = false) {
+    onSelectedParameterChange: function(selectedParameter, oldValue, onChangeSelectSensorWithMostSessions = false) {
       console.log('onSelectedParameterChange() - ', selectedParameter)
       if (selectedParameter === oldValue) return; // first run
       if (selectedParameter) { // not 'all'
         this.availableSensors = _(this.sensors).filter(function(sensor) { return sensor["measurement_type"] == selectedParameter["id"]})
-        if (onChangeSelectFirstSensor) params.update({data: {sensorId: this.availableSensors[0].id}});
+        if (onChangeSelectSensorWithMostSessions) {
+          var sensor = max(function(sensor) { return sensor.session_count; }, this.availableSensors) || { id: null };
+          params.update({data: {sensorId: sensor.id}});
+        }
       } else { // 'all'
         this.availableSensors = this.sensors;
         this.setAllSensors();

--- a/app/assets/javascripts/code/services/sensors.js
+++ b/app/assets/javascripts/code/services/sensors.js
@@ -122,10 +122,11 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
         return this.sensors;
       }
     },
-    onSelectedParameterChange: function(selectedParameter) {
+    onSelectedParameterChange: function(selectedParameter, onChangeSelectFirstSensor = false) {
       console.log('onSelectedParameterChange() - ', selectedParameter)
       if (selectedParameter) {
         this.availableSensors = _(this.sensors).filter(function(sensor) { return sensor["measurement_type"] == selectedParameter["id"]})
+        if (onChangeSelectFirstSensor) params.update({data: {sensorId: this.availableSensors[0].id}});
       } else {
         this.availableSensors = this.sensors;
         this.setAllSensors();

--- a/app/assets/javascripts/code/services/sensors.js
+++ b/app/assets/javascripts/code/services/sensors.js
@@ -1,4 +1,8 @@
 angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', function(params, $http, spinner) {
+  function sensorChangedToAll(newValue) {
+    return !newValue;
+  }
+
   var Sensors = function() {
     spinner.show();
 
@@ -101,9 +105,6 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
       console.log('setAllSensors')
       params.update({data: {sensorId: ""}});
     },
-    sensorChangedToAll: function(newValue) {
-      return !newValue;
-    },
     findSensorById: function(id) {
       return this.sensors[id]
     },
@@ -131,7 +132,10 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
       }
     },
     onSelectedSensorChange: function(newSensorId) {
-      console.log('onSelectedSensorChange() - ', newSensorId)
+      console.log('onSelectedSensorChange() - ', newSensorId);
+      if(sensorChangedToAll(newSensorId)){
+        params.update({data: {sensorId: ""}});
+      }
       var sensor = this.findSensorById(newSensorId);
       var parameterForSensor = this.findParameterForSensor(sensor);
       this.selectedParameter = parameterForSensor;

--- a/app/assets/javascripts/code/services/sensors.js
+++ b/app/assets/javascripts/code/services/sensors.js
@@ -122,12 +122,13 @@ angular.module("aircasting").factory('sensors', ['params', '$http', 'spinner', f
         return this.sensors;
       }
     },
-    onSelectedParameterChange: function(selectedParameter, onChangeSelectFirstSensor = false) {
+    onSelectedParameterChange: function(selectedParameter, oldValue, onChangeSelectFirstSensor = false) {
       console.log('onSelectedParameterChange() - ', selectedParameter)
-      if (selectedParameter) {
+      if (selectedParameter === oldValue) return; // first run
+      if (selectedParameter) { // not 'all'
         this.availableSensors = _(this.sensors).filter(function(sensor) { return sensor["measurement_type"] == selectedParameter["id"]})
         if (onChangeSelectFirstSensor) params.update({data: {sensorId: this.availableSensors[0].id}});
-      } else {
+      } else { // 'all'
         this.availableSensors = this.sensors;
         this.setAllSensors();
       }

--- a/public/partials/crowd_map.html
+++ b/public/partials/crowd_map.html
@@ -2,14 +2,10 @@
   <h4 ng-click="expandables.toggle('sensor')" ng-class="expandables.css('sensor')">Parameter - Sensor</h4>
   <section ng-show="expandables.visible('sensor')" >
     <p>
-      <select ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id">
-        <option value="">All</option>
-      </select>
+      <select ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id" />
     </p>
     <p>
-      <select ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for (sensorId, sensor) in sensors.availableSensors">
-        <option value="">All</option>
-      </select>
+      <select ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for (sensorId, sensor) in sensors.availableSensors" />
     </p>
   </section>
 


### PR DESCRIPTION
Closes https://llp.kanbanery.com/projects/8040/board/tasks/2322468

Done
- Remove all from parameters' and sensors' dropdowns in crowd map
- Select sensor with the most sessions when changing parameter in crow map

Improved
- remove duplication by pushing code to `sensors.js`
- move some private functions (eg `max`) out of the exported service 
- added comments for the future, when the code will be cleaner we will remove them


Notice that the sensor selected below is the second (most sessions) not the first.
![jul-13-2018 13-19-22](https://user-images.githubusercontent.com/5238698/42689126-64d49b66-869f-11e8-8f4e-3219af7358f3.gif)
