### PR TITLE
Show mobile sessions starting points

### DIFF
--- a/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
@@ -39,6 +39,7 @@ export const FixedSessionsMapCtrl = (
     rectangles.clear();
     infoWindow.hide();
     map.unregisterAll();
+    map.removeAllMarkers();
 
     if (process.env.NODE_ENV !== 'test') {
       $($window).resize(function() {
@@ -116,4 +117,3 @@ export const FixedSessionsMapCtrl = (
 
   $scope.setDefaults();
 }
-

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -10,7 +10,7 @@ export const drawSession = (
   };
 
   DrawSession.prototype = {
-    drawMobileSession: function(session, bounds) {
+    drawMobileSession: function(session) {
       if(!session || !session.loaded || !sensors.anySelected()){
         return;
       }
@@ -41,7 +41,7 @@ export const drawSession = (
       session.drawed = true;
     },
 
-    drawFixedSession: function(session, bounds) {
+    drawFixedSession: function(session) {
       this.undoDraw(session);
       session.markers = [];
       session.noteDrawings = [];
@@ -50,7 +50,7 @@ export const drawSession = (
       var level;
 
       if (sensors.anySelected() && !sensors.tmpSelected() && session.last_hour_average) {
-        level = this.calculateHeatLevel(session.last_hour_average);
+        level = this._calculateHeatLevel(session.last_hour_average);
       } else {
         level = 0;
       }
@@ -61,7 +61,21 @@ export const drawSession = (
       return session.markers;
     },
 
-    calculateHeatLevel: function(value) {
+    drawMobileSessionStartPoint: function(session) {
+      if(!session || !sensors.anySelected()){
+        return;
+      }
+      this.undoDraw(session);
+
+      session.markers = [];
+      var markerOptions = {title: session.title, zIndex: 0};
+      var lngLatObject = { longitude: session.starting_longitude, latitude: session.starting_latitude }
+      session.markers.push(map.drawMarker(lngLatObject, markerOptions, null, "0"));
+
+      session.drawed = true;
+    },
+
+    _calculateHeatLevel: function(value) {
       return heat.getLevel(value);
     },
 

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -50,7 +50,7 @@ export const drawSession = (
       var level;
 
       if (sensors.anySelected() && !sensors.tmpSelected() && session.last_hour_average) {
-        level = this._calculateHeatLevel(session.last_hour_average);
+        level = this.calculateHeatLevel(session.last_hour_average);
       } else {
         level = 0;
       }
@@ -62,21 +62,11 @@ export const drawSession = (
     },
 
     drawMobileSessionStartPoint: function(session) {
-      if(!session || !sensors.anySelected()){
-        return;
-      }
       this.undoDraw(session);
 
-      session.markers = [];
-      var markerOptions = {title: session.title, zIndex: 0};
-      var lngLatObject = { longitude: session.starting_longitude, latitude: session.starting_latitude }
+      var markerOptions = map.defaultMarkerOptions;
+      var lngLatObject = { longitude: session.startingLongitude, latitude: session.startingLatitude }
       session.markers.push(map.drawMarker(lngLatObject, markerOptions, null, "0"));
-
-      session.drawed = true;
-    },
-
-    _calculateHeatLevel: function(value) {
-      return heat.getLevel(value);
     },
 
     undoDraw: function(session, mapPosition) {
@@ -125,4 +115,8 @@ export const drawSession = (
     }
   };
   return new DrawSession();
-}
+};
+
+function calculateHeatLevel(value) {
+  return heat.getLevel(value);
+};

--- a/app/assets/javascripts/code/services/_fixed_sessions.js
+++ b/app/assets/javascripts/code/services/_fixed_sessions.js
@@ -129,7 +129,7 @@ export const fixedSessions = (
 
     drawSessionsInLocation: function() {
       map.markers = [];
-      _(this.get()).each(session => drawSession.drawFixedSession(session));
+      (this.get()).forEach(session => drawSession.drawFixedSession(session));
     },
 
     _fetch: function(page) {

--- a/app/assets/javascripts/code/services/_fixed_sessions.js
+++ b/app/assets/javascripts/code/services/_fixed_sessions.js
@@ -129,7 +129,7 @@ export const fixedSessions = (
 
     drawSessionsInLocation: function() {
       map.markers = [];
-      _(this.get()).each(session => drawSession.drawFixedSession(session, boundsCalculator(this.sessions)));
+      _(this.get()).each(session => drawSession.drawFixedSession(session));
     },
 
     _fetch: function(page) {

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -108,7 +108,15 @@ export const mobileSessions = (
 
     drawSessionsInLocation: function() {
       map.markers = [];
-      _(this.get()).each(session => drawSession.drawMobileSessionStartPoint(session));
+      if(sensors.anySelected()) {
+        (this.get()).forEach(session => this.drawSessionInLocation(session));
+      }
+    },
+
+    drawSessionInLocation: function(session) {
+      session.markers = [];
+      drawSession.drawMobileSessionStartPoint(session);
+      session.drawed = true;
     },
 
     _selectSession: function(id, callback) {

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -62,9 +62,11 @@ export const mobileSessions = (
 
     sessionsChanged: function (newIds, oldIds) { sessionsUtils.sessionsChanged(this, newIds, oldIds); },
 
-    onSessionsFetch: function() { sessionsUtils.onSessionsFetch(this); },
 
-
+    onSessionsFetch: function() {
+      this.drawSessionsInLocation();
+      sessionsUtils.onSessionsFetch(this);
+    },
 
     onSessionsFetchWithCrowdMapLayerUpdate: function() {
       this.onSessionsFetch();
@@ -81,12 +83,13 @@ export const mobileSessions = (
     },
 
     selectSession: function(id) {
+      drawSession.clear(this.sessions);
       const callback = (session, allSelected) => (data) => {
         prevMapPosition = {
           bounds: map.getBounds(),
           zoom: map.getZoom()
         };
-        const draw = () => drawSession.drawMobileSession(session, boundsCalculator(allSelected));
+        const draw = () => drawSession.drawMobileSession(session);
         map.fitBounds(boundsCalculator(allSelected));
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       }
@@ -94,11 +97,18 @@ export const mobileSessions = (
     },
 
     reSelectSession: function(id) {
+      // I think this is never used since we blocked the button to select all sessions
+      drawSession.clear(this.sessions);
       const callback = (session, allSelected) => (data) => {
-        const draw = () => drawSession.drawMobileSession(session, boundsCalculator(allSelected));
+        const draw = () => drawSession.drawMobileSession(session);
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       }
       this._selectSession(id, callback);
+    },
+
+    drawSessionsInLocation: function() {
+      map.markers = [];
+      _(this.get()).each(session => drawSession.drawMobileSessionStartPoint(session));
     },
 
     _selectSession: function(id, callback) {

--- a/app/assets/javascripts/code/services/google/_map.js
+++ b/app/assets/javascripts/code/services/google/_map.js
@@ -202,6 +202,10 @@ export const map = (
 
     clearRectangles: function() {
       rectangles.clear();
+    },
+
+    defaultMarkerOptions: function() {
+      return { title: session.title, zIndex: 0 };
     }
   };
 

--- a/app/assets/javascripts/tests/_fixed_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_fixed_sessions_map_ctrl.test.js
@@ -7,7 +7,7 @@ test('registers a callback to map.goToAddress', t => {
   const $scope = {
     $watch: (str, callback) => str.includes('address') ? callbacks.push(callback) : null
   };
-  const map = { ...mock('goToAddress'), unregisterAll: () => {} };
+  const map = { ...mock('goToAddress'), unregisterAll: () => {}, removeAllMarkers: () => {} };
   const controller = _FixedSessionsMapCtrl({ $scope, map, callbacks });
 
   callbacks.forEach(callback => callback({ location: 'new york' }));

--- a/app/assets/javascripts/tests/_mobile_sessions.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions.test.js
@@ -295,6 +295,20 @@ test('hasSelectedSessions with selected session returns true', t => {
   t.end();
 });
 
+test('drawSessionsInLocation calls drawSession.drawMobileSessionStartPoint', t => {
+  const session = "session"
+  const sessions = { session1: session }
+  const sessionsUtils = { get: () => (sessions) };
+  const drawSession = mock('drawMobileSessionStartPoint');
+  const mobileSessionsService = _mobileSessions({ drawSession, sessionsUtils });
+
+  mobileSessionsService.drawSessionsInLocation();
+
+  t.true(drawSession.wasCalledWith(session));
+
+  t.end();
+});
+
 const buildData = obj => ({ time: {}, location: {}, sensorId: 123, ...obj });
 
 const _mobileSessions = ({ sessionsDownloaderCalls = [], data, drawSession, utils, sessionIds = [], $location, map, sessionsUtils, sensors }) => {

--- a/app/assets/javascripts/tests/_mobile_sessions.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions.test.js
@@ -295,16 +295,30 @@ test('hasSelectedSessions with selected session returns true', t => {
   t.end();
 });
 
-test('drawSessionsInLocation calls drawSession.drawMobileSessionStartPoint', t => {
-  const session = "session"
-  const sessions = { session1: session }
-  const sessionsUtils = { get: () => (sessions) };
+test('when sensor is selected drawSessionInLocation calls drawSession.drawMobileSessionStartPoint', t => {
+  const session = { drawed: false }
+  const sessions = [ session ];
+  const sessionsUtils = { get: () => sessions };
   const drawSession = mock('drawMobileSessionStartPoint');
-  const mobileSessionsService = _mobileSessions({ drawSession, sessionsUtils });
+  const sensors = { anySelected: () => true };
+  const mobileSessionsService = _mobileSessions({ drawSession, sessionsUtils, sensors });
 
   mobileSessionsService.drawSessionsInLocation();
 
   t.true(drawSession.wasCalledWith(session));
+  t.true(session.drawed);
+
+  t.end();
+});
+
+test('when no sensor is selected drawSessionInLocation doesnt call drawSession.drawMobileSessionStartPoint', t => {
+  const drawSession = mock('drawMobileSessionStartPoint');
+  const sensors = { anySelected: () => false };
+  const mobileSessionsService = _mobileSessions({ drawSession, sensors });
+
+  mobileSessionsService.drawSessionsInLocation();
+
+  t.false(drawSession.wasCalled());
 
   t.end();
 });

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -210,7 +210,7 @@ class Session < ActiveRecord::Base
     end
 
     first_measurement = fetch_first_measurement_coordinates
-    res.merge!(:starting_longitude => first_measurement.longitude, :starting_latitude => first_measurement.latitude)
+    res.merge!(:startingLongitude => first_measurement.longitude, :startingLatitude => first_measurement.latitude)
 
     res.merge!(:streams => map_of_streams)
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -209,6 +209,9 @@ class Session < ActiveRecord::Base
       end
     end
 
+    first_measurement = fetch_first_measurement_coordinates
+    res.merge!(:starting_longitude => first_measurement.longitude, :starting_latitude => first_measurement.latitude)
+
     res.merge!(:streams => map_of_streams)
 
     res
@@ -257,6 +260,10 @@ class Session < ActiveRecord::Base
 
   private
 
+  def fetch_first_measurement_coordinates
+    self.measurements.select("longitude, latitude").order(time: :asc).first || NullMeasuremnt.new
+  end
+
   def get_measurement_scope(stream_id, since_date)
     if since_date
       data = { stream_id: stream_id, since_date: since_date }
@@ -291,5 +298,15 @@ class Session < ActiveRecord::Base
 
   def insert_into_deleted_sessions
     DeletedSession.where(:uuid => uuid, :user_id => user.id).first_or_create!
+  end
+end
+
+class NullMeasuremnt
+  def longitude
+    0
+  end
+
+  def latitude
+    0
   end
 end


### PR DESCRIPTION
This is the first step in marking mobile session starting points. I added the logic that shows the points, default blue for every session for now.

I guess it should have more tests, but I'm having trouble writing them, especially for drawSession, since there isn't anything similar that I can get inspired by :D

Also, I need to remember to tests how it behaves when crowd map for mobile is in place. Cause it wasn't easy to trace all the places where stuff are drawn and unDrawn, so it's possible I missed something.