### PR TITLE
Fix parameter sensor dropdowns

### DIFF
--- a/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
@@ -49,8 +49,11 @@ export const FixedSessionsMapCtrl = (
       $scope.expandables.show(name);
     });
 
+    const sensorId = params
+      .get('data', { sensorId: sensors.defaultSensor })
+      .sensorId;
     storage.updateDefaults({
-      sensorId: sensors.defaultSensor,
+      sensorId,
       location: {address: "", indoorOnly: false, streaming: true},
       tags: "",
       usernames: ""

--- a/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
@@ -50,7 +50,7 @@ export const FixedSessionsMapCtrl = (
     });
 
     const sensorId = params
-      .get('data', { sensorId: sensors.defaultSensor })
+      .get('data', { sensorId: sensors.defaultSensorId })
       .sensorId;
     storage.updateDefaults({
       sensorId,

--- a/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
@@ -46,7 +46,7 @@ export const MobileSessionsMapCtrl = (
     });
 
     const sensorId = params
-      .get('data', { sensorId: sensors.defaultSensor })
+      .get('data', { sensorId: sensors.defaultSensorId })
       .sensorId;
     storage.updateDefaults({
       sensorId,

--- a/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
@@ -45,8 +45,11 @@ export const MobileSessionsMapCtrl = (
       $scope.expandables.show(name);
     });
 
+    const sensorId = params
+      .get('data', { sensorId: sensors.defaultSensor })
+      .sensorId;
     storage.updateDefaults({
-      sensorId: sensors.defaultSensor,
+      sensorId,
       location: {address: ""},
       tags: "",
       usernames: "",

--- a/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
@@ -107,7 +107,7 @@ export const SessionsListCtrl = (
   $scope.$watch("params.get('selectedSessionIds')", function(newIds, oldIds) {
     console.log("watch - params.get('selectedSessionIds')");
     functionBlocker.use("sessionDialog", function(){
-      if(newIds.length === 1 && !sensors.selected()) {
+      if(newIds.length === 1 && sensors.selected().id === "all") {
         var usableSensors = singleSession.availSensors();
         if(usableSensors.length > 1) {
           sensors.candidateSelectedSensorId = _(usableSensors).first().id;

--- a/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
@@ -46,7 +46,7 @@ export const SessionsListCtrl = (
   };
 
   $scope.sessionFetchCondition = function() {
-    return {id:  sensors.selectedId(), params: params.getWithout('data', 'heat')};
+    return {id: sensors.selectedId(), params: params.getWithout('data', 'heat')};
   };
 
   $scope.updateSessionsPage = function() {

--- a/app/assets/javascripts/code/services/_build_query_params_for_crowd_map_layer.js
+++ b/app/assets/javascripts/code/services/_build_query_params_for_crowd_map_layer.js
@@ -4,7 +4,7 @@ export const buildQueryParamsForCrowdMapLayer = (
   utils
 ) => ({
   call: (sessionIds, bounds) => {
-    if (!sensors.selected()) return false;
+    if (sensors.selected().id === "all") return false;
     if (!hasTruthyValues(bounds)) return false;
     const data = params.get('data');
     if (!data.time) return false;

--- a/app/assets/javascripts/code/services/_fixed_sessions.js
+++ b/app/assets/javascripts/code/services/_fixed_sessions.js
@@ -98,7 +98,9 @@ export const fixedSessions = (
     _selectSession: function(id, callback) {
       var session = this.find(id);
       if(!session || session.alreadySelected) return;
-      var sensorId = params.get("data", {}).sensorId || sensors.tmpSelectedId();
+      var sensorId = params.get("data", {}).sensorId && params.get("data", {}).sensorId !== "all" ?
+        params.get("data", {}).sensorId :
+        sensors.tmpSelectedId();
       var sensor = sensors.sensors[sensorId] || {};
       var sensorName = sensor.sensor_name;
       if (!sensorName) return;

--- a/app/assets/javascripts/code/services/_fixed_sessions.js
+++ b/app/assets/javascripts/code/services/_fixed_sessions.js
@@ -168,7 +168,7 @@ export const fixedSessions = (
         });
       }
 
-      if(sensors.selected()){
+      if(sensors.selected().id !== "all"){
         _(reqData).extend({
           sensor_name:  sensors.selected().sensor_name,
           measurement_type:  sensors.selected().measurement_type,

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -144,7 +144,7 @@ export const mobileSessions = (
         north: bounds.north
       });
 
-      if(sensors.selected()){
+      if(sensors.selected().id !== "all"){
         _(reqData).extend({
           sensor_name:  sensors.selected().sensor_name,
           measurement_type:  sensors.selected().measurement_type,

--- a/app/assets/javascripts/code/services/_sensors.js
+++ b/app/assets/javascripts/code/services/_sensors.js
@@ -98,7 +98,6 @@ export const sensors = (params, $http) => {
     },
     onSelectedParameterChange: function(selectedParameter, oldValue) {
       console.log('onSelectedParameterChange() - ', selectedParameter)
-      if (selectedParameter === oldValue) return; // first angular watch run
       params.update({selectedSessionIds: []});
       if (selectedParameter.id === ALL_PARAMETER.id) {
         this.availableSensors = [ALL_SENSOR].concat(sort(Object.values(this.sensors)));

--- a/app/assets/javascripts/code/services/_sensors.js
+++ b/app/assets/javascripts/code/services/_sensors.js
@@ -97,6 +97,7 @@ export const sensors = (params, $http) => {
     },
     onSelectedParameterChange: function(selectedParameter, oldValue) {
       console.log('onSelectedParameterChange() - ', selectedParameter)
+      if (selectedParameter === oldValue) return; // first angular watch run
       params.update({selectedSessionIds: []});
       if (selectedParameter.id === ALL_PARAMETER.id) {
         this.availableSensors = [ALL_SENSOR].concat(sort(Object.values(this.sensors)));

--- a/app/assets/javascripts/code/services/_sensors.js
+++ b/app/assets/javascripts/code/services/_sensors.js
@@ -94,7 +94,7 @@ export const sensors = (params, $http) => {
       console.log('onSelectedParameterChange() - ', selectedParameter, ' - ', oldValue)
       if (selectedParameter === oldValue) return; // first angular watch run
       params.update({selectedSessionIds: []});
-      if (selectedParameter.id === ALL_PARAMETER.id) {
+      if (selectedParameter=== ALL_PARAMETER) {
         this.availableSensors = [ALL_SENSOR].concat(sort(Object.values(this.sensors)));
         params.update({data: {sensorId: ALL_SENSOR.id}});
       } else {
@@ -119,7 +119,8 @@ export const sensors = (params, $http) => {
     onSensorsSelectedIdChange: function(newValue, oldValue, callback) {
       console.log("onSensorsSelectedIdChange - ", newValue, " - ", oldValue);
 
-      if(!newValue || newValue === ALL_SENSOR.id) return;
+      if(!newValue) return;
+      if(newValue === ALL_SENSOR.id) return;
 
       if (callback) {
         $http.get( '/api/thresholds/' + this.selected().sensor_name, {

--- a/app/assets/javascripts/code/services/_sensors.js
+++ b/app/assets/javascripts/code/services/_sensors.js
@@ -7,7 +7,6 @@ export const sensors = (params, $http) => {
   var Sensors = function() {
     this.sensors = {};
     this.candidateSelectedSensorId = undefined;
-    this.shouldInitSelected = false;
     this.defaultSensor = this.buildSensorId({
       measurement_type: "Particulate Matter",
       sensor_name:      "AirBeam2-PM2.5",

--- a/app/assets/javascripts/code/services/_sensors.js
+++ b/app/assets/javascripts/code/services/_sensors.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-const ALL_SENSOR = { id: "all", select_label: "All", session_count: 0 };
+const ALL_SENSOR = { id: "all", select_label: "All", session_count: 0, measurement_type: "all" };
 const ALL_PARAMETER = { id: "all", label: "All" };
 
 export const sensors = (params, $http) => {
@@ -12,15 +12,13 @@ export const sensors = (params, $http) => {
       sensor_name:      "AirBeam2-PM2.5",
       unit_symbol:      "µg/m³"
     });
-
     this.availableSensors = [];
-    this.defaultParameter = {id: "Particulate Matter", label: "Particulate Matter"};
     this.selectedParameter = {};
-    // [{label: "Activity Level", id: "Activity Level"}, ...]
     this.availableParameters = [];
   };
+
   Sensors.prototype = {
-    setSensors : function(data, status, headers, config) {
+    setSensors: function(data, status, headers, config) {
       // Sensors
       var sensors = {};
       var self = this;
@@ -57,10 +55,11 @@ export const sensors = (params, $http) => {
 
     //selected sensor in dropdown
     selected: function() {
-      return this.sensors[params.get('data').sensorId];
+      return params.get('data').sensorId === ALL_SENSOR.id ?
+        ALL_SENSOR : this.sensors[params.get('data').sensorId] || this.sensors[this.defaultSensor];
     },
     selectedId: function() {
-      return this.selected() ? this.selected().id : ALL_SENSOR.id;
+      return this.selected().id;
     },
     //used when "all" sensors are choosen
     tmpSelected: function() {
@@ -86,17 +85,13 @@ export const sensors = (params, $http) => {
       params.update({tmp: {selectedSensorId: this.candidateSelectedSensorId}});
     },
     findSensorById: function(id) {
-      return this.sensors[id]
+      return id === ALL_SENSOR.id ? ALL_SENSOR : this.sensors[id];
     },
     findParameterForSensor: function(sensor) {
-      if (sensor) {
-        return _(this.availableParameters).find(function(parameter) { return (parameter.id == sensor["measurement_type"]) });
-      } else {
-        return ALL_PARAMETER;
-      }
+      return _(this.availableParameters).find(function(parameter) { return (parameter.id == sensor["measurement_type"]) });
     },
     onSelectedParameterChange: function(selectedParameter, oldValue) {
-      console.log('onSelectedParameterChange() - ', selectedParameter)
+      console.log('onSelectedParameterChange() - ', selectedParameter, ' - ', oldValue)
       if (selectedParameter === oldValue) return; // first angular watch run
       params.update({selectedSessionIds: []});
       if (selectedParameter.id === ALL_PARAMETER.id) {
@@ -109,8 +104,8 @@ export const sensors = (params, $http) => {
       }
     },
     // changed params.get('data').sensorId
-    onSelectedSensorChange: function(newSensorId) {
-      console.log('onSelectedSensorChange() - ', newSensorId);
+    onSelectedSensorChange: function(newSensorId, oldSensorId) {
+      console.log('onSelectedSensorChange() - ', newSensorId, ' - ', oldSensorId);
       if (!newSensorId) return;
       if(newSensorId === ALL_SENSOR.id) params.update({data: {sensorId: ALL_SENSOR.id}});
       var sensor = this.findSensorById(newSensorId);

--- a/app/assets/javascripts/code/services/_sensors.js
+++ b/app/assets/javascripts/code/services/_sensors.js
@@ -7,7 +7,7 @@ export const sensors = (params, $http) => {
   var Sensors = function() {
     this.sensors = {};
     this.candidateSelectedSensorId = undefined;
-    this.defaultSensor = this.buildSensorId({
+    this.defaultSensorId = this.buildSensorId({
       measurement_type: "Particulate Matter",
       sensor_name:      "AirBeam2-PM2.5",
       unit_symbol:      "µg/m³"
@@ -45,7 +45,7 @@ export const sensors = (params, $http) => {
 
       if(_(params.get('data').sensorId).isNull()) {
         console.log('initSelected() - sensorId is null')
-        params.update({data: {sensorId: this.defaultSensor }});
+        params.update({data: {sensorId: this.defaultSensorId }});
       } else {
         console.log('initSelected() - sensorId is NOT null')
       }
@@ -56,7 +56,7 @@ export const sensors = (params, $http) => {
     //selected sensor in dropdown
     selected: function() {
       return params.get('data').sensorId === ALL_SENSOR.id ?
-        ALL_SENSOR : this.sensors[params.get('data').sensorId] || this.sensors[this.defaultSensor];
+        ALL_SENSOR : this.sensors[params.get('data').sensorId] || this.sensors[this.defaultSensorId];
     },
     selectedId: function() {
       return this.selected().id;

--- a/app/assets/javascripts/tests/_fixed_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_fixed_sessions_map_ctrl.test.js
@@ -17,17 +17,47 @@ test('registers a callback to map.goToAddress', t => {
   t.end();
 });
 
-const _FixedSessionsMapCtrl = ({ $scope, map, callback }) => {
+test('it updates defaults', t => {
+  let defaults = {};
+  const sensorId = "sensor id";
+  const params = {
+    get: () => ({ sensorId })
+  };
+  const storage = {
+    updateDefaults: opts => defaults = opts
+  };
+
+  _FixedSessionsMapCtrl({ storage, params });
+
+  const expected = {
+    sensorId,
+    location: {
+      address: "",
+      indoorOnly: false,
+      streaming: true
+    },
+    tags: "",
+    usernames: ""
+  };
+  t.deepEqual(defaults, expected);
+
+  t.end();
+});
+
+const _FixedSessionsMapCtrl = ({ $scope, map, callback, storage, params }) => {
   const expandables = { show: () => {} };
   const sensors = { setSensors: () => {} };
   const functionBlocker = { block: () => {} };
-  const params = { get: () => {} };
+  const _params = { get: () => ({}), ...params };
   const rectangles = { clear: () => {} };
   const infoWindow = { hide: () => {} };
-  const storage = {
+  const _storage = {
     updateDefaults: () => {},
-    updateFromDefaults: () => {}
+    updateFromDefaults: () => {},
+    ...storage
   };
+  const _$scope = { $watch: () => {}, ...$scope };
+  const _map = { unregisterAll: () => {}, ...map };
 
-  return FixedSessionsMapCtrl($scope, params, null, map, sensors, expandables, storage, null, null, null, null, functionBlocker, null, null, rectangles, infoWindow);
+  return FixedSessionsMapCtrl(_$scope, _params, null, _map, sensors, expandables, _storage, null, null, null, null, functionBlocker, null, null, rectangles, infoWindow);
 };

--- a/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
@@ -33,14 +33,14 @@ test('it shows by default sensor, location, usernames and layers sections', t =>
 test('it updates defaults', t => {
   let defaults = {};
   const sensorId = "sensor id";
-  const sensors = {
-    defaultSensor: sensorId
+  const params = {
+    get: () => ({ sensorId })
   };
   const storage = {
     updateDefaults: opts => defaults = opts
   };
 
-  _MobileSessionsMapCtrl({ storage, sensors });
+  _MobileSessionsMapCtrl({ storage, params });
 
   const expected = {
     sensorId,
@@ -55,11 +55,11 @@ test('it updates defaults', t => {
   t.end();
 });
 
-const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables, sensors }) => {
+const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables, sensors, params }) => {
   const _expandables = { show: () => {}, ...expandables };
   const _sensors = { setSensors: () => {}, ...sensors };
   const functionBlocker = { block: () => {} };
-  const params = { get: () => {} };
+  const _params = { get: () => ({}), ...params };
   const infoWindow = { hide: () => {} };
   const _storage = {
     updateDefaults: () => {},
@@ -75,5 +75,5 @@ const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables, s
   };
   const _$scope = { $watch: () => {}, ...$scope };
 
-  return MobileSessionsMapCtrl(_$scope, params, _map, _sensors, _expandables, _storage, null, null, null, null, functionBlocker, null, infoWindow);
+  return MobileSessionsMapCtrl(_$scope, _params, _map, _sensors, _expandables, _storage, null, null, null, null, functionBlocker, null, infoWindow);
 };

--- a/app/assets/javascripts/tests/_sensors.test.js
+++ b/app/assets/javascripts/tests/_sensors.test.js
@@ -169,7 +169,7 @@ test('defaultSensorIdForParameter returns hardcoded id for Sound Level', t => {
   t.end();
 });
 
-test('buildAvailableParameters builds available parameters sorted by session_count', t => {
+test('buildAvailableParameters builds available parameters sorted by session_count with all as first', t => {
   const sensors = {
     "a": {
       measurement_type: "Particulate Matter",
@@ -183,11 +183,11 @@ test('buildAvailableParameters builds available parameters sorted by session_cou
 
   const actual = buildAvailableParameters(sensors);
 
-  const expected = [{
-    label: "Humidity", id: "Humidity"
-  }, {
-    label: "Particulate Matter", id: "Particulate Matter"
-  }];
+  const expected = [
+    { label: "All", id: "all" },
+    { label: "Humidity", id: "Humidity" },
+    { label: "Particulate Matter", id: "Particulate Matter" }
+];
   t.deepEqual(actual, expected);
 
   t.end();

--- a/public/partials/fixed_sessions_map.html
+++ b/public/partials/fixed_sessions_map.html
@@ -8,12 +8,12 @@
       <section ng-show="expandables.visible('sensor')" >
       <p>
         <select ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id">
-          <option value="">All</option>
+          <option value="all">All</option>
         </select>
       </p>
       <p>
         <select ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for sensor in sensors.availableSensors">
-          <option disabled value="">All</option>
+          <option disabled value="all">All</option>
         </select>
       </p>
       </section>

--- a/public/partials/mobile_sessions_map.html
+++ b/public/partials/mobile_sessions_map.html
@@ -8,12 +8,12 @@
       <section ng-show="expandables.visible('sensor')" >
       <p>
         <select ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id">
-          <option value="">All</option>
+          <option value="all">All</option>
         </select>
       </p>
       <p>
         <select ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for sensor in sensors.availableSensors">
-          <option disabled value="">All</option>
+          <option disabled value="all">All</option>
         </select>
       </p>
       </section>


### PR DESCRIPTION
The tab could be opened in three different ways:
- by opening `/map` (ie clicking on the maps link in the menu)
- by switching to fixed / mobile
- by copy / pasting a url (eg `/map#/map_fixed_sessions?map=%7B%22zoom%22:5,%22lat%22:37.09024,%22lng%22:-95.71289100000001,%22mapType%22:%22terrain%22%7D&data=%7B%22sensorId%22:%22Particulate%20Matter-AirBeam2-PM2.5%20(%C2%B5g%2Fm%C2%B3)%22,%22location%22:%7B%22address%22:%22%22,%22indoorOnly%22:false,%22streaming%22:true%7D,%22tags%22:%22%22,%22usernames%22:%22%22,%22time%22:%7B%22timeFrom%22:-60,%22timeTo%22:1379,%22dayFrom%22:1,%22dayTo%22:365,%22yearFrom%22:2017,%22yearTo%22:2018%7D,%22heat%22:%7B%22highest%22:150,%22high%22:55,%22mid%22:35,%22low%22:12,%22lowest%22:0%7D%7D&selectedSessionIds=%5B%5D&tmp=%7B%22selectedSensorId%22:%22%22%7D`)

Before this PR the app always loaded as parameter / sensor the default (ie particulate matter / ab2 pm 2.5) when in the url no `sensorId` was specified or if `sensorId` was "". Unfortunately, all / all was equivalent to `sensorId === ""` which loaded particulate matter / ab2 pm 2.5 and not all / all. That happened for example if a user selected all / all and then pasted the link to navigate back to the page.

Now the code persists `sensorId === "all"` when all / all is selected, therefore pasting the link works.

Also, the smaller commit fixed another bug. In particular, on the first load the sensors weren't filtered by parameter when the page was loaded. In fact, the default selection was in place particulate matter / ab2 pm 2.5 but the sensors in the dropdown contained all of them (eg humidity, sound level)