### PR TITLE
Case insensitive sensors

### DIFF
--- a/app/assets/javascripts/code/services/_sensors.js
+++ b/app/assets/javascripts/code/services/_sensors.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 
 const buildSensorId = sensor =>
-  sensor.measurement_type + "-" + sensor.sensor_name + " (" + sensor.unit_symbol + ")";
+  sensor.measurement_type + "-" + sensor.sensor_name.toLowerCase() + " (" + sensor.unit_symbol + ")";
 
 const ALL_SENSOR = { id: "all", select_label: "All", session_count: 0, measurement_type: "all" };
 const ALL_PARAMETER = { id: "all", label: "All" };
@@ -28,6 +28,9 @@ export const sensors = (params, $http) => {
       _(data).each(function(sensor){
         sensor.id =  buildSensorId(sensor);
         sensor.label = sensor.sensor_name + " (" + sensor.unit_symbol + ")";
+
+        sensor.sensor_name = sensor.sensor_name.toLowerCase();
+
         if (sensor.label.length >= 42) {
           sensor.select_label = sensor.label.slice(0, 40) + "…";
         } else {
@@ -164,17 +167,16 @@ export const findAvailableSensorsForParameter = (sort, sensors, parameter) =>
     sort(Object.values(sensors).filter(sensor => sensor.measurement_type === parameter.id));
 
 export const sort = sensors => {
-  const ORDERS = {
-    "Particulate Matter-AirBeam2-PM2.5 (µg/m³)": 4,
-    "Particulate Matter-AirBeam2-PM1 (µg/m³)": 3,
-    "Particulate Matter-AirBeam2-PM10 (µg/m³)": 2,
-    "Particulate Matter-AirBeam-PM (µg/m³)": 1,
-    "Humidity-AirBeam2-RH (%)": 2,
-    "Humidity-AirBeam-RH (%)": 1,
-    "Temperature-AirBeam2-F (F)": 2,
-    "Temperature-AirBeam-F (F)": 1,
-    "Sound Level-Phone Microphone (dB)": 1
-  };
+  const ORDERS = {};
+  ORDERS[buildSensorId({measurement_type: "Particulate Matter", sensor_name: "AirBeam2-PM2.5", unit_symbol: "µg/m³"})] = 4;
+  ORDERS[buildSensorId({measurement_type: "Particulate Matter", sensor_name: "AirBeam2-PM1", unit_symbol: "µg/m³"})] = 3;
+  ORDERS[buildSensorId({measurement_type: "Particulate Matter", sensor_name: "AirBeam2-PM10", unit_symbol: "µg/m³"})] = 2;
+  ORDERS[buildSensorId({measurement_type: "Particulate Matter", sensor_name: "AirBeam-PM", unit_symbol: "µg/m³"})] = 1;
+  ORDERS[buildSensorId({measurement_type: "Humidity", sensor_name: "AirBeam2-RH", unit_symbol: "%"})] = 2;
+  ORDERS[buildSensorId({measurement_type: "Humidity", sensor_name: "AirBeam-RH", unit_symbol: "%"})] = 1;
+  ORDERS[buildSensorId({measurement_type: "Temperature", sensor_name: "AirBeam2-F", unit_symbol: "F"})] = 2;
+  ORDERS[buildSensorId({measurement_type: "Temperature", sensor_name: "AirBeam-F", unit_symbol: "F"})] = 1;
+  ORDERS[buildSensorId({measurement_type: "Sound Level", sensor_name: "Phone Microphone", unit_symbol: "dB"})] = 1;
 
   const compare = (sensor1, sensor2) => {
     if (ORDERS[sensor1.id] && ORDERS[sensor2.id]) {

--- a/app/assets/javascripts/code/services/_sessions_utils.js
+++ b/app/assets/javascripts/code/services/_sessions_utils.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import {keysToLowerCase} from '../utils.js';
 
 export const sessionsUtils = (
   params,
@@ -85,7 +86,7 @@ export const sessionsUtils = (
   },
 
   onSingleSessionFetch: function(session, data, callback) {
-    var streams = data.streams;
+    var streams = keysToLowerCase(data.streams);
     delete data.streams;
     _(session).extend(data);
     _(session.streams).extend(streams);

--- a/app/assets/javascripts/code/services/sessions_downloader.js
+++ b/app/assets/javascripts/code/services/sessions_downloader.js
@@ -1,3 +1,5 @@
+import {keysToLowerCase} from '../utils.js';
+
 angular.module("aircasting").factory("sessionsDownloader", ['$rootScope', '$http', '$timeout', 'orderByFilter', function ($rootScope, $http, $timeout, orderBy) {
 
   var fetch = function (url, reqData, sessions, params, refreshSessionsCallback, errorCallback) {
@@ -40,6 +42,8 @@ angular.module("aircasting").factory("sessionsDownloader", ['$rootScope', '$http
         session.timeframe = times[0].format('MM/DD/YYYY, HH:mm') +
           '-' +  times[1].format('HH:mm');
       }
+
+      session.streams = keysToLowerCase(session.streams)
 
       session.shortTypes = _(session.streams).chain().map(function(stream){
         return {name: stream.measurement_short_type, type: stream.sensor_name};

--- a/app/assets/javascripts/code/utils.js
+++ b/app/assets/javascripts/code/utils.js
@@ -1,0 +1,5 @@
+export const keysToLowerCase = (object) => {
+  const reducer = (acc, key) => ({ ...acc, [key.toLowerCase()]: object[key] });
+
+  return Object.keys(object).reduce(reducer, {});
+}

--- a/app/assets/javascripts/tests/_sensors.test.js
+++ b/app/assets/javascripts/tests/_sensors.test.js
@@ -52,10 +52,10 @@ test('sort sorts sensors by session_count descending', t => {
 });
 
 test('sort when sorting particulate matter sensors it first puts AirBeams', t => {
-  const airbeamSensor1 = { session_count: 1, id: "Particulate Matter-AirBeam2-PM2.5 (µg/m³)" };
-  const airbeamSensor2 = { session_count: 2, id: "Particulate Matter-AirBeam2-PM1 (µg/m³)" };
-  const airbeamSensor3 = { session_count: 3, id: "Particulate Matter-AirBeam2-PM10 (µg/m³)" };
-  const airbeamSensor4 = { session_count: 4, id: "Particulate Matter-AirBeam-PM (µg/m³)" };
+  const airbeamSensor1 = { session_count: 1, id: "Particulate Matter-airbeam2-pm2.5 (µg/m³)" };
+  const airbeamSensor2 = { session_count: 2, id: "Particulate Matter-airbeam2-pm1 (µg/m³)" };
+  const airbeamSensor3 = { session_count: 3, id: "Particulate Matter-airbeam2-pm10 (µg/m³)" };
+  const airbeamSensor4 = { session_count: 4, id: "Particulate Matter-airbeam-pm (µg/m³)" };
   const otherSensor = { session_count: 5 };
   const sensors = [otherSensor, airbeamSensor4, airbeamSensor3, airbeamSensor2, airbeamSensor1];
 
@@ -68,8 +68,8 @@ test('sort when sorting particulate matter sensors it first puts AirBeams', t =>
 });
 
 test('sort when sorting humidity sensors it first puts AirBeams', t => {
-  const airbeamSensor1 = { session_count: 1, id: "Humidity-AirBeam2-RH (%)" };
-  const airbeamSensor2 = { session_count: 2, id: "Humidity-AirBeam-RH (%)" };
+  const airbeamSensor1 = { session_count: 1, id: "Humidity-airbeam2-rh (%)" };
+  const airbeamSensor2 = { session_count: 2, id: "Humidity-airbeam-rh (%)" };
   const otherSensor = { session_count: 3 };
   const sensors = [otherSensor, airbeamSensor2, airbeamSensor1];
 
@@ -82,8 +82,8 @@ test('sort when sorting humidity sensors it first puts AirBeams', t => {
 });
 
 test('sort when sorting temperature sensors it first puts AirBeams', t => {
-  const airbeamSensor1 = { session_count: 1, id: "Temperature-AirBeam2-F (F)" };
-  const airbeamSensor2 = { session_count: 2, id: "Temperature-AirBeam-F (F)" };
+  const airbeamSensor1 = { session_count: 1, id: "Temperature-airbeam2-f (F)" };
+  const airbeamSensor2 = { session_count: 2, id: "Temperature-airbeam-f (F)" };
   const otherSensor = { session_count: 3 };
   const sensors = [otherSensor, airbeamSensor2, airbeamSensor1];
 
@@ -96,7 +96,7 @@ test('sort when sorting temperature sensors it first puts AirBeams', t => {
 });
 
 test('sort when sorting sound level sensors it first puts Phone Microphone', t => {
-  const phoneMicrophoneSensor = { session_count: 1, id: "Sound Level-Phone Microphone (dB)" };
+  const phoneMicrophoneSensor = { session_count: 1, id: "Sound Level-phone microphone (dB)" };
   const otherSensor = { session_count: 2 };
   const sensors = [otherSensor, phoneMicrophoneSensor];
 
@@ -128,7 +128,7 @@ test('defaultSensorIdForParameter returns hardcoded id for Particulate Matter', 
 
   const actual = defaultSensorIdForParameter(parameter, sensors);
 
-  const expected = "Particulate Matter-AirBeam2-PM2.5 (µg/m³)";
+  const expected = "Particulate Matter-airbeam2-pm2.5 (µg/m³)";
   t.deepEqual(actual, expected);
 
   t.end();
@@ -140,7 +140,7 @@ test('defaultSensorIdForParameter returns hardcoded id for Humidity', t => {
 
   const actual = defaultSensorIdForParameter(parameter, sensors);
 
-  const expected = "Humidity-AirBeam2-RH (%)";
+  const expected = "Humidity-airbeam2-rh (%)";
   t.deepEqual(actual, expected);
 
   t.end();
@@ -152,7 +152,7 @@ test('defaultSensorIdForParameter returns hardcoded id for Temperature', t => {
 
   const actual = defaultSensorIdForParameter(parameter, sensors);
 
-  const expected = "Temperature-AirBeam2-F (F)";
+  const expected = "Temperature-airbeam2-f (F)";
   t.deepEqual(actual, expected);
 
   t.end();
@@ -164,7 +164,7 @@ test('defaultSensorIdForParameter returns hardcoded id for Sound Level', t => {
 
   const actual = defaultSensorIdForParameter(parameter, sensors);
 
-  const expected = "Sound Level-Phone Microphone (dB)";
+  const expected = "Sound Level-phone microphone (dB)";
   t.deepEqual(actual, expected);
 
   t.end();
@@ -211,7 +211,7 @@ test('selected with no sensor id in the url returns the default sensor with adde
 
   const expected = {
     ...defaultSensor,
-    id: 'Particulate Matter-AirBeam2-PM2.5 (µg/m³)',
+    id: 'Particulate Matter-airbeam2-pm2.5 (µg/m³)',
     label: 'AirBeam2-PM2.5 (µg/m³)',
     select_label: 'AirBeam2-PM2.5 (µg/m³)'
   };
@@ -236,7 +236,7 @@ test('selected with all as sensor id in the url returns undefined', t => {
 
 test('selected with sensor id in the url returns the correct sensor with added id, label, select_label', t => {
   const params = {
-    get: () => ({ sensorId: "Humidity-AirBeam2-RH (%)" })
+    get: () => ({ sensorId: "Humidity-airbeam2-rh (%)" })
   };
   const service = _sensors({ params })
   const sensor = {
@@ -251,7 +251,7 @@ test('selected with sensor id in the url returns the correct sensor with added i
 
   const expected = {
     ...sensor,
-    id: 'Humidity-AirBeam2-RH (%)',
+    id: 'Humidity-airbeam2-rh (%)',
     label: 'AirBeam2-RH (%)',
     select_label: 'AirBeam2-RH (%)'
   };
@@ -275,7 +275,7 @@ test('selectedId with no sensor id in the url returns the default sensor id', t 
 
   const actual = service.selectedId();
 
-  const expected = 'Particulate Matter-AirBeam2-PM2.5 (µg/m³)';
+  const expected = 'Particulate Matter-airbeam2-pm2.5 (µg/m³)';
   t.deepEqual(actual, expected);
 
   t.end();
@@ -297,7 +297,7 @@ test('selectedId with all as sensor id in the url returns undefined', t => {
 
 test('selectedId with sensor id in the url returns the correct sensor id', t => {
   const params = {
-    get: () => ({ sensorId: "Humidity-AirBeam2-RH (%)" })
+    get: () => ({ sensorId: "Humidity-airbeam2-rh (%)" })
   };
   const service = _sensors({ params })
   const sensor = {
@@ -310,7 +310,7 @@ test('selectedId with sensor id in the url returns the correct sensor id', t => 
 
   const actual = service.selectedId();
 
-  const expected = 'Humidity-AirBeam2-RH (%)';
+  const expected = 'Humidity-airbeam2-rh (%)';
   t.deepEqual(actual, expected);
 
   t.end();

--- a/app/assets/javascripts/tests/_sessions_utils.test.js
+++ b/app/assets/javascripts/tests/_sessions_utils.test.js
@@ -2,15 +2,26 @@ import test from 'blue-tape';
 import { mock } from './helpers';
 import { sessionsUtils } from '../code/services/_sessions_utils';
 
-test('onSingleSessionFetch overwrites session.streams with data.streams and add loaded flag to session', t => {
-  const data = { streams: [1] };
-  const session = { streams: [2] };
+test('onSingleSessionFetch extends session.streams with data.streams with lower case keys', t => {
+  const data = { streams: { Key1: 1 } };
+  const session = { streams: { key2: 2 } };
   const service = _sessionsUtils({});
 
   service.onSingleSessionFetch(session, data, () => {});
 
   t.deepEqual(data, {});
-  t.deepEqual(session, { loaded: true, streams: [1] });
+  t.deepEqual(session, { loaded: true, streams: { key2: 2, key1: 1 } });
+
+  t.end();
+});
+
+test('onSingleSessionFetch adds loaded flag to session', t => {
+  const session = {};
+  const service = _sessionsUtils({});
+
+  service.onSingleSessionFetch(session, { streams: {} }, () => {});
+
+  t.deepEqual(session, { loaded: true });
 
   t.end();
 });
@@ -21,7 +32,7 @@ test('onSingleSessionFetch calls the passed callback', t => {
 
   const service = _sessionsUtils({});
 
-  service.onSingleSessionFetch({}, {}, callback);
+  service.onSingleSessionFetch({}, { streams: {} }, callback);
 
   t.true(called);
 
@@ -34,7 +45,7 @@ test('onSingleSessionFetch calls updateCrowdMapLayer with the session id', t => 
   const updateCrowdMapLayer = mock('call');
   const service = _sessionsUtils({ updateCrowdMapLayer });
 
-  service.onSingleSessionFetch(session, {}, () => {});
+  service.onSingleSessionFetch(session, { streams: {} }, () => {});
 
   t.true(updateCrowdMapLayer.wasCalledWith([sessionId]));
 

--- a/app/assets/javascripts/tests/utils.test.js
+++ b/app/assets/javascripts/tests/utils.test.js
@@ -1,0 +1,14 @@
+import test from 'blue-tape';
+import { keysToLowerCase } from '../code/utils';
+
+test('keysToLowerCase changes object keys to lower case', t => {
+  const value = 1;
+  const object = { Aa: value };
+
+  const actual = keysToLowerCase(object);
+
+  const expected = { aa: value };
+  t.deepEqual(actual, expected);
+
+  t.end();
+})


### PR DESCRIPTION
It turned out that mysql database used in this project is NOT case sensitive, while other parts of the code were using hashes assuming that the keys are case sensitive. In order to unify this, we transform all sensor names to lower case at the entry point from backend to frontend. Or as close to it as possible. We still need to keep the original capitalization in the db as it is used for names that are displayed for the users.

A side effect of this change is that the sensor names in the URL are now all lower case and the old links will misbehave. We agreed that it's not an issue right now. We will revisit this if we receive feedback from users that it is needed.