### PR TITLE
Search by uuid first

### DIFF
--- a/app/controllers/api/user_sessions_controller.rb
+++ b/app/controllers/api/user_sessions_controller.rb
@@ -30,7 +30,7 @@ class Api::UserSessionsController < Api::BaseController
   end
 
   def show
-    session = (current_user.sessions.find_by_id(params[:id]) or current_user.sessions.find_by_uuid(params[:uuid])) or raise NotFound
+    session = (current_user.sessions.find_by_uuid(params[:uuid]) or current_user.sessions.find_by_id(params[:id])) or raise NotFound
 
     stream_measurements = params[:stream_measurements]
 


### PR DESCRIPTION
Mobile app sends sessions by uuid now. However, it also sends some ids which do not correspond to the ids in the main database. Therefore we want to look up sessions by uuid. But we still need the logic that looks up sessions by id, at least until all users upgrade to the new mobile app version. 