### PR TITLE
Click mobile points

### DIFF
--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -64,7 +64,7 @@ export const drawSession = (
     drawMobileSessionStartPoint: function(session, selectedSensor) {
       this.undoDraw(session);
 
-      const markerOptions = map.defaultMarkerOptions;
+      const markerOptions = map.defaultMarkerOptions(session);
       const lngLatObject = {
         longitude: session.streams[selectedSensor]["start_longitude"],
         latitude: session.streams[selectedSensor]["start_latitude"],

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -67,7 +67,8 @@ export const drawSession = (
       const markerOptions = map.defaultMarkerOptions;
       const lngLatObject = {
         longitude: session.streams[selectedSensor]["start_longitude"],
-        latitude: session.streams[selectedSensor]["start_latitude"]
+        latitude: session.streams[selectedSensor]["start_latitude"],
+        id: session.id
       }
       const level = heat.getLevel(session.average)
       session.markers.push(map.drawMarker(lngLatObject, markerOptions, null, level));

--- a/app/assets/javascripts/code/services/google/_map.js
+++ b/app/assets/javascripts/code/services/google/_map.js
@@ -196,7 +196,7 @@ export const map = (
       rectangles.clear();
     },
 
-    defaultMarkerOptions: function() {
+    defaultMarkerOptions: function(session) {
       return { title: session.title, zIndex: 0 };
     }
   };


### PR DESCRIPTION
Adds the same function that fixed sessions have.
1. Users can click the session marker to select the session.
2. While hovering over the marker session name is shown. 