### PR TITLE
Add new measurements only when stream exists

### DIFF
--- a/app/workers/async_measurements_creator.rb
+++ b/app/workers/async_measurements_creator.rb
@@ -2,8 +2,10 @@ class AsyncMeasurementsCreator
   include Sidekiq::Worker
 
   def perform(stream_id, measurements_attributes)
-    stream = streams_repository.find(stream_id)
-    measurements_creator.call(stream, measurements_attributes)
+    stream = streams_repository.find_by_id(stream_id)
+    if stream
+      measurements_creator.call(stream, measurements_attributes)
+    end
   end
 
   private


### PR DESCRIPTION
Prevents the `ActiveRecord::RecordNotFound: Couldn't find Stream with id=1234` error. Which happens when a user deletes a mobile session before all jobs connected with that sessions are finished.