### PR TITLE
Don't reset markers list when selecting a session

### DIFF
--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -17,7 +17,6 @@ export const drawSession = (
       }
 
       var suffix = ' ' + sensors.anySelected().unit_symbol;
-      session.markers = [];
       session.noteDrawings = [];
       session.lines = [];
       var points = [];


### PR DESCRIPTION
This fixes a bug I noticed with mobile start points. 
Bug: When a user selects and then deselects a session the starting point is not removed. It's not visible at first cause after deselecting all markers appear again. But if a user selects a second session then the starting point from the first session is still visible.