### PR TITLE
Update Sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'rails', '3.2.22.5'
 gem 'rake', '10.0.3'
 gem 'rb-gsl', '1.16.0.6'
 gem 'rubyzip', '>= 1.0.0'
-gem 'sidekiq', '< 4'
+gem 'sidekiq', '~> 4.0'
 gem 'sidekiq-unique-jobs', '3.0.12'
 gem 'sinatra', require: false
 gem 'thin', '~> 1.6', '>= 1.6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,23 +104,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    celluloid (0.17.3)
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      timers (>= 4.1.1)
-    celluloid-essentials (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-extras (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-fsm (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-pool (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-supervision (0.20.6)
-      timers (>= 4.1.1)
     chronic (0.10.2)
     churn (0.0.35)
       chronic (>= 0.2.3)
@@ -340,8 +323,6 @@ GEM
       json (~> 1.4)
     redcard (1.1.0)
     redis (3.3.5)
-    redis-namespace (1.6.0)
-      redis (>= 3.0.4)
     reek (2.2.1)
       parser (~> 2.2)
       rainbow (~> 2.0)
@@ -388,12 +369,11 @@ GEM
     sexp_processor (4.11.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    sidekiq (3.5.4)
-      celluloid (~> 0.17.2)
+    sidekiq (4.2.10)
+      concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
-      json (~> 1.0)
+      rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
-      redis-namespace (~> 1.5, >= 1.5.2)
     sidekiq-unique-jobs (3.0.12)
       sidekiq (>= 2.6)
     sinatra (1.4.6)
@@ -421,7 +401,6 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (1.4.1)
-    timers (4.2.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -497,7 +476,7 @@ DEPENDENCIES
   rubyzip (>= 1.0.0)
   sass-rails (~> 3.2.2)
   shoulda-matchers
-  sidekiq (< 4)
+  sidekiq (~> 4.0)
   sidekiq-unique-jobs (= 3.0.12)
   sinatra
   spork (~> 0.9.0)


### PR DESCRIPTION
Sidekiq is often getting slow, jobs take a few minutes. Some of the most common warnings below. They are connected with celluloid gem, which is a dependency for sidekiq 3.x.x. 
This PR upgrades sidekiq to 4.x which doesn't use celluloid as a dependency anymore.


```2019-01-14T15:23:18.837Z 26599 TID-gsla48xvo WARN: Thread TID-orv8ezzpg
2019-01-14T15:23:18.838Z 26599 TID-gsla48xvo WARN: /home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/connection_adapters/mysql2_adapter.rb:218:in `each'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/connection_adapters/mysql2_adapter.rb:218:in `to_a'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/connection_adapters/mysql2_adapter.rb:218:in `exec_query'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/connection_adapters/mysql2_adapter.rb:226:in `select'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/connection_adapters/abstract/database_statements.rb:18:in `select_all'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/connection_adapters/abstract/query_cache.rb:63:in `select_all'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/querying.rb:38:in `block in find_by_sql'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/explain.rb:41:in `logging_query_plan'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/querying.rb:37:in `find_by_sql'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/relation.rb:171:in `exec_queries'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/relation.rb:160:in `block in to_a'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/explain.rb:41:in `logging_query_plan'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/relation.rb:159:in `to_a'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/relation.rb:189:in `exec_queries'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/relation.rb:160:in `block in to_a'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/explain.rb:41:in `logging_query_plan'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/relation.rb:159:in `to_a'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/activerecord-3.2.22.5/lib/active_record/relation/delegation.rb:39:in `reduce'
/home/aircasting/application/releases/20190114141843/app/services/outliers/calculate_centroid.rb:10:in `sum_coordinates'
/home/aircasting/application/releases/20190114141843/app/services/outliers/calculate_centroid.rb:3:in `call'
/home/aircasting/application/releases/20190114141843/app/services/outliers/calculate_bounding_box.rb:27:in `call'
/home/aircasting/application/releases/20190114141843/app/repositories/streams_repository.rb:8:in `calc_bounding_box!'
/home/aircasting/application/releases/20190114141843/app/services/measurements_creator.rb:23:in `call'
/home/aircasting/application/releases/20190114141843/app/workers/async_measurements_creator.rb:6:in `perform'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/processor.rb:80:in `execute_job'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/processor.rb:56:in `block (2 levels) in process'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/chain.rb:127:in `block in invoke'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/newrelic_rpm-3.18.1.330/lib/new_relic/agent/instrumentation/sidekiq.rb:33:in `block in call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/newrelic_rpm-3.18.1.330/lib/new_relic/agent/instrumentation/controller_instrumentation.rb:363:in `perform_action_with_newrelic_trace'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/newrelic_rpm-3.18.1.330/lib/new_relic/agent/instrumentation/sidekiq.rb:29:in `call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/honeybadger-2.7.2/lib/honeybadger/plugins/sidekiq.rb:10:in `call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-unique-jobs-3.0.12/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb:17:in `call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/server/active_record.rb:6:in `call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/server/retry_jobs.rb:74:in `call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/server/logging.rb:11:in `block in call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/logging.rb:30:in `with_context'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/server/logging.rb:7:in `call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/chain.rb:132:in `call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/middleware/chain.rb:132:in `invoke'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/processor.rb:51:in `block in process'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/processor.rb:104:in `stats'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/sidekiq-3.5.4/lib/sidekiq/processor.rb:50:in `process'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `public_send'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `dispatch'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/call/async.rb:7:in `dispatch'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:50:in `block in dispatch'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:76:in `block in task'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'


2019-01-15T08:46:23.538Z 26599 TID-gsla48xvo WARN: Thread TID-oruo0sxvs
2019-01-15T08:46:23.538Z 26599 TID-gsla48xvo WARN: /home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `sleep'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `wait'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `block in check'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/timers-4.2.0/lib/timers/wait.rb:20:in `block in for'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/timers-4.2.0/lib/timers/wait.rb:19:in `loop'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/timers-4.2.0/lib/timers/wait.rb:19:in `for'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:58:in `check'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:155:in `block in run'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/timers-4.2.0/lib/timers/group.rb:73:in `wait'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:152:in `run'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:131:in `block in start'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-essentials-0.20.5/lib/celluloid/internals/thread_handle.rb:14:in `block in initialize'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/actor/system.rb:78:in `block in get_thread'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/group/spawner.rb:50:in `call'
/home/aircasting/application/shared/bundle/ruby/2.2.0/gems/celluloid-0.17.3/lib/celluloid/group/spawner.rb:50:in `block in instantiate'```