### PR TITLE
Add utc time to measurements coming from fixed sessions.

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -25,6 +25,7 @@ class Session < ActiveRecord::Base
   MINUTES_IN_DAY = 60 * 24
   FIRST_MINUTE_OF_DAY = 0
   LAST_MINUTE_OF_DAY = MINUTES_IN_DAY - 1
+  FIXED_SESSION = "FixedSession"
 
   belongs_to :user
   has_many :measurements, :through => :streams, :inverse_of => :session
@@ -252,6 +253,10 @@ class Session < ActiveRecord::Base
   end
 
   def after_measurements_created
+  end
+
+  def fixed?
+    type == FIXED_SESSION
   end
 
   private

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -180,8 +180,8 @@ class Stream < ActiveRecord::Base
     max_longitude.present? &&
     min_longitude.present?
   end
-  
+
   def fixed?
-    self.session.type == "FixedSession"
+    session.fixed?
   end
 end

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -180,4 +180,8 @@ class Stream < ActiveRecord::Base
     max_longitude.present? &&
     min_longitude.present?
   end
+  
+  def fixed?
+    self.session.type == "FixedSession"
+  end
 end

--- a/app/services/measurements_creator.rb
+++ b/app/services/measurements_creator.rb
@@ -2,6 +2,13 @@ class MeasurementsCreator
   SLICE_SIZE = 500
 
   def self.call(stream, measurements_attributes)
+    if stream.session.type == "FixedSession"
+      measurements_attributes = measurements_attributes.map do |measurement_attributes|
+        measurement_attributes[:utc_time] = Time.now.utc
+        measurement_attributes
+      end
+    end
+
     if measurements_attributes.count == 1
       new.call(stream, measurements_attributes)
     else

--- a/app/services/measurements_creator.rb
+++ b/app/services/measurements_creator.rb
@@ -32,7 +32,7 @@ class MeasurementsCreator
 
   def self.add_arrival_time(measurements_attributes)
     measurements_attributes.map do |measurement_attributes|
-      measurement_attributes[:arrival_utc_time] = Time.current.utc
+      measurement_attributes[:arrival_utc_time] = Time.current
       measurement_attributes
     end
   end

--- a/db/migrate/20181114165757_add_utc_time_to_measurement.rb
+++ b/db/migrate/20181114165757_add_utc_time_to_measurement.rb
@@ -1,0 +1,5 @@
+class AddUtcTimeToMeasurement < ActiveRecord::Migration
+  def change
+    add_column :measurements, :utc_time, :datetime
+  end
+end

--- a/db/migrate/20181114165757_add_utc_time_to_measurement.rb
+++ b/db/migrate/20181114165757_add_utc_time_to_measurement.rb
@@ -1,5 +1,5 @@
 class AddUtcTimeToMeasurement < ActiveRecord::Migration
   def change
-    add_column :measurements, :utc_time, :datetime
+    add_column :measurements, :arrival_utc_time, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(:version => 20181114165757) do
     t.integer  "stream_id"
     t.integer  "milliseconds",                                   :default => 0
     t.float    "measured_value"
-    t.datetime "utc_time"
+    t.datetime "arrival_utc_time"
   end
 
   add_index "measurements", ["latitude"], :name => "index_measurements_on_latitude"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20181113100336) do
+ActiveRecord::Schema.define(:version => 20181114165757) do
 
   create_table "deleted_sessions", :force => true do |t|
     t.datetime "created_at", :null => false
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(:version => 20181113100336) do
     t.integer  "stream_id"
     t.integer  "milliseconds",                                   :default => 0
     t.float    "measured_value"
+    t.datetime "utc_time"
   end
 
   add_index "measurements", ["latitude"], :name => "index_measurements_on_latitude"

--- a/spec/services/measurements_creator_spec.rb
+++ b/spec/services/measurements_creator_spec.rb
@@ -1,23 +1,21 @@
 require "spec_helper"
 
 describe MeasurementsCreator do
-  let(:measurements_attributes) { [{:longitude=>25.4356212, :latitude=>56.4523456, :time=>"2016-05-11T17:09:02", :milliseconds=>925, :measured_value=>59.15683475380729, :value=>59.15683475380729}] }
-
-  it "creates a mesurement" do
+  it "creates a measurement" do
     stream = create_stream!
     MeasurementsCreator.call(stream, measurements_attributes)
 
     expect(Measurement.count).to eq(1)
   end
 
-  it "creates a mesurement with utc time for fixed sessions" do
+  it "creates a measurement with utc time for fixed sessions" do
     stream = create_stream!("FixedSession")
     MeasurementsCreator.call(stream, measurements_attributes)
 
     expect(Measurement.first.utc_time).to be_within(1.second).of Time.now
   end
 
-  it "creates a mesurement without utc time for mobile sessions" do
+  it "creates a measurement without utc time for mobile sessions" do
     stream = create_stream!("MobileSession")
     MeasurementsCreator.call(stream, measurements_attributes)
 
@@ -25,6 +23,16 @@ describe MeasurementsCreator do
   end
 
   private
+
+  def measurements_attributes
+    [{ longitude: 25.4356212,
+      latitude: 56.4523456,
+      time: "2016-05-11T17:09:02",
+      milliseconds: 925,
+      measured_value: 59.15683475380729,
+      value: 59.15683475380729,
+    }]
+  end
 
   def create_stream!(session_type  = "MobileSession")
     Stream.create!(

--- a/spec/services/measurements_creator_spec.rb
+++ b/spec/services/measurements_creator_spec.rb
@@ -1,43 +1,59 @@
 require "spec_helper"
+require 'sidekiq/testing'
 
 describe MeasurementsCreator do
-  it "creates a measurement" do
-    session = create_session!
-    stream = create_stream!(session: session)
+  describe "#self.call" do
+    context "when there is only one measurement" do
+      it "creates a measurement" do
+        session = create_session!
+        stream = create_stream!(session: session)
 
-    MeasurementsCreator.call(stream, measurements_attributes)
+        MeasurementsCreator.call(stream, [measurement_attributes])
 
-    expect(Measurement.count).to eq(1)
-  end
+        expect(Measurement.count).to eq(1)
+      end
 
-  it "when sessions fixed creates a measurement with utc time" do
-    session = create_session!(type: "FixedSession")
-    stream = create_stream!(session: session)
+      it "when sessions fixed creates a measurement with utc time" do
+        session = create_session!(type: "FixedSession")
+        stream = create_stream!(session: session)
 
-    MeasurementsCreator.call(stream, measurements_attributes)
+        MeasurementsCreator.call(stream, [measurement_attributes])
 
-    expect(Measurement.first.utc_time).to be_within(1.second).of Time.now
-  end
+        expect(Measurement.first.arrival_utc_time).to be_within(1.second).of Time.current
+      end
 
-  it "when session is moblie creates a measurement without utc time" do
-    session = create_session!(type: "MoblieSession")
-    stream = create_stream!(session: session)
+      it "when session is moblie creates a measurement without utc time" do
+        session = create_session!(type: "MoblieSession")
+        stream = create_stream!(session: session)
 
-    MeasurementsCreator.call(stream, measurements_attributes)
+        MeasurementsCreator.call(stream, [measurement_attributes])
 
-    expect(Measurement.first.utc_time).to be_nil
+        expect(Measurement.first.arrival_utc_time).to be_nil
+      end
+    end
+
+    context "when there are more than one measurements" do
+      it "schedules the creation of measurements" do
+        session = create_session!
+        stream = create_stream!(session: session)
+
+        MeasurementsCreator.call(stream, [measurement_attributes, measurement_attributes])
+
+        assert_equal 1, AsyncMeasurementsCreator.jobs.size
+      end
+    end
   end
 
   private
 
-  def measurements_attributes
-    [{ longitude: 25.4356212,
+  def measurement_attributes
+    { longitude: 25.4356212,
       latitude: 56.4523456,
       time: "2016-05-11T17:09:02",
       milliseconds: 925,
       measured_value: 59.15683475380729,
       value: 59.15683475380729,
-    }]
+    }
   end
 
   def create_stream!(attributes)

--- a/spec/services/measurements_creator_spec.rb
+++ b/spec/services/measurements_creator_spec.rb
@@ -1,10 +1,11 @@
 require "spec_helper"
 
 describe MeasurementsCreator do
-  describe "#self.call" do
-    before() do
-      @arrival_utc_time = Time.utc(2018, 11, 19)
-      allow(Time).to receive(:current).and_return(@arrival_utc_time)
+  describe ".call" do
+    let(:arrival_utc_time) { Time.utc(2018, 11, 19) }
+
+    before do
+      allow(Time).to receive(:current).and_return(arrival_utc_time)
     end
 
     context "when there is only one measurement" do
@@ -23,10 +24,10 @@ describe MeasurementsCreator do
 
         MeasurementsCreator.call(stream, single_measurement_attributes)
 
-        expect(Measurement.first.arrival_utc_time).to eq(@arrival_utc_time)
+        expect(Measurement.first.arrival_utc_time).to eq(arrival_utc_time)
       end
 
-      it "when session is moblie creates a measurement without utc time" do
+      it "when session is mobile creates a measurement without utc time" do
         session = create_session!(type: "MoblieSession")
         stream = create_stream!(session: session)
 
@@ -43,17 +44,17 @@ describe MeasurementsCreator do
 
         MeasurementsCreator.call(stream, multiple_measurements_attributes)
 
-        assert_equal 1, AsyncMeasurementsCreator.jobs.size
+        expect(AsyncMeasurementsCreator.jobs.size).to be(1)
       end
     end
   end
 
   describe "#call" do
-    let(:streams_repository) { double(StreamsRepository.new) }
+    let(:streams_repository) { double("streams_repository" ) }
     let(:measurements_creator) { MeasurementsCreator.new(streams_repository) }
-    let(:stream) { double(Stream.new) }
+    let(:stream) { double("stream") }
 
-    before() do
+    before do
       allow(stream).to receive(:after_measurements_created)
       allow(stream).to receive(:build_measurements!)
       allow(streams_repository).to receive(:calc_average_value!)
@@ -76,7 +77,7 @@ describe MeasurementsCreator do
     end
 
     context "for sessions that are not fixed" do
-      before() do
+      before do
         allow(stream).to receive(:fixed?).and_return(false)
       end
 
@@ -86,7 +87,7 @@ describe MeasurementsCreator do
         measurements_creator.call(stream, single_measurement_attributes)
       end
 
-      it "calculattes average value of stream" do
+      it "calculates average value of stream" do
         expect(streams_repository).to receive(:calc_average_value!).with(stream)
 
         measurements_creator.call(stream, single_measurement_attributes)
@@ -120,7 +121,7 @@ describe MeasurementsCreator do
       sensor_name: "AirBeam2-F",
       measurement_type: "Temperature",
       unit_name: "Fahrenheit",
-      session: attributes[:session],
+      session: attributes.fetch(:session),
       measurement_short_type: "dB",
       unit_symbol: "dB",
       threshold_very_low: 20,
@@ -142,7 +143,7 @@ describe MeasurementsCreator do
       start_time_local: DateTime.current,
       end_time: DateTime.current,
       end_time_local: DateTime.current,
-      type: attributes[:type]
+      type: attributes.fetch(:type)
     )
   end
 end

--- a/spec/services/measurements_creator_spec.rb
+++ b/spec/services/measurements_creator_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+describe MeasurementsCreator do
+  let(:measurements_attributes) { [{:longitude=>25.4356212, :latitude=>56.4523456, :time=>"2016-05-11T17:09:02", :milliseconds=>925, :measured_value=>59.15683475380729, :value=>59.15683475380729}] }
+
+  it "creates a mesurement" do
+    stream = create_stream!
+    MeasurementsCreator.call(stream, measurements_attributes)
+
+    expect(Measurement.count).to eq(1)
+  end
+
+  it "creates a mesurement with utc time for fixed sessions" do
+    stream = create_stream!("FixedSession")
+    MeasurementsCreator.call(stream, measurements_attributes)
+
+    expect(Measurement.first.utc_time).to be_within(1.second).of Time.now
+  end
+
+  it "creates a mesurement without utc time for mobile sessions" do
+    stream = create_stream!("MobileSession")
+    MeasurementsCreator.call(stream, measurements_attributes)
+
+    expect(Measurement.first.utc_time).to be_nil
+  end
+
+  private
+
+  def create_stream!(session_type  = "MobileSession")
+    Stream.create!(
+      sensor_package_name: "AirBeam2:00189610719F",
+      sensor_name: "AirBeam2-F",
+      measurement_type: "Temperature",
+      unit_name: "Fahrenheit",
+      session: create_session!(session_type),
+      measurement_short_type: "dB",
+      unit_symbol: "dB",
+      threshold_very_low: 20,
+      threshold_low: 60,
+      threshold_medium: 70,
+      threshold_high: 80,
+      threshold_very_high: 100
+    )
+  end
+
+  def create_session!(type)
+    Session.create!(
+      title: "Example Session",
+      user: User.new,
+      uuid: "845342a6-f9f4-4835-86b3-b100163ec39a",
+      calibration: 100,
+      offset_60_db: 0,
+      start_time: DateTime.current,
+      start_time_local: DateTime.current,
+      end_time: DateTime.current,
+      end_time_local: DateTime.current,
+      type: type
+    )
+  end
+end

--- a/spec/services/measurements_creator_spec.rb
+++ b/spec/services/measurements_creator_spec.rb
@@ -2,21 +2,27 @@ require "spec_helper"
 
 describe MeasurementsCreator do
   it "creates a measurement" do
-    stream = create_stream!
+    session = create_session!
+    stream = create_stream!(session: session)
+
     MeasurementsCreator.call(stream, measurements_attributes)
 
     expect(Measurement.count).to eq(1)
   end
 
-  it "creates a measurement with utc time for fixed sessions" do
-    stream = create_stream!("FixedSession")
+  it "when sessions fixed creates a measurement with utc time" do
+    session = create_session!(type: "FixedSession")
+    stream = create_stream!(session: session)
+
     MeasurementsCreator.call(stream, measurements_attributes)
 
     expect(Measurement.first.utc_time).to be_within(1.second).of Time.now
   end
 
-  it "creates a measurement without utc time for mobile sessions" do
-    stream = create_stream!("MobileSession")
+  it "when session is moblie creates a measurement without utc time" do
+    session = create_session!(type: "MoblieSession")
+    stream = create_stream!(session: session)
+
     MeasurementsCreator.call(stream, measurements_attributes)
 
     expect(Measurement.first.utc_time).to be_nil
@@ -34,13 +40,13 @@ describe MeasurementsCreator do
     }]
   end
 
-  def create_stream!(session_type  = "MobileSession")
+  def create_stream!(attributes)
     Stream.create!(
       sensor_package_name: "AirBeam2:00189610719F",
       sensor_name: "AirBeam2-F",
       measurement_type: "Temperature",
       unit_name: "Fahrenheit",
-      session: create_session!(session_type),
+      session: attributes[:session],
       measurement_short_type: "dB",
       unit_symbol: "dB",
       threshold_very_low: 20,
@@ -51,7 +57,7 @@ describe MeasurementsCreator do
     )
   end
 
-  def create_session!(type)
+  def create_session!(attributes = { type: "MobileSession" })
     Session.create!(
       title: "Example Session",
       user: User.new,
@@ -62,7 +68,7 @@ describe MeasurementsCreator do
       start_time_local: DateTime.current,
       end_time: DateTime.current,
       end_time_local: DateTime.current,
-      type: type
+      type: attributes[:type]
     )
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ Spork.prefork do
   # Add this to load Capybara integration:
   require 'capybara/rspec'
   require 'capybara/rails'
+  require 'sidekiq/testing'
 end
 
 Spork.each_run do


### PR DESCRIPTION
It's not clear what is the bast place to put the logic that will add the utc time to the measurements. I wen't with MeasurementsCreator class even though it doesn't really creates the measurements.

I will leave my notes here, just in case they help someone :). I looked through the structure of the code and there are 3 controllers that created measurements, calling classes in this order:

* controller: Api::Realtime::MeasurementController.create
  * lib: RealtimeMeasurementBuilder.new.build!
  * lib: RealtimeMeasurementBuilder.new.build_measuremnt!
  * model: Stream.build_or_update!
  * service: MeasurementsCreator.call
     - at this moment it becomes async so the time has to be added before
  * service: MeasurementsCreator.new.call
  * model: Stream.build_measurements!
  * model: Measurement.new

* Api::Realtime::SessionController.create
   * lib: SessionBuilder.build!
   * lib: SessionBuilder.build_session!
   * model: Stream.build!
   * service: MeasurementsCreator.call
      - at this moment it becomes async so the time has to be added before
   * service: MeasurementsCreator.new.call
   * model: Stream.build_measurements!
   * model: Measurement.new


* Api::MeasurementSessionController.create 
  I think this is only used by mobile sessions
  * lib: SessionBuilder.build!
  * lib: SessionBuilder.build_session!
  * model: Stream.build!
  * service: MeasurementsCreator.call
     - at this moment it becomes async so the time has to be added before
  * service: MeasurementsCreator.new.call
  * model: Stream.build_measurements!
  * model: Measurement.new

