### PR TITLE
Fix db/schema

### DIFF
--- a/db/migrate/20181113100336_add_null_true_to_timestamps.rb
+++ b/db/migrate/20181113100336_add_null_true_to_timestamps.rb
@@ -1,0 +1,12 @@
+class AddNullTrueToTimestamps < ActiveRecord::Migration
+  def change
+    change_column :notes, :created_at, :datetime, null: true
+    change_column :notes, :updated_at, :datetime, null: true
+
+    change_column :sessions, :created_at, :datetime, null: true
+    change_column :sessions, :updated_at, :datetime, null: true
+
+    change_column :users, :created_at, :datetime, null: true
+    change_column :users, :updated_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20161103124035) do
+ActiveRecord::Schema.define(:version => 20181113100336) do
 
   create_table "deleted_sessions", :force => true do |t|
     t.datetime "created_at", :null => false
@@ -32,12 +32,12 @@ ActiveRecord::Schema.define(:version => 20161103124035) do
     t.integer  "stream_id"
     t.integer  "milliseconds",                                   :default => 0
     t.float    "measured_value"
-    t.datetime "created_at"
   end
 
   add_index "measurements", ["latitude"], :name => "index_measurements_on_latitude"
   add_index "measurements", ["longitude", "latitude"], :name => "index_measurements_on_longitude_and_latitude"
   add_index "measurements", ["longitude"], :name => "index_measurements_on_longitude"
+  add_index "measurements", ["stream_id", "time"], :name => "index_measurements_on_stream_id_and_time"
   add_index "measurements", ["stream_id"], :name => "index_measurements_on_stream_id"
   add_index "measurements", ["time"], :name => "index_measurements_on_time"
 


### PR DESCRIPTION
Dropping and running all migrations created a schema that was different
than the one committed in the repo. This is what I assume happened and
the fixes:
- `t.datetime "created_at"` on measurements was present in db/schema but not after
running all migrations. Also, no migrations were adding that column. I
assume the migration which added the column has been removed. The fix is
to just commit the new db/schema that doesn't include that column. I've
double checked on production and that column is not there so this should
be a safe move.
- `add_index "measurements", ["stream_id", "time"], :name =>
"index_measurements_on_stream_id_and_time"` was not present in db/schema
but present after running all migrations. It's clear by checking the
schema version in db/schema that the migration was created but the
resulting schema wasn't committed to the repo. The fix is to just commit
the new db/schema. Since the index is on production this should be the
right thing to do.
- `timestamps` on `notes`, `sessions`, `users` had not `:null => false` in
db/schema but had them after running all migrations. This seems to be
connected to https://github.com/rails/rails/pull/3334 when they added a
not null by default. The fix is to add a migration which makes those
columns explicitly nullable. Since on production those columns are
nullable this should be ok