### PR TITLE
Fix parameter sensor dropdowns 2

### DIFF
--- a/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
@@ -50,7 +50,7 @@ export const FixedSessionsMapCtrl = (
     });
 
     storage.updateDefaults({
-      sensorId: sensors.defaultSensor,
+      sensorId: sensors.defaultSensorId,
       location: {address: "", indoorOnly: false, streaming: true},
       tags: "",
       usernames: ""

--- a/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_fixed_sessions_map_ctrl.js
@@ -49,8 +49,12 @@ export const FixedSessionsMapCtrl = (
       $scope.expandables.show(name);
     });
 
+    const sensorId = params
+      .get('data', { sensorId: sensors.defaultSensorId })
+      .sensorId;
+
     storage.updateDefaults({
-      sensorId: sensors.defaultSensorId,
+      sensorId,
       location: {address: "", indoorOnly: false, streaming: true},
       tags: "",
       usernames: ""

--- a/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
@@ -45,8 +45,12 @@ export const MobileSessionsMapCtrl = (
       $scope.expandables.show(name);
     });
 
+    const sensorId = params
+      .get('data', { sensorId: sensors.defaultSensorId })
+      .sensorId;
+
     storage.updateDefaults({
-      sensorId: sensors.defaultSensorId,
+      sensorId,
       location: {address: ""},
       tags: "",
       usernames: "",

--- a/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
@@ -46,7 +46,7 @@ export const MobileSessionsMapCtrl = (
     });
 
     storage.updateDefaults({
-      sensorId: sensors.defaultSensor,
+      sensorId: sensors.defaultSensorId,
       location: {address: ""},
       tags: "",
       usernames: "",

--- a/app/assets/javascripts/code/services/_fixed_sessions.js
+++ b/app/assets/javascripts/code/services/_fixed_sessions.js
@@ -98,7 +98,7 @@ export const fixedSessions = (
     _selectSession: function(id, callback) {
       var session = this.find(id);
       if(!session || session.alreadySelected) return;
-      var sensorId = params.get("data", {}).sensorId || sensors.tmpSelectedId();
+      var sensorId = sensors.selectedId() || sensors.tmpSelectedId();
       var sensor = sensors.sensors[sensorId] || {};
       var sensorName = sensor.sensor_name;
       if (!sensorName) return;

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -105,7 +105,7 @@ export const mobileSessions = (
       const allSelected = this.allSelected();
       var session = this.find(id);
       if(!session || session.alreadySelected) return;
-      var sensorId = params.get("data", {}).sensorId || sensors.tmpSelectedId();
+      var sensorId = sensors.selectedId() || sensors.tmpSelectedId();
       var sensor = sensors.sensors[sensorId] || {};
       var sensorName = sensor.sensor_name;
       if (!sensorName) return;

--- a/app/assets/javascripts/code/services/_sensors.js
+++ b/app/assets/javascripts/code/services/_sensors.js
@@ -5,7 +5,7 @@ export const sensors = (params, $http) => {
     this.sensors = {};
     this.candidateSelectedSensorId = undefined;
     this.shouldInitSelected = false;
-    this.defaultSensor = this.buildSensorId({
+    this.defaultSensorId = this.buildSensorId({
       measurement_type: "Particulate Matter",
       sensor_name:      "AirBeam2-PM2.5",
       unit_symbol:      "µg/m³"
@@ -45,7 +45,7 @@ export const sensors = (params, $http) => {
 
       if(_(params.get('data').sensorId).isNull()) {
         console.log('initSelected() - sensorId is null')
-        params.update({data: {sensorId: this.defaultSensor }});
+        params.update({data: {sensorId: this.defaultSensorId }});
       } else {
         console.log('initSelected() - sensorId is NOT null')
       }

--- a/app/assets/javascripts/code/services/_sensors.js
+++ b/app/assets/javascripts/code/services/_sensors.js
@@ -4,7 +4,6 @@ export const sensors = (params, $http) => {
   var Sensors = function() {
     this.sensors = {};
     this.candidateSelectedSensorId = undefined;
-    this.shouldInitSelected = false;
     this.defaultSensorId = this.buildSensorId({
       measurement_type: "Particulate Matter",
       sensor_name:      "AirBeam2-PM2.5",
@@ -12,9 +11,7 @@ export const sensors = (params, $http) => {
     });
 
     this.availableSensors = [];
-    this.defaultParameter = {id: "Particulate Matter", label: "Particulate Matter"};
     this.selectedParameter = {};
-    // [{label: "Activity Level", id: "Activity Level"}, ...]
     this.availableParameters = [];
   };
   Sensors.prototype = {

--- a/app/assets/javascripts/tests/_fixed_sessions.test.js
+++ b/app/assets/javascripts/tests/_fixed_sessions.test.js
@@ -320,7 +320,7 @@ const _fixedSessions = ({ sessionsDownloaderCalls = [], data, drawSession, utils
   };
   const _map = { getBounds: () => ({}), getZoom: () => undefined, ...map };
   const _utils = utils || {};
-  const _sensors = { selected: () => {}, sensors: {}, ...sensors };
+  const _sensors = { selectedId: () => 123, selected: () => {}, sensors: {}, ...sensors };
   const _drawSession = drawSession || { clear: () => {} };
   const sessionsDownloader = (_, arg) => { sessionsDownloaderCalls.push(arg) };
   const _$location = $location || { path: () => '/map_fixed_sessions' };

--- a/app/assets/javascripts/tests/_fixed_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_fixed_sessions_map_ctrl.test.js
@@ -17,17 +17,47 @@ test('registers a callback to map.goToAddress', t => {
   t.end();
 });
 
-const _FixedSessionsMapCtrl = ({ $scope, map, callback }) => {
+test('it updates defaults', t => {
+  let defaults = {};
+  const sensorId = "sensor id";
+  const params = {
+    get: () => ({ sensorId })
+  };
+  const storage = {
+    updateDefaults: opts => defaults = opts
+  };
+
+  _FixedSessionsMapCtrl({ storage, params });
+
+  const expected = {
+    sensorId,
+    location: {
+      address: "",
+      indoorOnly: false,
+      streaming: true
+    },
+    tags: "",
+    usernames: ""
+  };
+  t.deepEqual(defaults, expected);
+
+  t.end();
+});
+
+const _FixedSessionsMapCtrl = ({ $scope, map, callback, storage, params }) => {
   const expandables = { show: () => {} };
   const sensors = { setSensors: () => {} };
   const functionBlocker = { block: () => {} };
-  const params = { get: () => {} };
+  const _params = { get: () => ({}), ...params };
   const rectangles = { clear: () => {} };
   const infoWindow = { hide: () => {} };
-  const storage = {
+  const _storage = {
     updateDefaults: () => {},
-    updateFromDefaults: () => {}
+    updateFromDefaults: () => {},
+    ...storage
   };
+  const _$scope = { $watch: () => {}, ...$scope };
+  const _map = { unregisterAll: () => {}, ...map };
 
-  return FixedSessionsMapCtrl($scope, params, null, map, sensors, expandables, storage, null, null, null, null, functionBlocker, null, null, rectangles, infoWindow);
+  return FixedSessionsMapCtrl(_$scope, _params, null, _map, sensors, expandables, _storage, null, null, null, null, functionBlocker, null, null, rectangles, infoWindow);
 };

--- a/app/assets/javascripts/tests/_mobile_sessions.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions.test.js
@@ -312,7 +312,7 @@ const _mobileSessions = ({ sessionsDownloaderCalls = [], data, drawSession, util
   };
   const _map = { getBounds: () => ({}), fitBounds: () => {}, getZoom: () => {}, ...map };
   const _utils = utils || {};
-  const _sensors = { selected: () => {}, sensors: {}, ...sensors };
+  const _sensors = { selectedId: () => 123, selected: () => {}, sensors: {}, ...sensors };
   const _drawSession = { clear: () => {}, drawMobileSession: () => {}, ...drawSession };
   const sessionsDownloader = (_, arg) => { sessionsDownloaderCalls.push(arg) };
   const _sessionsUtils = { find: () => ({}), allSelected: () => {}, onSingleSessionFetch: (x, y, callback) => callback(), ...sessionsUtils };

--- a/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
@@ -34,7 +34,7 @@ test('it updates defaults', t => {
   let defaults = {};
   const sensorId = "sensor id";
   const sensors = {
-    defaultSensor: sensorId
+    defaultSensorId: sensorId
   };
   const storage = {
     updateDefaults: opts => defaults = opts

--- a/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
@@ -33,14 +33,14 @@ test('it shows by default sensor, location, usernames and layers sections', t =>
 test('it updates defaults', t => {
   let defaults = {};
   const sensorId = "sensor id";
-  const sensors = {
-    defaultSensorId: sensorId
+  const params = {
+    get: () => ({ sensorId })
   };
   const storage = {
     updateDefaults: opts => defaults = opts
   };
 
-  _MobileSessionsMapCtrl({ storage, sensors });
+  _MobileSessionsMapCtrl({ storage, params });
 
   const expected = {
     sensorId,
@@ -55,11 +55,11 @@ test('it updates defaults', t => {
   t.end();
 });
 
-const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables, sensors }) => {
+const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables, sensors, params }) => {
   const _expandables = { show: () => {}, ...expandables };
   const _sensors = { setSensors: () => {}, ...sensors };
   const functionBlocker = { block: () => {} };
-  const params = { get: () => {} };
+  const _params = { get: () => ({}), ...params };
   const infoWindow = { hide: () => {} };
   const _storage = {
     updateDefaults: () => {},
@@ -75,5 +75,5 @@ const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables, s
   };
   const _$scope = { $watch: () => {}, ...$scope };
 
-  return MobileSessionsMapCtrl(_$scope, params, _map, _sensors, _expandables, _storage, null, null, null, null, functionBlocker, null, infoWindow);
+  return MobileSessionsMapCtrl(_$scope, _params, _map, _sensors, _expandables, _storage, null, null, null, null, functionBlocker, null, infoWindow);
 };

--- a/app/assets/javascripts/tests/_sensors.test.js
+++ b/app/assets/javascripts/tests/_sensors.test.js
@@ -169,7 +169,7 @@ test('defaultSensorIdForParameter returns hardcoded id for Sound Level', t => {
   t.end();
 });
 
-test('buildAvailableParameters builds available parameters sorted by session_count', t => {
+test('buildAvailableParameters builds available parameters sorted by session_count with all as first', t => {
   const sensors = {
     "a": {
       measurement_type: "Particulate Matter",
@@ -183,11 +183,11 @@ test('buildAvailableParameters builds available parameters sorted by session_cou
 
   const actual = buildAvailableParameters(sensors);
 
-  const expected = [{
-    label: "Humidity", id: "Humidity"
-  }, {
-    label: "Particulate Matter", id: "Particulate Matter"
-  }];
+  const expected = [
+    { label: "All", id: "all" },
+    { label: "Humidity", id: "Humidity" },
+    { label: "Particulate Matter", id: "Particulate Matter" }
+  ];
   t.deepEqual(actual, expected);
 
   t.end();

--- a/app/assets/javascripts/tests/_sensors.test.js
+++ b/app/assets/javascripts/tests/_sensors.test.js
@@ -4,7 +4,8 @@ import {
   findAvailableSensorsForParameter,
   sort,
   defaultSensorIdForParameter,
-  buildAvailableParameters
+  buildAvailableParameters,
+  sensors
 } from '../code/services/_sensors';
 
 test('findAvailableSensorsForParameter when parameter is falsy it returns sensors sorted with passed function', t => {
@@ -192,3 +193,135 @@ test('buildAvailableParameters builds available parameters sorted by session_cou
 
   t.end();
 });
+
+test('selected with no sensor id in the url returns the default sensor with added id, label, select_label', t => {
+  const params = {
+    get: () => ({ sensorId: null })
+  };
+  const service = _sensors({ params })
+  const defaultSensor = {
+    measurement_type: "Particulate Matter",
+    sensor_name: "AirBeam2-PM2.5",
+    unit_symbol: "µg/m³"
+  };
+  const allSensors = [defaultSensor];
+  service.setSensors(allSensors)
+
+  const actual = service.selected();
+
+  const expected = {
+    ...defaultSensor,
+    id: 'Particulate Matter-AirBeam2-PM2.5 (µg/m³)',
+    label: 'AirBeam2-PM2.5 (µg/m³)',
+    select_label: 'AirBeam2-PM2.5 (µg/m³)'
+  };
+  t.deepEqual(actual, expected);
+
+  t.end();
+});
+
+test('selected with all as sensor id in the url returns undefined', t => {
+  const params = {
+    get: () => ({ sensorId: "all" })
+  };
+  const service = _sensors({ params })
+
+  const actual = service.selected();
+
+  const expected = undefined;
+  t.deepEqual(actual, expected);
+
+  t.end();
+});
+
+test('selected with sensor id in the url returns the correct sensor with added id, label, select_label', t => {
+  const params = {
+    get: () => ({ sensorId: "Humidity-AirBeam2-RH (%)" })
+  };
+  const service = _sensors({ params })
+  const sensor = {
+    measurement_type: "Humidity",
+    sensor_name:      "AirBeam2-RH",
+    unit_symbol:      "%"
+  };
+  const allSensors = [sensor];
+  service.setSensors(allSensors)
+
+  const actual = service.selected();
+
+  const expected = {
+    ...sensor,
+    id: 'Humidity-AirBeam2-RH (%)',
+    label: 'AirBeam2-RH (%)',
+    select_label: 'AirBeam2-RH (%)'
+  };
+  t.deepEqual(actual, expected);
+
+  t.end();
+});
+
+test('selectedId with no sensor id in the url returns the default sensor id', t => {
+  const params = {
+    get: () => ({ sensorId: null })
+  };
+  const service = _sensors({ params })
+  const defaultSensor = {
+    measurement_type: "Particulate Matter",
+    sensor_name: "AirBeam2-PM2.5",
+    unit_symbol: "µg/m³"
+  };
+  const allSensors = [defaultSensor];
+  service.setSensors(allSensors)
+
+  const actual = service.selectedId();
+
+  const expected = 'Particulate Matter-AirBeam2-PM2.5 (µg/m³)';
+  t.deepEqual(actual, expected);
+
+  t.end();
+});
+
+test('selectedId with all as sensor id in the url returns undefined', t => {
+  const params = {
+    get: () => ({ sensorId: "all" })
+  };
+  const service = _sensors({ params })
+
+  const actual = service.selectedId();
+
+  const expected = undefined;
+  t.deepEqual(actual, expected);
+
+  t.end();
+});
+
+test('selectedId with sensor id in the url returns the correct sensor id', t => {
+  const params = {
+    get: () => ({ sensorId: "Humidity-AirBeam2-RH (%)" })
+  };
+  const service = _sensors({ params })
+  const sensor = {
+    measurement_type: "Humidity",
+    sensor_name:      "AirBeam2-RH",
+    unit_symbol:      "%"
+  };
+  const allSensors = [sensor];
+  service.setSensors(allSensors)
+
+  const actual = service.selectedId();
+
+  const expected = 'Humidity-AirBeam2-RH (%)';
+  t.deepEqual(actual, expected);
+
+  t.end();
+});
+
+const _sensors = ({ params }) => {
+  const _params = {
+    get: () => ({ sensorId: null }),
+    update: () => {},
+    ...params
+  };
+
+  return sensors(_params);
+};

--- a/app/views/layouts/map.html.haml
+++ b/app/views/layouts/map.html.haml
@@ -10,7 +10,7 @@
     = render :partial => 'shared/analytics'
     = render :partial => 'shared/fb_logo'
 
-  %body(id="map" data-version="1.0.9")
+  %body(id="map" data-version="1.0.10")
     .notice(ng-controller="FlashCtrl" ng-cloak ng-show="flash.message" ng-click="clear()") {{flash.message}}
     #mapview(ng-controller="MapCtrl" googlemap="")
     #hud(ng-controller="HudCtrl" ng-cloak ng-hide="map.streetViewVisible()")

--- a/public/partials/fixed_sessions_map.html
+++ b/public/partials/fixed_sessions_map.html
@@ -7,14 +7,10 @@
       <h4 ng-click="expandables.toggle('sensor')" ng-class="expandables.css('sensor')">Parameter - Sensor</h4>
       <section ng-show="expandables.visible('sensor')" >
       <p>
-        <select ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id">
-          <option value="">All</option>
-        </select>
+        <select ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id"></select>
       </p>
       <p>
-        <select ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for sensor in sensors.availableSensors">
-          <option disabled value="">All</option>
-        </select>
+        <select ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for sensor in sensors.availableSensors"></select>
       </p>
       </section>
 

--- a/public/partials/mobile_sessions_map.html
+++ b/public/partials/mobile_sessions_map.html
@@ -7,14 +7,10 @@
       <h4 ng-click="expandables.toggle('sensor')" ng-class="expandables.css('sensor')">Parameter - Sensor</h4>
       <section ng-show="expandables.visible('sensor')" >
       <p>
-        <select ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id">
-          <option value="">All</option>
-        </select>
+        <select ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id"></select>
       </p>
       <p>
-        <select ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for sensor in sensors.availableSensors">
-          <option disabled value="">All</option>
-        </select>
+        <select ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for sensor in sensors.availableSensors"></select>
       </p>
       </section>
 


### PR DESCRIPTION
This is a rewrite of https://github.com/HabitatMap/AirCasting/pull/67

Unfortunately, a lot of modules depend on the behaviour of _sensors.js. In particular, mutations of variables and `undefined` return values. That is not good but making the code immutable / always return values would break a lot of stuff. The ticket I'm working on does not justify all of that work.

Therefore, this PR implements the same features / fixes but keeps the public API closer to the one that was in place. Since I couldn't refactor the public code, I tried to make the internals better at least.