### PR TITLE
Show mobile starting point when session is selected

### DIFF
--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -1,3 +1,4 @@
+import _ from "underscore";
 
 export const drawSession = (
   sensors,
@@ -14,7 +15,6 @@ export const drawSession = (
       if(!session || !session.loaded || !sensors.anySelected()){
         return;
       }
-      this.undoDraw(session);
 
       var suffix = ' ' + sensors.anySelected().unit_symbol;
       session.markers = [];
@@ -64,12 +64,12 @@ export const drawSession = (
     drawMobileSessionStartPoint: function(session, selectedSensor) {
       this.undoDraw(session);
 
-      const markerOptions = map.defaultMarkerOptions(session);
+      const markerOptions = { title: session.title, zIndex: 100000 };
       const lngLatObject = {
         longitude: session.streams[selectedSensor]["start_longitude"],
         latitude: session.streams[selectedSensor]["start_latitude"],
         id: session.id
-      }
+      };
       const level = calculateHeatLevel(heat, session.average);
       session.markers.push(map.drawMarker(lngLatObject, markerOptions, null, level));
     },
@@ -105,7 +105,13 @@ export const drawSession = (
     },
 
     clear: function(sessions) {
-      _(sessions).each(_(this.undoDraw).bind(this));
+      sessions.forEach(this.undoDraw);
+    },
+
+    clearOtherSessions: function(sessions, selectedSession) {
+      sessions
+      .filter(session => session !== selectedSession)
+      .forEach(this.undoDraw)
     },
 
     measurementsForSensor: function(session, sensor_name){

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -86,8 +86,8 @@ export const mobileSessions = (
     },
 
     selectSession: function(id) {
-      drawSession.clear(this.sessions);
       const callback = (session, allSelected) => (data) => {
+        drawSession.clearOtherSessions(this.sessions, session);
         prevMapPosition = {
           bounds: map.getBounds(),
           zoom: map.getZoom()

--- a/app/assets/javascripts/code/services/google/_map.js
+++ b/app/assets/javascripts/code/services/google/_map.js
@@ -186,10 +186,6 @@ export const map = (
     clearRectangles: function() {
       rectangles.clear();
     },
-
-    defaultMarkerOptions: function(session) {
-      return { title: session.title, zIndex: 0 };
-    }
   };
 
   return new Map();

--- a/app/assets/javascripts/tests/_draw_session.test.js
+++ b/app/assets/javascripts/tests/_draw_session.test.js
@@ -1,0 +1,38 @@
+import test from 'blue-tape';
+import { mock } from './helpers';
+import { drawSession } from '../code/services/_draw_session';
+
+test('clearOtherSessions removes all markers expect the selected one', t => {
+  const map = mock('removeMarker');
+  const selected_session = { drawed: true, markers: ["selected session marker"] };
+  const other_session = { drawed: true, markers: ["other session marker"] }
+  const sessions = [other_session, selected_session];
+  const drawSessionMock = _drawSession({ map });
+
+  drawSessionMock.clearOtherSessions(sessions, selected_session);
+
+  t.true(map.wasCalledWith("other session marker"));
+
+  t.end();
+});
+
+
+test('drawMobileSessionStartPoint calls drawMarker', t => {
+  const map = mock('drawMarker');
+  const selectedSensor = "sensorId";
+  const streams = { sensorId: {} };
+  const session = { streams: streams, markers: [] };
+  const drawSessionMock = _drawSession({map});
+
+  drawSessionMock.drawMobileSessionStartPoint(session, selectedSensor);
+
+  t.true(map.wasCalled());
+
+  t.end();
+});
+
+const _drawSession = ({ map }) => {
+  const _map = { ...map };
+  const _heat = { getLevel: () => {} };
+  return drawSession(null, _map, _heat);
+};

--- a/app/assets/javascripts/tests/_mobile_sessions.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions.test.js
@@ -341,7 +341,7 @@ const _mobileSessions = ({ sessionsDownloaderCalls = [], data, drawSession, util
   const _map = { getBounds: () => ({}), fitBounds: () => {}, getZoom: () => {}, ...map };
   const _utils = utils || {};
   const _sensors = { selectedId: () => 123, selected: () => {}, sensors: {}, ...sensors };
-  const _drawSession = { clear: () => {}, drawMobileSession: () => {}, ...drawSession };
+  const _drawSession = { clear: () => {}, clearOtherSessions: () => {}, drawMobileSession: () => {}, ...drawSession };
   const sessionsDownloader = (_, arg) => { sessionsDownloaderCalls.push(arg) };
   const _sessionsUtils = { find: () => ({}), allSelected: () => {}, onSingleSessionFetch: (x, y, callback) => callback(), ...sessionsUtils };
   const $http = { get: () => ({ success: callback => callback() }) };


### PR DESCRIPTION
Keeps the mobile starting point when selecting a session, but remove the rest of the markers.
Makes sure that starting points are drawn on top of measurements values. But under the notes.