### PR TITLE
Sidekiq two queues

### DIFF
--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -106,7 +106,7 @@ class Stream < ActiveRecord::Base
   def self.build!(data = {})
     measurements = data.delete(:measurements)
     stream = create!(data)
-    MeasurementsCreator.call(stream, measurements)
+    MeasurementsCreator.new.call(stream, measurements)
     stream
   end
 
@@ -119,7 +119,7 @@ class Stream < ActiveRecord::Base
     stream.set_bounding_box(latitude, longitude) unless stream.has_bounds?
     stream.save!
 
-    MeasurementsCreator.call(stream, measurements_attributes)
+    MeasurementsCreator.new.call(stream, measurements_attributes)
     stream
   end
 

--- a/app/services/async_measurements_creator.rb
+++ b/app/services/async_measurements_creator.rb
@@ -7,16 +7,13 @@ class AsyncMeasurementsCreator
   end
 
   def call(stream:, measurements_attributes:)
-    if measurements_attributes.size < AMOUNT_THRESHOLD
-      create_multiple_async(stream.id, measurements_attributes, :default)
-    else
-      create_multiple_async(stream.id, measurements_attributes, :slow)
-    end
+    queue = measurements_attributes.size < AMOUNT_THRESHOLD ? :default : :slow
+    create(stream.id, measurements_attributes, queue)
   end
 
   private
 
-  def create_multiple_async(stream_id, measurements_attributes, queue)
+  def create(stream_id, measurements_attributes, queue)
     measurements_attributes.each_slice(SLICE_SIZE) do |attributes|
       @measurements_creator_worker
         .set(queue: queue)

--- a/app/services/async_measurements_creator.rb
+++ b/app/services/async_measurements_creator.rb
@@ -17,7 +17,7 @@ class AsyncMeasurementsCreator
     measurements_attributes.each_slice(SLICE_SIZE) do |attributes|
       @measurements_creator_worker
         .set(queue: queue)
-        .perform_async(stream_id: stream_id, measurements_attributes: attributes)
+        .perform_async(stream_id, attributes)
     end
   end
 end

--- a/app/services/async_measurements_creator.rb
+++ b/app/services/async_measurements_creator.rb
@@ -1,0 +1,26 @@
+class AsyncMeasurementsCreator
+  SLICE_SIZE = 500
+  AMOUNT_THRESHOLD = 20_000
+
+  def initialize(measurements_creator_worker: MeasurementsCreatorWorker)
+    @measurements_creator_worker = measurements_creator_worker
+  end
+
+  def call(stream:, measurements_attributes:)
+    if measurements_attributes.size < AMOUNT_THRESHOLD
+      create_multiple_async(stream.id, measurements_attributes, :default)
+    else
+      create_multiple_async(stream.id, measurements_attributes, :slow)
+    end
+  end
+
+  private
+
+  def create_multiple_async(stream_id, measurements_attributes, queue)
+    measurements_attributes.each_slice(SLICE_SIZE) do |attributes|
+      @measurements_creator_worker
+        .set(queue: queue)
+        .perform_async(stream_id: stream_id, measurements_attributes: attributes)
+    end
+  end
+end

--- a/app/services/measurements_creator.rb
+++ b/app/services/measurements_creator.rb
@@ -3,41 +3,11 @@ class MeasurementsCreator
 
   def self.call(stream, measurements_attributes)
     if measurements_attributes.count == 1
-      new.call(stream, measurements_attributes)
+      SyncMeasurementsCreator.new.call(stream, measurements_attributes)
     else
       measurements_attributes.each_slice(SLICE_SIZE) do |measurement_attributes|
         AsyncMeasurementsCreator.perform_async(stream.id, measurement_attributes)
       end
     end
   end
-
-  def initialize(streams_repository = StreamsRepository.new)
-    @streams_repository = streams_repository
-  end
-
-  def call(stream, measurements_attributes, jid=nil)
-    Sidekiq.logger.info "processing stream #{stream.id} with #{measurements_attributes.count} measurements" if jid
-    time1 = Time.current
-    stream.build_measurements!(measurements_attributes, jid)
-    time2 = Time.current
-    Sidekiq.logger.info "build_measurements in #{(time2 - time1).round(3)}" if jid
-    stream.after_measurements_created
-    time3 = Time.current
-    Sidekiq.logger.info "after_measurements_created in #{(time3 - time2).round(3)}" if jid
-
-    return if stream.session.type == 'FixedSession'
-    streams_repository.calc_bounding_box!(stream)
-    time4 = Time.current
-    Sidekiq.logger.info "calc_bounding_box! in #{(time4 - time3).round(3)}" if jid
-    streams_repository.calc_average_value!(stream)
-    time5 = Time.current
-    Sidekiq.logger.info "calc_average_value! in #{(time5 - time4).round(3)}" if jid
-    streams_repository.add_start_coordinates!(stream)
-    time6 = Time.current
-    Sidekiq.logger.info "add_start_coordinates! in #{(time6 - time5).round(3)}" if jid
-  end
-
-  private
-
-  attr_reader :streams_repository
 end

--- a/app/services/measurements_creator.rb
+++ b/app/services/measurements_creator.rb
@@ -1,10 +1,7 @@
 class MeasurementsCreator
-  SLICE_SIZE = 500
-  AMOUNT_THRESHOLD = 20_000
-
   def initialize(
     sync_measurements_creator: SyncMeasurementsCreator.new,
-    async_measurements_creator: AsyncMeasurementsCreator
+    async_measurements_creator: AsyncMeasurementsCreator.new
   )
     @sync_measurements_creator = sync_measurements_creator
     @async_measurements_creator = async_measurements_creator
@@ -12,31 +9,9 @@ class MeasurementsCreator
 
   def call(stream, measurements_attributes)
     if measurements_attributes.one?
-      create_one_sync(stream, measurements_attributes)
-    elsif measurements_attributes.size < AMOUNT_THRESHOLD
-      create_several_async(stream.id, measurements_attributes)
+      @sync_measurements_creator.call(stream: stream, measurements_attributes: measurements_attributes)
     else
-      create_many_async(stream.id, measurements_attributes)
-    end
-  end
-
-  private
-
-  def create_one_sync(stream, measurements_attributes)
-    @sync_measurements_creator.call(stream, measurements_attributes)
-  end
-
-  def create_several_async(stream_id, measurements_attributes)
-    create_multiple_async(stream_id, measurements_attributes, :several)
-  end
-
-  def create_many_async(stream_id, measurements_attributes)
-    create_multiple_async(stream_id, measurements_attributes, :many)
-  end
-
-  def create_multiple_async(stream_id, measurements_attributes, amount)
-    measurements_attributes.each_slice(SLICE_SIZE) do |attributes|
-      @async_measurements_creator.perform_async(stream_id: stream_id, measurements_attributes: attributes, amount: amount)
+      @async_measurements_creator.call(stream: stream, measurements_attributes: measurements_attributes)
     end
   end
 end

--- a/app/services/measurements_creator.rb
+++ b/app/services/measurements_creator.rb
@@ -11,11 +11,21 @@ class MeasurementsCreator
 
   def call(stream, measurements_attributes)
     if measurements_attributes.one?
-      @sync_measurements_creator.call(stream, measurements_attributes)
+      create_one_sync(stream, measurements_attributes)
     else
-      measurements_attributes.each_slice(SLICE_SIZE) do |measurement_attributes|
-        @async_measurements_creator.perform_async(stream.id, measurement_attributes)
-      end
+      create_multiple_async(stream.id, measurements_attributes)
+    end
+  end
+
+  private
+
+  def create_one_sync(stream, measurements_attributes)
+    @sync_measurements_creator.call(stream, measurements_attributes)
+  end
+
+  def create_multiple_async(stream_id, measurements_attributes)
+    measurements_attributes.each_slice(SLICE_SIZE) do |attributes|
+      @async_measurements_creator.perform_async(stream_id: stream_id, measurements_attributes: attributes)
     end
   end
 end

--- a/app/services/measurements_creator.rb
+++ b/app/services/measurements_creator.rb
@@ -1,12 +1,20 @@
 class MeasurementsCreator
   SLICE_SIZE = 500
 
-  def self.call(stream, measurements_attributes)
-    if measurements_attributes.count == 1
-      SyncMeasurementsCreator.new.call(stream, measurements_attributes)
+  def initialize(
+    sync_measurements_creator: SyncMeasurementsCreator.new,
+    async_measurements_creator: AsyncMeasurementsCreator
+  )
+    @sync_measurements_creator = sync_measurements_creator
+    @async_measurements_creator = async_measurements_creator
+  end
+
+  def call(stream, measurements_attributes)
+    if measurements_attributes.one?
+      @sync_measurements_creator.call(stream, measurements_attributes)
     else
       measurements_attributes.each_slice(SLICE_SIZE) do |measurement_attributes|
-        AsyncMeasurementsCreator.perform_async(stream.id, measurement_attributes)
+        @async_measurements_creator.perform_async(stream.id, measurement_attributes)
       end
     end
   end

--- a/app/services/measurements_creator.rb
+++ b/app/services/measurements_creator.rb
@@ -1,5 +1,6 @@
 class MeasurementsCreator
   SLICE_SIZE = 500
+  AMOUNT_THRESHOLD = 20_000
 
   def initialize(
     sync_measurements_creator: SyncMeasurementsCreator.new,
@@ -12,8 +13,10 @@ class MeasurementsCreator
   def call(stream, measurements_attributes)
     if measurements_attributes.one?
       create_one_sync(stream, measurements_attributes)
+    elsif measurements_attributes.size < AMOUNT_THRESHOLD
+      create_several_async(stream.id, measurements_attributes)
     else
-      create_multiple_async(stream.id, measurements_attributes)
+      create_many_async(stream.id, measurements_attributes)
     end
   end
 
@@ -23,9 +26,17 @@ class MeasurementsCreator
     @sync_measurements_creator.call(stream, measurements_attributes)
   end
 
-  def create_multiple_async(stream_id, measurements_attributes)
+  def create_several_async(stream_id, measurements_attributes)
+    create_multiple_async(stream_id, measurements_attributes, :several)
+  end
+
+  def create_many_async(stream_id, measurements_attributes)
+    create_multiple_async(stream_id, measurements_attributes, :many)
+  end
+
+  def create_multiple_async(stream_id, measurements_attributes, amount)
     measurements_attributes.each_slice(SLICE_SIZE) do |attributes|
-      @async_measurements_creator.perform_async(stream_id: stream_id, measurements_attributes: attributes)
+      @async_measurements_creator.perform_async(stream_id: stream_id, measurements_attributes: attributes, amount: amount)
     end
   end
 end

--- a/app/services/sync_measurements_creator.rb
+++ b/app/services/sync_measurements_creator.rb
@@ -1,9 +1,9 @@
 class SyncMeasurementsCreator
-  def initialize(streams_repository = StreamsRepository.new)
+  def initialize(streams_repository: StreamsRepository.new)
     @streams_repository = streams_repository
   end
 
-  def call(stream, measurements_attributes, jid=nil)
+  def call(stream:, measurements_attributes:, jid: nil)
     Sidekiq.logger.info "processing stream #{stream.id} with #{measurements_attributes.count} measurements" if jid
     time1 = Time.current
     stream.build_measurements!(measurements_attributes, jid)

--- a/app/services/sync_measurements_creator.rb
+++ b/app/services/sync_measurements_creator.rb
@@ -1,0 +1,31 @@
+class SyncMeasurementsCreator
+  def initialize(streams_repository = StreamsRepository.new)
+    @streams_repository = streams_repository
+  end
+
+  def call(stream, measurements_attributes, jid=nil)
+    Sidekiq.logger.info "processing stream #{stream.id} with #{measurements_attributes.count} measurements" if jid
+    time1 = Time.current
+    stream.build_measurements!(measurements_attributes, jid)
+    time2 = Time.current
+    Sidekiq.logger.info "build_measurements in #{(time2 - time1).round(3)}" if jid
+    stream.after_measurements_created
+    time3 = Time.current
+    Sidekiq.logger.info "after_measurements_created in #{(time3 - time2).round(3)}" if jid
+
+    return if stream.session.type == 'FixedSession'
+    streams_repository.calc_bounding_box!(stream)
+    time4 = Time.current
+    Sidekiq.logger.info "calc_bounding_box! in #{(time4 - time3).round(3)}" if jid
+    streams_repository.calc_average_value!(stream)
+    time5 = Time.current
+    Sidekiq.logger.info "calc_average_value! in #{(time5 - time4).round(3)}" if jid
+    streams_repository.add_start_coordinates!(stream)
+    time6 = Time.current
+    Sidekiq.logger.info "add_start_coordinates! in #{(time6 - time5).round(3)}" if jid
+  end
+
+  private
+
+  attr_reader :streams_repository
+end

--- a/app/workers/async_measurements_creator.rb
+++ b/app/workers/async_measurements_creator.rb
@@ -1,7 +1,7 @@
 class AsyncMeasurementsCreator
   include Sidekiq::Worker
 
-  def perform(stream_id, measurements_attributes)
+  def perform(stream_id:, measurements_attributes:)
     stream = streams_repository.find(stream_id)
     measurements_creator.call(stream, measurements_attributes, self.jid)
   end

--- a/app/workers/async_measurements_creator.rb
+++ b/app/workers/async_measurements_creator.rb
@@ -1,7 +1,7 @@
 class AsyncMeasurementsCreator
   include Sidekiq::Worker
 
-  def perform(stream_id:, measurements_attributes:)
+  def perform(stream_id:, measurements_attributes:, amount:)
     stream = streams_repository.find(stream_id)
     measurements_creator.call(stream, measurements_attributes, self.jid)
   end

--- a/app/workers/async_measurements_creator.rb
+++ b/app/workers/async_measurements_creator.rb
@@ -13,6 +13,6 @@ class AsyncMeasurementsCreator
   end
 
   def measurements_creator
-    @measurements_creator ||= MeasurementsCreator.new
+    @measurements_creator ||= SyncMeasurementsCreator.new
   end
 end

--- a/app/workers/measurements_creator_worker.rb
+++ b/app/workers/measurements_creator_worker.rb
@@ -2,7 +2,7 @@ class MeasurementsCreatorWorker
   include Sidekiq::Worker
   sidekiq_options queue: :default
 
-  def perform(stream_id:, measurements_attributes:, amount:)
+  def perform(stream_id:, measurements_attributes:)
     stream = streams_repository.find(stream_id)
     measurements_creator.call(stream: stream, measurements_attributes: measurements_attributes, jid: self.jid)
   end

--- a/app/workers/measurements_creator_worker.rb
+++ b/app/workers/measurements_creator_worker.rb
@@ -2,7 +2,7 @@ class MeasurementsCreatorWorker
   include Sidekiq::Worker
   sidekiq_options queue: :default
 
-  def perform(stream_id:, measurements_attributes:)
+  def perform(stream_id, measurements_attributes)
     stream = streams_repository.find(stream_id)
     measurements_creator.call(stream: stream, measurements_attributes: measurements_attributes, jid: self.jid)
   end

--- a/app/workers/measurements_creator_worker.rb
+++ b/app/workers/measurements_creator_worker.rb
@@ -1,9 +1,10 @@
-class AsyncMeasurementsCreator
+class MeasurementsCreatorWorker
   include Sidekiq::Worker
+  sidekiq_options queue: :default
 
   def perform(stream_id:, measurements_attributes:, amount:)
     stream = streams_repository.find(stream_id)
-    measurements_creator.call(stream, measurements_attributes, self.jid)
+    measurements_creator.call(stream: stream, measurements_attributes: measurements_attributes, jid: self.jid)
   end
 
   private

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,6 @@
 :pidfile: ./tmp/pids/sidekiq.pid
 :logfile: ./log/sidekiq.log
 :concurrency: 25
+:queues:
+  - [default, 8]
+  - [slow, 2]

--- a/spec/controllers/api/realtime/measurements_controller_spec.rb
+++ b/spec/controllers/api/realtime/measurements_controller_spec.rb
@@ -86,7 +86,7 @@ describe Api::Realtime::MeasurementsController do
       end
 
       it 'creates measurement' do
-        expect(MeasurementsCreator).to receive(:call).once
+        expect_any_instance_of(MeasurementsCreator).to receive(:call).once
         subject
       end
     end

--- a/spec/services/async_measurements_creator_spec.rb
+++ b/spec/services/async_measurements_creator_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+describe AsyncMeasurementsCreator do
+  it "with 500 measurement or less it queues them in the default queue" do
+    measurements_creator_worker = class_double(MeasurementsCreatorWorker)
+    subject = AsyncMeasurementsCreator.new(measurements_creator_worker: measurements_creator_worker)
+    stream = Stream.new
+    stream_id = 1
+    stream.id = stream_id
+    measurement_attributes = [{}] * 500
+
+    expect(measurements_creator_worker)
+      .to receive(:set)
+      .with(queue: :default)
+      .once
+      .and_return(measurements_creator_worker)
+    expect(measurements_creator_worker)
+      .to receive(:perform_async)
+      .with(stream_id: stream_id, measurements_attributes: measurement_attributes)
+      .once
+
+    subject.call(stream: stream, measurements_attributes: measurement_attributes)
+  end
+
+  it "with 501 measurements it queues them in the default queue in groups of 500" do
+    measurements_creator_worker = class_double(MeasurementsCreatorWorker)
+    subject = AsyncMeasurementsCreator.new(measurements_creator_worker: measurements_creator_worker)
+    stream = Stream.new
+    stream_id = 1
+    stream.id = stream_id
+    measurement_attributes = [{}] * 501
+
+    expect(measurements_creator_worker)
+      .to receive(:set)
+      .with(queue: :default)
+      .once
+      .and_return(measurements_creator_worker)
+    expect(measurements_creator_worker)
+      .to receive(:perform_async)
+      .with(stream_id: stream_id, measurements_attributes: [{}] * 500)
+      .once
+    expect(measurements_creator_worker)
+      .to receive(:set)
+      .with(queue: :default)
+      .once
+      .and_return(measurements_creator_worker)
+    expect(measurements_creator_worker)
+      .to receive(:perform_async)
+      .with(stream_id: stream_id, measurements_attributes: [{}])
+      .once
+
+    subject.call(stream: stream, measurements_attributes: measurement_attributes)
+  end
+
+  it "with 20_000 measurements it queues them in the slow queue in groups of 500" do
+    measurements_creator_worker = class_double(MeasurementsCreatorWorker)
+    subject = AsyncMeasurementsCreator.new(measurements_creator_worker: measurements_creator_worker)
+    stream = Stream.new
+    stream_id = 1
+    stream.id = stream_id
+    measurement_attributes = [{}] * 20_000
+
+    expect(measurements_creator_worker)
+      .to receive(:set)
+      .with(queue: :slow)
+      .exactly(40)
+      .times
+      .and_return(measurements_creator_worker)
+    expect(measurements_creator_worker)
+      .to receive(:perform_async)
+      .with(stream_id: stream_id, measurements_attributes: [{}] * 500)
+      .exactly(40)
+      .times
+
+    subject.call(stream: stream, measurements_attributes: measurement_attributes)
+  end
+end

--- a/spec/services/async_measurements_creator_spec.rb
+++ b/spec/services/async_measurements_creator_spec.rb
@@ -16,7 +16,7 @@ describe AsyncMeasurementsCreator do
       .and_return(measurements_creator_worker)
     expect(measurements_creator_worker)
       .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: measurement_attributes)
+      .with(stream_id, measurement_attributes)
       .once
 
     subject.call(stream: stream, measurements_attributes: measurement_attributes)
@@ -37,7 +37,7 @@ describe AsyncMeasurementsCreator do
       .and_return(measurements_creator_worker)
     expect(measurements_creator_worker)
       .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: [{}] * 500)
+      .with(stream_id, measurement_attributes)
       .once
     expect(measurements_creator_worker)
       .to receive(:set)
@@ -46,7 +46,7 @@ describe AsyncMeasurementsCreator do
       .and_return(measurements_creator_worker)
     expect(measurements_creator_worker)
       .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: [{}])
+      .with(stream_id, measurement_attributes)
       .once
 
     subject.call(stream: stream, measurements_attributes: measurement_attributes)
@@ -68,7 +68,7 @@ describe AsyncMeasurementsCreator do
       .and_return(measurements_creator_worker)
     expect(measurements_creator_worker)
       .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: [{}] * 500)
+      .with(stream_id, measurement_attributes)
       .exactly(40)
       .times
 

--- a/spec/services/async_measurements_creator_spec.rb
+++ b/spec/services/async_measurements_creator_spec.rb
@@ -37,7 +37,7 @@ describe AsyncMeasurementsCreator do
       .and_return(measurements_creator_worker)
     expect(measurements_creator_worker)
       .to receive(:perform_async)
-      .with(stream_id, measurement_attributes)
+      .with(stream_id, [{}] * 500)
       .once
     expect(measurements_creator_worker)
       .to receive(:set)
@@ -46,7 +46,7 @@ describe AsyncMeasurementsCreator do
       .and_return(measurements_creator_worker)
     expect(measurements_creator_worker)
       .to receive(:perform_async)
-      .with(stream_id, measurement_attributes)
+      .with(stream_id, [{}])
       .once
 
     subject.call(stream: stream, measurements_attributes: measurement_attributes)
@@ -68,7 +68,7 @@ describe AsyncMeasurementsCreator do
       .and_return(measurements_creator_worker)
     expect(measurements_creator_worker)
       .to receive(:perform_async)
-      .with(stream_id, measurement_attributes)
+      .with(stream_id, [{}] * 500)
       .exactly(40)
       .times
 

--- a/spec/services/measurements_creator_spec.rb
+++ b/spec/services/measurements_creator_spec.rb
@@ -20,7 +20,10 @@ describe MeasurementsCreator do
     stream.id = stream_id
     measurement_attributes = [{}] * 2
 
-    expect(async_measurements_creator).to receive(:perform_async).with(stream_id, measurement_attributes).once
+    expect(async_measurements_creator)
+      .to receive(:perform_async)
+      .with(stream_id: stream_id, measurements_attributes: measurement_attributes)
+      .once
 
     subject.call(stream, measurement_attributes)
 	end
@@ -33,8 +36,14 @@ describe MeasurementsCreator do
     stream.id = stream_id
     measurement_attributes = [{}] * 501
 
-    expect(async_measurements_creator).to receive(:perform_async).with(stream_id, [{}] * 500).once
-    expect(async_measurements_creator).to receive(:perform_async).with(stream_id, [{}]).once
+    expect(async_measurements_creator)
+      .to receive(:perform_async)
+      .with(stream_id: stream_id, measurements_attributes: [{}] * 500)
+      .once
+    expect(async_measurements_creator)
+      .to receive(:perform_async)
+      .with(stream_id: stream_id, measurements_attributes: [{}])
+      .once
 
     subject.call(stream, measurement_attributes)
 	end

--- a/spec/services/measurements_creator_spec.rb
+++ b/spec/services/measurements_creator_spec.rb
@@ -12,7 +12,7 @@ describe MeasurementsCreator do
     subject.call(stream, measurement_attributes)
 	end
 
-  it "with more than 1 measurement it delegates to async_measurements_creator" do
+  it "with more than 1 measurement it delegates to async_measurements_creator and labeling them as several" do
     async_measurements_creator = class_double(AsyncMeasurementsCreator)
     subject = MeasurementsCreator.new(async_measurements_creator: async_measurements_creator)
     stream_id = 1
@@ -22,13 +22,13 @@ describe MeasurementsCreator do
 
     expect(async_measurements_creator)
       .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: measurement_attributes)
+      .with(stream_id: stream_id, measurements_attributes: measurement_attributes, amount: :several)
       .once
 
     subject.call(stream, measurement_attributes)
 	end
 
-  it "with 501 measurements it delegates to async_measurements_creator by batching in groups of 500" do
+  it "with 501 measurements it delegates to async_measurements_creator by batching in groups of 500 and labeling them as several" do
     async_measurements_creator = class_double(AsyncMeasurementsCreator)
     subject = MeasurementsCreator.new(async_measurements_creator: async_measurements_creator)
     stream_id = 1
@@ -38,12 +38,29 @@ describe MeasurementsCreator do
 
     expect(async_measurements_creator)
       .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: [{}] * 500)
+      .with(stream_id: stream_id, measurements_attributes: [{}] * 500, amount: :several)
       .once
     expect(async_measurements_creator)
       .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: [{}])
+      .with(stream_id: stream_id, measurements_attributes: [{}], amount: :several)
       .once
+
+    subject.call(stream, measurement_attributes)
+	end
+
+  it "with 20_000 measurements it delegates to async_measurements_creator by batching in groups of 500 and labeling them as many" do
+    async_measurements_creator = class_double(AsyncMeasurementsCreator)
+    subject = MeasurementsCreator.new(async_measurements_creator: async_measurements_creator)
+    stream_id = 1
+    stream = Stream.new
+    stream.id = stream_id
+    measurement_attributes = [{}] * 20_000
+
+    expect(async_measurements_creator)
+      .to receive(:perform_async)
+      .with(stream_id: stream_id, measurements_attributes: [{}] * 500, amount: :many)
+      .exactly(40)
+      .times
 
     subject.call(stream, measurement_attributes)
 	end

--- a/spec/services/measurements_creator_spec.rb
+++ b/spec/services/measurements_creator_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe MeasurementsCreator do
+  it "with 1 measurement it delegates to sync_measurements_creator" do
+    sync_measurements_creator = instance_double(SyncMeasurementsCreator)
+    subject = MeasurementsCreator.new(sync_measurements_creator: sync_measurements_creator)
+    stream = Stream.new
+    measurement_attributes = [{}]
+
+    expect(sync_measurements_creator).to receive(:call).with(stream, measurement_attributes)
+
+    subject.call(stream, measurement_attributes)
+	end
+
+  it "with more than 1 measurement it delegates to async_measurements_creator" do
+    async_measurements_creator = class_double(AsyncMeasurementsCreator)
+    subject = MeasurementsCreator.new(async_measurements_creator: async_measurements_creator)
+    stream_id = 1
+    stream = Stream.new
+    stream.id = stream_id
+    measurement_attributes = [{}] * 2
+
+    expect(async_measurements_creator).to receive(:perform_async).with(stream_id, measurement_attributes).once
+
+    subject.call(stream, measurement_attributes)
+	end
+
+  it "with 501 measurements it delegates to async_measurements_creator by batching in groups of 500" do
+    async_measurements_creator = class_double(AsyncMeasurementsCreator)
+    subject = MeasurementsCreator.new(async_measurements_creator: async_measurements_creator)
+    stream_id = 1
+    stream = Stream.new
+    stream.id = stream_id
+    measurement_attributes = [{}] * 501
+
+    expect(async_measurements_creator).to receive(:perform_async).with(stream_id, [{}] * 500).once
+    expect(async_measurements_creator).to receive(:perform_async).with(stream_id, [{}]).once
+
+    subject.call(stream, measurement_attributes)
+	end
+end

--- a/spec/services/measurements_creator_spec.rb
+++ b/spec/services/measurements_creator_spec.rb
@@ -7,60 +7,23 @@ describe MeasurementsCreator do
     stream = Stream.new
     measurement_attributes = [{}]
 
-    expect(sync_measurements_creator).to receive(:call).with(stream, measurement_attributes)
+    expect(sync_measurements_creator)
+      .to receive(:call)
+      .with(stream: stream, measurements_attributes: measurement_attributes)
 
     subject.call(stream, measurement_attributes)
 	end
 
-  it "with more than 1 measurement it delegates to async_measurements_creator and labeling them as several" do
-    async_measurements_creator = class_double(AsyncMeasurementsCreator)
+  it "with more than 1 measurement it delegates to async_measurements_creator" do
+    async_measurements_creator = instance_double(AsyncMeasurementsCreator)
     subject = MeasurementsCreator.new(async_measurements_creator: async_measurements_creator)
-    stream_id = 1
     stream = Stream.new
-    stream.id = stream_id
     measurement_attributes = [{}] * 2
 
     expect(async_measurements_creator)
-      .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: measurement_attributes, amount: :several)
+      .to receive(:call)
+      .with(stream: stream, measurements_attributes: measurement_attributes)
       .once
-
-    subject.call(stream, measurement_attributes)
-	end
-
-  it "with 501 measurements it delegates to async_measurements_creator by batching in groups of 500 and labeling them as several" do
-    async_measurements_creator = class_double(AsyncMeasurementsCreator)
-    subject = MeasurementsCreator.new(async_measurements_creator: async_measurements_creator)
-    stream_id = 1
-    stream = Stream.new
-    stream.id = stream_id
-    measurement_attributes = [{}] * 501
-
-    expect(async_measurements_creator)
-      .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: [{}] * 500, amount: :several)
-      .once
-    expect(async_measurements_creator)
-      .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: [{}], amount: :several)
-      .once
-
-    subject.call(stream, measurement_attributes)
-	end
-
-  it "with 20_000 measurements it delegates to async_measurements_creator by batching in groups of 500 and labeling them as many" do
-    async_measurements_creator = class_double(AsyncMeasurementsCreator)
-    subject = MeasurementsCreator.new(async_measurements_creator: async_measurements_creator)
-    stream_id = 1
-    stream = Stream.new
-    stream.id = stream_id
-    measurement_attributes = [{}] * 20_000
-
-    expect(async_measurements_creator)
-      .to receive(:perform_async)
-      .with(stream_id: stream_id, measurements_attributes: [{}] * 500, amount: :many)
-      .exactly(40)
-      .times
 
     subject.call(stream, measurement_attributes)
 	end


### PR DESCRIPTION
* refactor and added tests coverage (previously there were no tests)
* use 2 queues instead of 1 in Sidekiq: streams with 20_000 measurements or more are pushed in the `slow` queue, streams with less are pushed in the default queue

I've left the lines adding info in the logs. I guess we will need them for some more time. At least until we really fix the problem with the slowness