### PR TITLE
Add crowd layer to mobile map: ui

### DIFF
--- a/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
@@ -93,5 +93,14 @@ export const MobileSessionsMapCtrl = (
       map.goToAddress(newValue.location);
     }, true);
 
+  $scope.$watch("storage.data.crowdMap", function(newValue, oldValue) {
+    console.log("watch - storage.data.crowdMap");
+  }, true);
+
+  $scope.$watch("params.get('data').gridResolution", function(newValue, oldValue) {
+    console.log("watch - params.get('data').gridResolution");
+    if (!storage.data.crowdMap) return;
+  }, true);
+
   $scope.setDefaults();
 }

--- a/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
@@ -50,8 +50,12 @@ export const MobileSessionsMapCtrl = (
       sensorId: "",
       location: {address: ""},
       tags: "",
-      usernames: ""
+      usernames: "",
+      gridResolution: 25
     });
+
+    $scope.minResolution = 10;
+    $scope.maxResolution = 50;
 
     storage.updateFromDefaults();
   };

--- a/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
@@ -41,7 +41,8 @@ export const MobileSessionsMapCtrl = (
         $scope.$digest();
       });
     }
-    _.each(['sensor', 'location', 'usernames'], function(name) {
+
+    ['sensor', 'location', 'usernames', 'layers'].forEach(function(name) {
       $scope.expandables.show(name);
     });
 

--- a/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
@@ -7,9 +7,8 @@ test('registers a callback to map.goToAddress', t => {
   const $scope = {
     $watch: (str, callback) => str.includes('address') ? callbacks.push(callback) : null
   };
-  // diff from fixed_sessions_map_ctrl removeAllMarkers
   const map = mock('goToAddress');
-  const controller = _MobileSessionsMapCtrl({ $scope, map, callbacks });
+  _MobileSessionsMapCtrl({ $scope, map, callbacks });
 
   callbacks.forEach(callback => callback({ location: 'new york' }));
 
@@ -18,8 +17,21 @@ test('registers a callback to map.goToAddress', t => {
   t.end();
 });
 
-const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage }) => {
-  const expandables = { show: () => {} };
+test('it shows by default sensor, location, usernames and layers sections', t => {
+  const shown = [];
+  const expandables = {
+    show: name => shown.push(name)
+  };
+
+  _MobileSessionsMapCtrl({ expandables });
+
+  t.deepEqual(shown, ['sensor', 'location', 'usernames', 'layers']);
+
+  t.end();
+});
+
+const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables }) => {
+  const _expandables = { show: () => {}, ...expandables };
   const sensors = { setSensors: () => {} };
   const functionBlocker = { block: () => {} };
   const params = { get: () => {} };
@@ -36,6 +48,7 @@ const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage }) => {
     removeAllMarkers: () => {},
     ...map
   };
+  const _$scope = { $watch: () => {}, ...$scope };
 
-  return MobileSessionsMapCtrl($scope, params, _map, sensors, expandables, _storage, null, null, null, null, functionBlocker, null, rectangles, infoWindow);
+  return MobileSessionsMapCtrl(_$scope, params, _map, sensors, _expandables, _storage, null, null, null, null, functionBlocker, null, rectangles, infoWindow);
 };

--- a/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
@@ -30,6 +30,26 @@ test('it shows by default sensor, location, usernames and layers sections', t =>
   t.end();
 });
 
+test('it updates defaults', t => {
+  let defaults = {};
+  const storage = {
+    updateDefaults: opts => defaults = opts
+  };
+
+  _MobileSessionsMapCtrl({ storage });
+
+  const expected = {
+    sensorId: "",
+    location: {address: ""},
+    tags: "",
+    usernames: "",
+    gridResolution: 25
+  };
+  t.deepEqual(defaults, expected);
+
+  t.end();
+});
+
 const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables }) => {
   const _expandables = { show: () => {}, ...expandables };
   const sensors = { setSensors: () => {} };

--- a/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
@@ -8,7 +8,7 @@ test('registers a callback to map.goToAddress', t => {
     $watch: (str, callback) => str.includes('address') ? callbacks.push(callback) : null
   };
   const map = mock('goToAddress');
-  _MobileSessionsMapCtrl({ $scope, map, callbacks });
+  _MobileSessionsMapCtrl({ $scope, map });
 
   callbacks.forEach(callback => callback({ location: 'new york' }));
 
@@ -46,6 +46,32 @@ test('it updates defaults', t => {
     gridResolution: 25
   };
   t.deepEqual(defaults, expected);
+
+  t.end();
+});
+
+test('registers a callback for the crowd map checkbox', t => {
+  const callbacks = [];
+  const $scope = {
+    $watch: (str, callback) => str.includes('crowdMap') ? callbacks.push(callback) : null
+  };
+
+  _MobileSessionsMapCtrl({ $scope });
+
+  t.equal(callbacks.length, 1);
+
+  t.end();
+});
+
+test('registers a callback for the crowd map resolution slider', t => {
+  const callbacks = [];
+  const $scope = {
+    $watch: (str, callback) => str.includes('gridResolution') ? callbacks.push(callback) : null
+  };
+
+  _MobileSessionsMapCtrl({ $scope });
+
+  t.equal(callbacks.length, 1);
 
   t.end();
 });

--- a/public/partials/mobile_sessions_map.html
+++ b/public/partials/mobile_sessions_map.html
@@ -36,6 +36,30 @@
       </section>
 
       <div class="section-divider" ng-include="versioner.path('/partials/usernames_and_tags.html')"></div>
+
+      <h4 ng-click="expandables.toggle('layers')" ng-class="expandables.css('layers')">Layers</h4>
+      <section ng-show="expandables.visible('layers')">
+        <div class="textfield">
+          <p>
+            <input type="checkbox" ng-model="storage.data.crowdMap" id="checkbox-crowd-map">
+            <label for="checkbox-crowd-map">Crowd Map</label>
+          </p>
+        </div>
+        <div>
+          <div class="slider full-slider">
+            <p>Resolution</p>
+            <div slider slider-max="maxResolution" slider-min="minResolution" slider-value="storage.data.gridResolution" slider-onslide="storageEvents.onResolutionSlide" ></div>
+            <span>{{storage.data.gridResolution}}</span>
+          </div>
+        </div>
+        <div>
+          <ul class="buttons">
+            <li><button ng-click="storage.reset('gridResolution')">reset</button></li>
+            <li><button ng-click="storage.update('gridResolution')">submit</button></li>
+          </ul>
+        </div>
+      </section>
+
       <div class="section-divider" ng-include="versioner.path('/partials/time_filters.html')"></div>
     </div>
     <div ng-switch on="!!singleSession.get() && !!sensors.anySelected()">

--- a/public/partials/mobile_sessions_map.html
+++ b/public/partials/mobile_sessions_map.html
@@ -37,27 +37,29 @@
 
       <div class="section-divider" ng-include="versioner.path('/partials/usernames_and_tags.html')"></div>
 
-      <h4 ng-click="expandables.toggle('layers')" ng-class="expandables.css('layers')">Layers</h4>
-      <section ng-show="expandables.visible('layers')">
-        <div class="textfield">
-          <p>
-            <input type="checkbox" ng-model="storage.data.crowdMap" id="checkbox-crowd-map">
-            <label for="checkbox-crowd-map">Crowd Map</label>
-          </p>
-        </div>
-        <div>
-          <div class="slider full-slider">
-            <p>Resolution</p>
-            <div slider slider-max="maxResolution" slider-min="minResolution" slider-value="storage.data.gridResolution" slider-onslide="storageEvents.onResolutionSlide" ></div>
-            <span>{{storage.data.gridResolution}}</span>
+      <section ng-show="false">
+        <h4 ng-click="expandables.toggle('layers')" ng-class="expandables.css('layers')">Layers</h4>
+        <section ng-show="expandables.visible('layers')">
+          <div class="textfield">
+            <p>
+              <input type="checkbox" ng-model="storage.data.crowdMap" id="checkbox-crowd-map">
+              <label for="checkbox-crowd-map">Crowd Map</label>
+            </p>
           </div>
-        </div>
-        <div>
-          <ul class="buttons">
-            <li><button ng-click="storage.reset('gridResolution')">reset</button></li>
-            <li><button ng-click="storage.update('gridResolution')">submit</button></li>
-          </ul>
-        </div>
+          <div>
+            <div class="slider full-slider">
+              <p>Resolution</p>
+              <div slider slider-max="maxResolution" slider-min="minResolution" slider-value="storage.data.gridResolution" slider-onslide="storageEvents.onResolutionSlide" ></div>
+              <span>{{storage.data.gridResolution}}</span>
+            </div>
+          </div>
+          <div>
+            <ul class="buttons">
+              <li><button ng-click="storage.reset('gridResolution')">reset</button></li>
+              <li><button ng-click="storage.update('gridResolution')">submit</button></li>
+            </ul>
+          </div>
+        </section>
       </section>
 
       <div class="section-divider" ng-include="versioner.path('/partials/time_filters.html')"></div>


### PR DESCRIPTION
This is the first step towards adding the crowd map in the mobile tab. In practice, in the mobile map it will be possible to enable (checkbox) the crow map layer and regulate the resolution as in the crowd map.

The section in the html is wrapped in `<section ng-show="false">` so that I can merge and go on with the work.