### PR TITLE
Fix use map type from url

### DIFF
--- a/app/assets/javascripts/code/directives/googlemap.js
+++ b/app/assets/javascripts/code/directives/googlemap.js
@@ -10,11 +10,11 @@ angular.module('aircasting').directive('googlemap', function() {
 
       var map = scope.map;
       var params = scope.params.get('map') || {};
-      var lat = params.lat || map.getMapCookie('vp_lat') || point.lat;
-      var lng = params.lng || map.getMapCookie('vp_lng') || point.lng;
+      var lat = params.lat || point.lat;
+      var lng = params.lng || point.lng;
       var latlng = new google.maps.LatLng(lat, lng);
-      var zoom = params.zoom || map.getMapCookie('vp_zoom') || point.zoom;
-      var mapType = params.mapType || map.getMapCookie('vp_mapType') || google.maps.MapTypeId.TERRAIN;
+      var zoom = params.zoom || point.zoom;
+      var mapType = params.mapType || google.maps.MapTypeId.TERRAIN;
       const minZoom = 3;
       var options = {
         zoom: parseInt(zoom, 10),

--- a/app/assets/javascripts/code/directives/googlemap.js
+++ b/app/assets/javascripts/code/directives/googlemap.js
@@ -14,7 +14,7 @@ angular.module('aircasting').directive('googlemap', function() {
       var lng = params.lng || map.getMapCookie('vp_lng') || point.lng;
       var latlng = new google.maps.LatLng(lat, lng);
       var zoom = params.zoom || map.getMapCookie('vp_zoom') || point.zoom;
-      var mapType = map.getMapCookie('vp_mapType') || google.maps.MapTypeId.TERRAIN || params.mapType;
+      var mapType = params.mapType || map.getMapCookie('vp_mapType') || google.maps.MapTypeId.TERRAIN;
       const minZoom = 3;
       var options = {
         zoom: parseInt(zoom, 10),

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -23,7 +23,7 @@ export const drawSession = (
       var points = [];
       _(this.measurements(session)).each(function(measurement, idx){
         var value = Math.round(measurement.value);
-        var level = heat.getLevel(value);
+        var level = calculateHeatLevel(heat, value);
         if (level){
           session.markers.push(map.drawMarker(measurement, {
             title: parseInt(measurement.value, 10).toString() + suffix,
@@ -50,7 +50,7 @@ export const drawSession = (
       var level;
 
       if (sensors.anySelected() && !sensors.tmpSelected() && session.last_hour_average) {
-        level = this.calculateHeatLevel(session.last_hour_average);
+        level = calculateHeatLevel(heat, session.last_hour_average);
       } else {
         level = 0;
       }
@@ -70,7 +70,7 @@ export const drawSession = (
         latitude: session.streams[selectedSensor]["start_latitude"],
         id: session.id
       }
-      const level = heat.getLevel(session.average)
+      const level = calculateHeatLevel(heat, session.average);
       session.markers.push(map.drawMarker(lngLatObject, markerOptions, null, level));
     },
 
@@ -122,6 +122,4 @@ export const drawSession = (
   return new DrawSession();
 };
 
-function calculateHeatLevel(value) {
-  return heat.getLevel(value);
-};
+const calculateHeatLevel = (heat, value) => heat.getLevel(value);

--- a/app/assets/javascripts/code/services/google/_map.js
+++ b/app/assets/javascripts/code/services/google/_map.js
@@ -2,7 +2,6 @@ import _ from 'underscore';
 
 export const map = (
   params,
-  $cookieStore,
   $rootScope,
   digester,
   rectangles,
@@ -25,10 +24,6 @@ export const map = (
 
     get: function(){
       return this.mapObj;
-    },
-
-    getMapCookie: function(name) {
-      return $cookieStore.get(name);
     },
 
     getBounds: function(){
@@ -67,10 +62,6 @@ export const map = (
       var lat = this.mapObj.getCenter().lat();
       var lng = this.mapObj.getCenter().lng();
       var mapType = this.mapObj.getMapTypeId();
-      $cookieStore.put("vp_zoom", zoom);
-      $cookieStore.put("vp_lat", lat);
-      $cookieStore.put("vp_lng", lng);
-      $cookieStore.put("vp_mapType", mapType);
       params.update({map: {zoom: zoom, lat: lat, lng: lng, mapType: mapType}});
       digester();
     },

--- a/app/assets/javascripts/code/services/google/map.js
+++ b/app/assets/javascripts/code/services/google/map.js
@@ -2,7 +2,6 @@ import { map } from './_map';
 
 angular.module("google").factory("map", [
   "params",
-  "$cookieStore",
   "$rootScope",
   "digester",
   "rectangles",

--- a/app/assets/javascripts/tests/_map.test.js
+++ b/app/assets/javascripts/tests/_map.test.js
@@ -5,7 +5,7 @@ import { map } from '../code/services/google/_map';
 
 test('goToAddress with no address it does not decode', t => {
   const geocoder = mock('get');
-  const mapService = map(null, null, null, null, null, geocoder);
+  const mapService = map(null, null, null, null, geocoder);
 
   mapService.goToAddress();
 
@@ -16,7 +16,7 @@ test('goToAddress with no address it does not decode', t => {
 
 test('goToAddress with address it decodes', t => {
   const geocoder = mock('get');
-  const mapService = map(null, null, null, null, null, geocoder);
+  const mapService = map(null, null, null, null, geocoder);
 
   mapService.goToAddress('new york');
 
@@ -28,7 +28,7 @@ test('goToAddress with address it decodes', t => {
 test('goToAddress with unsuccessful geocoding does not call fitBounds', t => {
   const geocoder = mockGeocoder();
   const googleMaps = mockGoogleMaps({ successfulGeocoding: false })
-  const mapService = map(null, null, null, null, null, geocoder, googleMaps);
+  const mapService = map(null, null, null, null, geocoder, googleMaps);
 
   mapService.goToAddress('new york');
 
@@ -40,7 +40,7 @@ test('goToAddress with unsuccessful geocoding does not call fitBounds', t => {
 test('goToAddress with successful geocoding calls fitBounds', t => {
   const geocoder = mockGeocoder();
   const googleMaps = mockGoogleMaps({ successfulGeocoding: true })
-  const mapService = map(null, null, null, null, null, geocoder, googleMaps);
+  const mapService = map(null, null, null, null, geocoder, googleMaps);
 
   mapService.goToAddress('new york');
 
@@ -56,7 +56,7 @@ test('goToAddress when calling fitBounds removes callbacks from the map', t => {
 
   t.true(googleMaps.hasCallbacks());
 
-  const mapService = map(null, null, null, null, null, geocoder, googleMaps);
+  const mapService = map(null, null, null, null, geocoder, googleMaps);
 
   mapService.goToAddress('new york');
 
@@ -70,7 +70,7 @@ test('goToAddress re-adds callbacks from the map after calling fitBounds', t => 
   const googleMaps = mockGoogleMaps({ successfulGeocoding: true })
   googleMaps.listen('bounds_changed', () => {});
 
-  const mapService = map(null, null, null, null, null, geocoder, googleMaps);
+  const mapService = map(null, null, null, null, geocoder, googleMaps);
 
   mapService.goToAddress('new york');
 
@@ -83,7 +83,7 @@ test('goToAddress re-adds callbacks from the map after calling fitBounds', t => 
 
 test('onPanOrZoom', t => {
   const googleMaps = mockGoogleMaps();
-  const mapService = map(null, null, null, null, null, null, googleMaps);
+  const mapService = map(null, null, null, null, null, googleMaps);
 
   mapService.onPanOrZoom(() => {});
 
@@ -94,7 +94,7 @@ test('onPanOrZoom', t => {
 
 test('unregisterAll removes the onPanOrZoom callback too', t => {
   const googleMaps = mockGoogleMaps();
-  const mapService = map(null, null, null, null, null, null, googleMaps);
+  const mapService = map(null, null, null, null, null, googleMaps);
   mapService.onPanOrZoom(() => {});
 
   mapService.unregisterAll();
@@ -106,7 +106,7 @@ test('unregisterAll removes the onPanOrZoom callback too', t => {
 
 test('fitBounds calls fitBounds', t => {
   const googleMaps = mockGoogleMaps();
-  const mapService = map(null, null, null, null, null, null, googleMaps);
+  const mapService = map(null, null, null, null, null, googleMaps);
 
   mapService.fitBounds({
     north: 1,
@@ -122,7 +122,7 @@ test('fitBounds calls fitBounds', t => {
 
 test('fitBounds with coord 200 north and 200 east calls fitBounds with a specific northeast coords', t => {
   const googleMaps = mockGoogleMaps();
-  const mapService = map(null, null, null, null, null, null, googleMaps);
+  const mapService = map(null, null, null, null, null, googleMaps);
 
   mapService.fitBounds({
     north: 200,
@@ -142,7 +142,7 @@ test('fitBounds when calling fitBounds removes callbacks from the map', t => {
 
   t.true(googleMaps.hasCallbacks());
 
-  const mapService = map(null, null, null, null, null, null, googleMaps);
+  const mapService = map(null, null, null, null, null, googleMaps);
 
   mapService.fitBounds({
     north: 123,
@@ -162,7 +162,7 @@ test('fitBounds re-adds callbacks from the map after calling fitBounds', t => {
 
   t.true(googleMaps.hasCallbacks());
 
-  const mapService = map(null, null, null, null, null, null, googleMaps);
+  const mapService = map(null, null, null, null, null, googleMaps);
 
   mapService.fitBounds({
     north: 123,


### PR DESCRIPTION
* Do not use cookie to store map info  (zoom, lat, lng, map type); since the same info is stored in url it's not clear why that should also be in a cookie.
* Restore map type from url

Decided not to put under test / refactor cause it would have been too much work and not justified in this case imo