### PR TITLE
Unify schema and migration history with changes made by percona

### DIFF
--- a/db/migrate/20181219094432_add_starting_longitude_and_latitude_to_streams.rb
+++ b/db/migrate/20181219094432_add_starting_longitude_and_latitude_to_streams.rb
@@ -1,0 +1,16 @@
+class AddStartingLongitudeAndLatitudeToStreams < ActiveRecord::Migration
+  def up
+    unless column_exists?(:streams, :start_longitude)
+      add_column :streams, :start_longitude, :decimal, :precision => 12, :scale => 9
+    end
+
+    unless column_exists?(:streams, :start_latitude)
+      add_column :streams, :start_latitude, :decimal, :precision => 12, :scale => 9
+    end
+  end
+
+  def down
+    remove_column :streams, :start_longitude
+    remove_column :streams, :start_latitude
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20181113100336) do
+ActiveRecord::Schema.define(:version => 20181219094432) do
 
   create_table "deleted_sessions", :force => true do |t|
     t.datetime "created_at", :null => false
@@ -135,6 +135,8 @@ ActiveRecord::Schema.define(:version => 20181113100336) do
     t.decimal "min_longitude",          :precision => 12, :scale => 9
     t.decimal "max_longitude",          :precision => 12, :scale => 9
     t.float   "average_value"
+    t.decimal "start_longitude",        :precision => 12, :scale => 9
+    t.decimal "start_latitude",         :precision => 12, :scale => 9
   end
 
   add_index "streams", ["max_latitude"], :name => "index_streams_on_max_latitude"


### PR DESCRIPTION
When I run a migration using percona toolkit our database will change without changing the rails schema. This PR introduces the needed changes to keep schema up to date. It also adds a migration that reflects the changes made by percona, so we can rely on db:migrate creating the same schema as we have now.