### PR TITLE
feat(outliers): service to filter measurement outliers

### DIFF
--- a/app/services/outliers/calculate_centroid.rb
+++ b/app/services/outliers/calculate_centroid.rb
@@ -1,0 +1,22 @@
+class Outliers::CalculateCentroid
+  def call(measurements)
+    lng_lat = sum_coordinates(measurements)
+    average(lng_lat, BigDecimal.new(measurements.size))
+  end
+
+  private
+
+  def sum_coordinates(measurements)
+    measurements.reduce([zero, zero]) do |(lng, lat), x|
+      [lng + x.longitude, lat + x.latitude]
+    end
+  end
+
+  def average(lng_lat, amount)
+    lng_lat.map { |x| x / amount }
+  end
+
+  def zero
+    "0".to_d
+  end
+end

--- a/app/services/outliers/calculate_centroid.rb
+++ b/app/services/outliers/calculate_centroid.rb
@@ -12,8 +12,8 @@ class Outliers::CalculateCentroid
     end
   end
 
-  def average(lng_lat, amount)
-    lng_lat.map { |x| x / amount }
+  def average(lng_lat, number)
+    lng_lat.map { |x| x / number }
   end
 
   def zero

--- a/app/services/outliers/calculate_distance.rb
+++ b/app/services/outliers/calculate_distance.rb
@@ -1,0 +1,9 @@
+class Outliers::CalculateDistance
+  def call(lng_lat1, lng_lat2)
+    xx1, yy1 = lng_lat1
+    xx2, yy2 = lng_lat2
+
+    BigDecimal.new((xx1 - xx2) ** 2 + (yy1 - yy2) ** 2).sqrt(12)
+  end
+end
+

--- a/app/services/outliers/filter_measurements.rb
+++ b/app/services/outliers/filter_measurements.rb
@@ -1,8 +1,7 @@
 class Outliers::FilterMeasurements
-  # Since San Francisco is ~ (37.7576793,-122.5076403) and Philadelphia ~ (40.0024137,-75.258118), 25 for MAX_DISTANCE
-  # means more or less half of the distance between them. In fact,
-  # sqrt[(37.7576793 - 40.0024137)^2 + (-122.5076403 - -75.258118)^2] ~= 47.31
-  MAX_DISTANCE = 25
+  # Since New York is located ~ (40.6971494, -74.259869) and Pittsburgh ~ (40.4313473,-80.0505407), 5 for MAX_DISTANCE
+  # the distance in between. In fact, sqrt[(40.6971494 - 40.4313473)^2 + (-74.259869 - -80.0505407)^2] ~= 5
+  MAX_DISTANCE = 5
 
   def initialize(
     max_distance = MAX_DISTANCE,

--- a/app/services/outliers/filter_measurements.rb
+++ b/app/services/outliers/filter_measurements.rb
@@ -15,6 +15,8 @@ class Outliers::FilterMeasurements
   end
 
   def call(measurements)
+    return measurements unless measurements.any?
+
     centroid = @calculate_centroid.call(measurements)
     filter_outliers(centroid, measurements, @max_distance)
   end

--- a/app/services/outliers/filter_measurements.rb
+++ b/app/services/outliers/filter_measurements.rb
@@ -1,0 +1,31 @@
+class Outliers::FilterMeasurements
+  # Since San Francisco is ~ (37.7576793,-122.5076403) and Philadelphia ~ (40.0024137,-75.258118), 25 for MAX_DISTANCE
+  # means more or less half of the distance between them. In fact,
+  # sqrt[(37.7576793 - 40.0024137)^2 + (-122.5076403 - -75.258118)^2] ~= 47.31
+  MAX_DISTANCE = 25
+
+  def initialize(
+    max_distance = MAX_DISTANCE,
+    calculate_centroid = Outliers::CalculateCentroid.new,
+    calculate_distance = Outliers::CalculateDistance.new
+  )
+    @max_distance = max_distance
+    @calculate_centroid = calculate_centroid
+    @calculate_distance = calculate_distance
+  end
+
+  def call(measurements)
+    centroid = @calculate_centroid.call(measurements)
+    filter_outliers(centroid, measurements, @max_distance)
+  end
+
+  private
+
+  def filter_outliers(centroid, measurements, max_distance)
+    measurements.select do |measurement|
+      lng_lat = [measurement.longitude, measurement.latitude]
+      @calculate_distance.call(lng_lat, centroid) <= max_distance
+    end
+  end
+end
+

--- a/spec/services/outliers/calculate_centroid_spec.rb
+++ b/spec/services/outliers/calculate_centroid_spec.rb
@@ -1,0 +1,112 @@
+require "spec_helper"
+
+describe Outliers::CalculateCentroid do
+  before(:each) do
+    @subject = Outliers::CalculateCentroid.new
+  end
+
+  it "with one measurement it returns its coordinates" do
+    m = Measurement.new(
+      longitude: one,
+      latitude: one
+    )
+
+    actual = @subject.call([m])
+
+    expect(actual).to eq([one, one])
+  end
+
+  it "with two measurements with the same coordinates it returns those coordinates" do
+    m1 = Measurement.new(
+      longitude: one,
+      latitude: one,
+    )
+    m2 = Measurement.new(
+      longitude: one,
+      latitude: one,
+    )
+
+    actual = @subject.call([m1, m2])
+
+    expect(actual).to eq([one, one])
+  end
+
+  it "with two measurements with different coordinates it returns the midpoint" do
+    m1 = Measurement.new(
+      longitude: one,
+      latitude: one,
+    )
+    m2 = Measurement.new(
+      longitude: three,
+      latitude: three,
+    )
+
+    actual = @subject.call([m1, m2])
+
+    expect(actual).to eq([two, two])
+  end
+
+  it "with three measurements with different coordinates it returns the centroid" do
+    m1 = Measurement.new(
+      longitude: one,
+      latitude: one,
+    )
+    m2 = Measurement.new(
+      longitude: four,
+      latitude: one,
+    )
+    m3 = Measurement.new(
+      longitude: four,
+      latitude: four,
+    )
+
+    actual = @subject.call([m1, m2, m3])
+
+    expect(actual).to eq([three, two])
+  end
+
+  it "with four measurements with different coordinates it returns the centroid" do
+    m1 = Measurement.new(
+      longitude: one,
+      latitude: one,
+    )
+    m2 = Measurement.new(
+      longitude: two,
+      latitude: one,
+    )
+    m3 = Measurement.new(
+      longitude: two,
+      latitude: two,
+    )
+    m4 = Measurement.new(
+      longitude: one,
+      latitude: two,
+    )
+
+    actual = @subject.call([m1, m2, m3, m4])
+
+    expect(actual).to eq([one_point_five, one_point_five])
+  end
+
+  private
+
+  def one
+    @one ||= "1".to_d
+  end
+
+  def two
+    @two ||= "2".to_d
+  end
+
+  def three
+    @three ||= "3".to_d
+  end
+
+  def four
+    @four ||= "4".to_d
+  end
+
+  def one_point_five
+    @one_point_five ||= "1.5".to_d
+  end
+end

--- a/spec/services/outliers/calculate_distance_spec.rb
+++ b/spec/services/outliers/calculate_distance_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe Outliers::CalculateDistance do
+  before(:each) do
+    @subject = Outliers::CalculateDistance.new
+  end
+
+  it "when the points are the same it returns 0" do
+    lng_lat = [one, one]
+
+    actual = @subject.call(lng_lat, lng_lat)
+
+    expect(actual).to eq(zero)
+  end
+
+  it "it returns the distance 1" do
+    lng_lat1 = [one, one]
+    lng_lat2 = [one, two]
+
+    actual = @subject.call(lng_lat1, lng_lat2)
+
+    expect(actual).to eq(one)
+  end
+
+  it "it returns the distance 2" do
+    lng_lat1 = [one, one]
+    lng_lat2 = [two, two]
+
+    actual = @subject.call(lng_lat1, lng_lat2)
+
+    expected = "1.414213562373095048801688724".to_d
+    expect(actual).to eq(expected)
+  end
+
+  private
+  def zero
+    @zero ||= "0".to_d
+  end
+
+  def one
+    @one ||= "1".to_d
+  end
+
+  def two
+    @two ||= "2".to_d
+  end
+end

--- a/spec/services/outliers/filter_measurements_spec.rb
+++ b/spec/services/outliers/filter_measurements_spec.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 describe Outliers::FilterMeasurements do
+  it "when measurements is an empty array it returns it" do
+    measurements = []
+
+    actual = Outliers::FilterMeasurements.new.call(measurements)
+
+    expect(actual).to eq(measurements)
+  end
+
   it "filters measurement outliers" do
     max_distance = 1
 

--- a/spec/services/outliers/filter_measurements_spec.rb
+++ b/spec/services/outliers/filter_measurements_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe Outliers::FilterMeasurements do
+  it "filters measurement outliers" do
+    max_distance = 1
+
+    calculate_centroid = lambda { |_| [one, one] }
+
+    calculate_distance = lambda do |lng_lat1, lng_lat2|
+      if (lng_lat1 == [one_thousand, one_thousand] || lng_lat2 == [one_thousand, one_thousand])
+        max_distance + 1
+      else
+        max_distance
+      end
+    end
+
+    subject = Outliers::FilterMeasurements.new(max_distance, calculate_centroid, calculate_distance)
+
+    m1 = Measurement.new(
+      longitude: one,
+      latitude: one,
+    )
+
+    m2 = Measurement.new(
+      longitude: one,
+      latitude: one,
+    )
+
+    m3 = Measurement.new(
+      longitude: one_thousand,
+      latitude: one_thousand,
+    )
+
+    measurements = [m1, m2, m3]
+
+
+    actual = subject.call(measurements)
+
+
+    expected = [m1, m2]
+    expect(actual).to eq(expected)
+  end
+
+  private
+
+  def one
+    @one ||= "1".to_d
+  end
+
+  def one_thousand
+    @one_thousand ||= "1000".to_d
+  end
+end


### PR DESCRIPTION
This PR introduces a service `Outliers::FilterMeasurements` that takes some measurements and filters out outliers.

This is the first step to be able to cache the correct bounding box of a session. Correct means that the bounding box doesn't take into account outliers.