### PR TITLE
Do not reset page when session deselected

### DIFF
--- a/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
@@ -58,10 +58,10 @@ export const SessionsListCtrl = (
     sessions.fetch($scope.page);
   }, true);
 
-  $scope.$watch("params.get('map')", () => {
+  $scope.$watch("params.get('map')", ({ hasChangedProgrammatically }) => {
     console.log("watch - params.get('map')");
     if (sessions.hasSelectedSessions()) return;
-    $scope.page = 0;
+    if (!hasChangedProgrammatically) $scope.page = 0;
     sessions.fetch($scope.page);
   }, true);
 

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -1,3 +1,4 @@
+import _ from "underscore";
 
 export const drawSession = (
   sensors,
@@ -14,7 +15,6 @@ export const drawSession = (
       if(!session || !session.loaded || !sensors.anySelected()){
         return;
       }
-      this.undoDraw(session);
 
       var suffix = ' ' + sensors.anySelected().unit_symbol;
       session.markers = [];
@@ -64,12 +64,12 @@ export const drawSession = (
     drawMobileSessionStartPoint: function(session, selectedSensor) {
       this.undoDraw(session);
 
-      const markerOptions = map.defaultMarkerOptions(session);
+      const markerOptions = { title: session.title, zIndex: 100000 };
       const lngLatObject = {
         longitude: session.streams[selectedSensor]["start_longitude"],
         latitude: session.streams[selectedSensor]["start_latitude"],
         id: session.id
-      }
+      };
       const level = calculateHeatLevel(heat, session.average);
       session.markers.push(map.drawMarker(lngLatObject, markerOptions, null, level));
     },
@@ -105,7 +105,13 @@ export const drawSession = (
     },
 
     clear: function(sessions) {
-      _(sessions).each(_(this.undoDraw).bind(this));
+      sessions.forEach(this.undoDraw);
+    },
+
+    clearOtherSessions: function(sessions, selectedSession) {
+      sessions
+      .filter(session => session !== selectedSession)
+      .forEach(this.undoDraw)
     },
 
     measurementsForSensor: function(session, sensor_name){

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -17,7 +17,6 @@ export const drawSession = (
       }
 
       var suffix = ' ' + sensors.anySelected().unit_symbol;
-      session.markers = [];
       session.noteDrawings = [];
       session.lines = [];
       var points = [];

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -86,8 +86,8 @@ export const mobileSessions = (
     },
 
     selectSession: function(id) {
-      drawSession.clear(this.sessions);
       const callback = (session, allSelected) => (data) => {
+        drawSession.clearOtherSessions(this.sessions, session);
         prevMapPosition = {
           bounds: map.getBounds(),
           zoom: map.getZoom()

--- a/app/assets/javascripts/code/services/google/_map.js
+++ b/app/assets/javascripts/code/services/google/_map.js
@@ -9,6 +9,7 @@ export const map = (
   googleMaps
 ) => {
   const TIMEOUT_DELAY = process.env.NODE_ENV === 'test' ? 0 : 1000;
+  let hasChangedProgrammatically = false;
 
   var Map = function() {};
 
@@ -62,7 +63,8 @@ export const map = (
       var lat = this.mapObj.getCenter().lat();
       var lng = this.mapObj.getCenter().lng();
       var mapType = this.mapObj.getMapTypeId();
-      params.update({map: {zoom: zoom, lat: lat, lng: lng, mapType: mapType}});
+      params.update({map: {zoom: zoom, lat: lat, lng: lng, mapType: mapType, hasChangedProgrammatically}});
+      hasChangedProgrammatically = false;
       digester();
     },
 
@@ -75,6 +77,7 @@ export const map = (
         googleMaps.latLng(bounds.north, bounds.east);
       const southwest = googleMaps.latLng(bounds.south, bounds.west);
       const latLngBounds = googleMaps.latLngBounds(southwest, northeast);
+      hasChangedProgrammatically = true;
       this._fitBoundsWithoutPanOrZoomCallback(this.mapObj, latLngBounds, zoom);
     },
 
@@ -92,7 +95,8 @@ export const map = (
     },
 
     listen: function(name, callback, diffmap) {
-      return google.maps.event.addListener(diffmap || this.mapObj, name, _(callback).bind(this));
+      const cb = _(callback).bind(this);
+      return googleMaps.listen(diffmap || this.mapObj, name, cb);
     },
 
     unregisterAll: function(){

--- a/app/assets/javascripts/code/services/google/_map.js
+++ b/app/assets/javascripts/code/services/google/_map.js
@@ -186,10 +186,6 @@ export const map = (
     clearRectangles: function() {
       rectangles.clear();
     },
-
-    defaultMarkerOptions: function(session) {
-      return { title: session.title, zIndex: 0 };
-    }
   };
 
   return new Map();

--- a/app/assets/javascripts/code/services/google/google_maps.js
+++ b/app/assets/javascripts/code/services/google/google_maps.js
@@ -26,6 +26,8 @@ angular.module("google").factory("googleMaps", [
         onPanOrZoomHandle = mapObj.addListener('bounds_changed', callback);
       },
 
+      listen: (obj, name, callback) => google.maps.event.addListener(obj, name, callback),
+
       latLng: (lat, lng) => new google.maps.LatLng(lat, lng),
 
       latLngBounds: (lat, lng) => new google.maps.LatLngBounds(lat, lng)

--- a/app/assets/javascripts/tests/_draw_session.test.js
+++ b/app/assets/javascripts/tests/_draw_session.test.js
@@ -1,0 +1,38 @@
+import test from 'blue-tape';
+import { mock } from './helpers';
+import { drawSession } from '../code/services/_draw_session';
+
+test('clearOtherSessions removes all markers expect the selected one', t => {
+  const map = mock('removeMarker');
+  const selected_session = { drawed: true, markers: ["selected session marker"] };
+  const other_session = { drawed: true, markers: ["other session marker"] }
+  const sessions = [other_session, selected_session];
+  const drawSessionMock = _drawSession({ map });
+
+  drawSessionMock.clearOtherSessions(sessions, selected_session);
+
+  t.true(map.wasCalledWith("other session marker"));
+
+  t.end();
+});
+
+
+test('drawMobileSessionStartPoint calls drawMarker', t => {
+  const map = mock('drawMarker');
+  const selectedSensor = "sensorId";
+  const streams = { sensorId: {} };
+  const session = { streams: streams, markers: [] };
+  const drawSessionMock = _drawSession({map});
+
+  drawSessionMock.drawMobileSessionStartPoint(session, selectedSensor);
+
+  t.true(map.wasCalled());
+
+  t.end();
+});
+
+const _drawSession = ({ map }) => {
+  const _map = { ...map };
+  const _heat = { getLevel: () => {} };
+  return drawSession(null, _map, _heat);
+};

--- a/app/assets/javascripts/tests/_mobile_sessions.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions.test.js
@@ -341,7 +341,7 @@ const _mobileSessions = ({ sessionsDownloaderCalls = [], data, drawSession, util
   const _map = { getBounds: () => ({}), fitBounds: () => {}, getZoom: () => {}, ...map };
   const _utils = utils || {};
   const _sensors = { selectedId: () => 123, selected: () => {}, sensors: {}, ...sensors };
-  const _drawSession = { clear: () => {}, drawMobileSession: () => {}, ...drawSession };
+  const _drawSession = { clear: () => {}, clearOtherSessions: () => {}, drawMobileSession: () => {}, ...drawSession };
   const sessionsDownloader = (_, arg) => { sessionsDownloaderCalls.push(arg) };
   const _sessionsUtils = { find: () => ({}), allSelected: () => {}, onSingleSessionFetch: (x, y, callback) => callback(), ...sessionsUtils };
   const $http = { get: () => ({ success: callback => callback() }) };

--- a/app/assets/javascripts/tests/_sessions_list_ctrl.test.js
+++ b/app/assets/javascripts/tests/_sessions_list_ctrl.test.js
@@ -12,8 +12,45 @@ test('it calls onPanOrZoom', t => {
   t.end();
 });
 
-const _SessionsListCtrl = ({ map, $scope, updateCrowdMapLayer }) => {
+test('with no sessions selected when params.map changes it calls sessions.fetch', t => {
+  const callbacks = [];
+  const $scope = {
+    $watch: (str, callback) => str.includes('map') ? callbacks.push(callback) : null,
+  };
+  const sessions = {
+    hasSelectedSessions: () => false,
+    ...mock('fetch')
+  }
+  _SessionsListCtrl({ $scope, sessions });
+
+  callbacks.forEach(callback => callback({}));
+
+  t.true(sessions.wasCalled());
+
+  t.end();
+});
+
+test('with session selected when params.map changes it does not call sessions.fetch', t => {
+  const callbacks = [];
+  const $scope = {
+    $watch: (str, callback) => str.includes('map') ? callbacks.push(callback) : null,
+  };
+  const sessions = {
+    hasSelectedSessions: () => true,
+    ...mock('fetch')
+  }
+  _SessionsListCtrl({ $scope, sessions });
+
+  callbacks.forEach(callback => callback({}));
+
+  t.false(sessions.wasCalled());
+
+  t.end();
+});
+
+const _SessionsListCtrl = ({ map, $scope, updateCrowdMapLayer, sessions }) => {
   const _$scope = {
+    sessions,
     setDefaults: () => {},
     $watch: () => {},
     $on: () => {},


### PR DESCRIPTION
Problem was that in SessionsListCtrl
```
$scope.$watch("params.get('map')",
```
whenever a session is not selected and the map moves, the code 
```
$scope.page = 0;
sessions.fetch($scope.page);
```
Doing that is fine when the user moved the map. In fact, in that case we want to fetch again all sessions from the first page.

Unfortunately, that is not correct when the map is moved programmatically. In fact, in that case we want the fetch to happen but the page to stay the same. We need the fetch to happen because on mobile we need to trigger the draw of the starting points. That happens is a callback pass to the fetch. Also, this does not create perf problems because the fetch is cached (`{ cache: true }`).

This PR fixes the problem by resetting the flag only if the user moves the map (and not on a programmatic change like `fitBounds`)
```
if (!hasChangedProgrammatically) $scope.page = 0;
```