### PR TITLE
New markers refreshing and reloading

### DIFF
--- a/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
@@ -91,14 +91,16 @@ export const MobileSessionsMapCtrl = (
   $scope.$watch("params.get('data').heat", function(newValue, oldValue) {
     console.log("watch - params.get('data').heat - ", newValue, " - ", oldValue);
     if (newValue === oldValue) return;
-    if (mobileSessions.noOfSelectedSessions() !== 0) {
-      sessionsUtils.updateCrowdMapLayer($scope.params.get('selectedSessionIds'))
-      return;
-    };
 
     if (storage.isCrowdMapLayerOn()) {
-      mobileSessions.onHeatLevelChangeWithCrowdMapLayerOn();
-    } else {
+      sessionsUtils.updateCrowdMapLayer($scope.params.get('selectedSessionIds'));
+    }
+
+    if (mobileSessions.noOfSelectedSessions() === 1) {
+      mobileSessions.redrawSelectedSession($scope.params.get('selectedSessionIds')[0]);
+    };
+
+    if (mobileSessions.noOfSelectedSessions() === 0) {
       $scope.sessions.drawSessionsInLocation();
     };
   }, true);

--- a/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
@@ -98,10 +98,6 @@ export const SessionsListCtrl = (
     $scope.sessionsForList = newSessions;
   }, true);
 
-  $scope.sessionRedrawCondition = function() {
-    return {id: params.get('tmp').selectedSensorId, heat: params.get('data').heat };
-  };
-
   $scope.$on('markerSelected', function(event, data){
     $scope.toggleSession(data.session_id, true);
     $scope.$apply();

--- a/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_sessions_list_ctrl.js
@@ -102,14 +102,6 @@ export const SessionsListCtrl = (
     return {id: params.get('tmp').selectedSensorId, heat: params.get('data').heat };
   };
 
-  $scope.$watch("sessionRedrawCondition()", function(newValue) {
-    console.log("watch - sessionRedrawCondition()");
-    if(singleSession.isFixed() || (!newValue.id && !newValue.heat)){
-      return;
-    }
-    drawSession.redraw(sessions.allSelected());
-  }, true);
-
   $scope.$on('markerSelected', function(event, data){
     $scope.toggleSession(data.session_id, true);
     $scope.$apply();

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -11,12 +11,12 @@ export const drawSession = (
   };
 
   DrawSession.prototype = {
-    drawMobileSession: function(session, drawSessionStartingMakrer) {
+    drawMobileSession: function(session, drawSessionStartingMarker) {
       if(!session || !session.loaded || !sensors.anySelected()){
         return;
       }
 
-      drawSessionStartingMakrer(session, sensors.selectedSensorName());
+      drawSessionStartingMarker(session, sensors.selectedSensorName());
 
       var suffix = ' ' + sensors.anySelected().unit_symbol;
       var points = [];

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -53,15 +53,6 @@ export const drawSession = (
       }
     },
 
-    redraw: function(sessions) {
-      this.clear(sessions);
-      _(sessions).each(function(session) {
-        if (session.type !== 'MobileSession') return;
-
-        _(this.drawMobileSession(session));
-      }.bind(this));
-    },
-
     clear: function(sessions) {
       _(sessions).each(_(this.undoDraw).bind(this));
     },

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -11,10 +11,12 @@ export const drawSession = (
   };
 
   DrawSession.prototype = {
-    drawMobileSession: function(session) {
+    drawMobileSession: function(session, drawSessionStartingMakrer) {
       if(!session || !session.loaded || !sensors.anySelected()){
         return;
       }
+
+      drawSessionStartingMakrer(session, sensors.selectedSensorName());
 
       var suffix = ' ' + sensors.anySelected().unit_symbol;
       var points = [];
@@ -55,12 +57,6 @@ export const drawSession = (
 
     clear: function(sessions) {
       _(sessions).each(_(this.undoDraw).bind(this));
-    },
-
-    clearOtherSessions: function(sessions, selectedSession) {
-      sessions
-      .filter(session => session !== selectedSession)
-      .forEach(this.undoDraw)
     },
 
     measurementsForSensor: function(session, sensor_name){

--- a/app/assets/javascripts/code/services/_draw_session.js
+++ b/app/assets/javascripts/code/services/_draw_session.js
@@ -30,14 +30,9 @@ export const drawSession = (
         session.noteDrawings.push(note.drawNote(noteItem, idx));
       });
       session.lines.push(map.drawLine(points));
-
-      session.drawed = true;
     },
 
     undoDraw: function(session, mapPosition) {
-      if(!session.drawed){
-        return;
-      }
       (session.markers || []).forEach(function(marker){
         map.removeMarker(marker);
       });
@@ -53,7 +48,6 @@ export const drawSession = (
       });
       session.noteDrawings = [];
 
-      session.drawed = false;
       if(mapPosition){
         map.fitBounds(mapPosition.bounds, mapPosition.zoom);
       }

--- a/app/assets/javascripts/code/services/_fixed_sessions.js
+++ b/app/assets/javascripts/code/services/_fixed_sessions.js
@@ -144,7 +144,6 @@ export const fixedSessions = (
         });
       session.markers.push(marker);
       map.markers.push(marker);
-      session.drawed = true;
     },
 
     drawDefaultMarkers: function(session) {
@@ -162,8 +161,6 @@ export const fixedSessions = (
         });
       session.markers.push(customMarker);
       map.markers.push(customMarker);
-
-      session.drawed = true;
     },
 
     _fetch: function(page) {

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -77,11 +77,6 @@ export const mobileSessions = (
       sessionsUtils.updateCrowdMapLayer(this.sessionIds());
     },
 
-    onHeatLevelChangeWithCrowdMapLayerOn: function() {
-      sessionsUtils.updateCrowdMapLayer(this.sessionIds());
-    },
-
-
     deselectSession: function(id) {
       const session = this.find(id);
       if (!session) return;
@@ -115,6 +110,15 @@ export const mobileSessions = (
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       }
       this._selectSession(id, callback);
+    },
+
+    redrawSelectedSession: function(id) {
+      const session = this.find(id);
+      if (!session) return;
+
+      const drawSessionStartingMakrer = (session, sensorName) => this.drawSessionWithLabel(session, sensorName);
+
+      drawSession.drawMobileSession(session, drawSessionStartingMakrer);
     },
 
     drawSessionsInLocation: function() {

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -143,7 +143,7 @@ export const mobileSessions = (
       session.markers = [];
 
       const content = Session.averageValueAndUnit(session, selectedSensor);
-      let heatLevel = heat.levelName(Session.average(session));
+      let heatLevel = heat.levelName(Session.average(session, selectedSensor));
       const latLng = Session.startingLatLng(session, selectedSensor);
       const callback = (id) => () => $rootScope.$broadcast('markerSelected', {session_id: id});
 
@@ -163,7 +163,7 @@ export const mobileSessions = (
       session.markers = [];
 
       const content = Session.averageValueAndUnit(session, selectedSensor);
-      let heatLevel = heat.levelName(Session.average(session));
+      let heatLevel = heat.levelName(Session.average(session, selectedSensor));
       const latLng = Session.startingLatLng(session, selectedSensor);
       const callback = (id) => () => $rootScope.$broadcast('markerSelected', {session_id: id});
 

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -93,8 +93,8 @@ export const mobileSessions = (
           bounds: map.getBounds(),
           zoom: map.getZoom()
         };
-        const drawSessionStartingMakrer = (session, sensorName) => this.drawSessionWithLabel(session, sensorName);
-        const draw = () => drawSession.drawMobileSession(session, drawSessionStartingMakrer);
+        const drawSessionStartingMarker = (session, sensorName) => this.drawSessionWithLabel(session, sensorName);
+        const draw = () => drawSession.drawMobileSession(session, drawSessionStartingMarker);
         map.fitBounds(boundsCalculator(allSelected));
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       }
@@ -105,8 +105,8 @@ export const mobileSessions = (
       // this is called when refreshing a page with selected session
       drawSession.clear(this.sessions);
       const callback = (session, allSelected) => (data) => {
-        const drawSessionStartingMakrer = (session, sensorName) => this.drawSessionWithLabel(session, sensorName);
-        const draw = () => drawSession.drawMobileSession(session, drawSessionStartingMakrer);
+        const drawSessionStartingMarker = (session, sensorName) => this.drawSessionWithLabel(session, sensorName);
+        const draw = () => drawSession.drawMobileSession(session, drawSessionStartingMarker);
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       }
       this._selectSession(id, callback);
@@ -116,9 +116,9 @@ export const mobileSessions = (
       const session = this.find(id);
       if (!session) return;
 
-      const drawSessionStartingMakrer = (session, sensorName) => this.drawSessionWithLabel(session, sensorName);
+      const drawSessionStartingMarker = (session, sensorName) => this.drawSessionWithLabel(session, sensorName);
 
-      drawSession.drawMobileSession(session, drawSessionStartingMakrer);
+      drawSession.drawMobileSession(session, drawSessionStartingMarker);
     },
 
     drawSessionsInLocation: function() {
@@ -148,7 +148,7 @@ export const mobileSessions = (
       drawSession.undoDraw(session);
       session.markers = [];
 
-      let heatLevel = heat.levelName(Session.average(session, selectedSensor));
+      const heatLevel = heat.levelName(Session.average(session, selectedSensor));
       const latLng = Session.startingLatLng(session, selectedSensor);
       const callback = (id) => () => $rootScope.$broadcast('markerSelected', {session_id: id});
 
@@ -166,7 +166,7 @@ export const mobileSessions = (
       session.markers = [];
 
       const content = Session.averageValueAndUnit(session, selectedSensor);
-      let heatLevel = heat.levelName(Session.average(session, selectedSensor));
+      const heatLevel = heat.levelName(Session.average(session, selectedSensor));
       const latLng = Session.startingLatLng(session, selectedSensor);
       const callback = (id) => () => $rootScope.$broadcast('markerSelected', {session_id: id});
 

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -156,8 +156,6 @@ export const mobileSessions = (
         });
       session.markers.push(marker);
       map.markers.push(marker);
-
-      session.drawed = true;
     },
 
     drawSessionWithLabel: function(session, selectedSensor) {
@@ -178,8 +176,6 @@ export const mobileSessions = (
         });
       session.markers.push(marker);
       map.markers.push(marker);
-
-      session.drawed = true;
     },
 
     _selectSession: function(id, callback) {

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -93,12 +93,13 @@ export const mobileSessions = (
 
     selectSession: function(id) {
       const callback = (session, allSelected) => (data) => {
-        drawSession.clearOtherSessions(this.sessions, session);
+        drawSession.clear(this.sessions);
         prevMapPosition = {
           bounds: map.getBounds(),
           zoom: map.getZoom()
         };
-        const draw = () => drawSession.drawMobileSession(session);
+        const drawSessionStartingMakrer = (session, sensorName) => this.drawSessionWithLabel(session, sensorName);
+        const draw = () => drawSession.drawMobileSession(session, drawSessionStartingMakrer);
         map.fitBounds(boundsCalculator(allSelected));
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       }
@@ -106,10 +107,11 @@ export const mobileSessions = (
     },
 
     reSelectSession: function(id) {
-      // I think this is never used since we blocked the button to select all sessions
+      // this is called when refreshing a page with selected session
       drawSession.clear(this.sessions);
       const callback = (session, allSelected) => (data) => {
-        const draw = () => drawSession.drawMobileSession(session);
+        const drawSessionStartingMakrer = (session, sensorName) => this.drawSessionWithLabel(session, sensorName);
+        const draw = () => drawSession.drawMobileSession(session, drawSessionStartingMakrer);
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       }
       this._selectSession(id, callback);

--- a/app/assets/javascripts/code/services/_mobile_sessions.js
+++ b/app/assets/javascripts/code/services/_mobile_sessions.js
@@ -148,20 +148,17 @@ export const mobileSessions = (
       drawSession.undoDraw(session);
       session.markers = [];
 
-      const content = Session.averageValueAndUnit(session, selectedSensor);
       let heatLevel = heat.levelName(Session.average(session, selectedSensor));
       const latLng = Session.startingLatLng(session, selectedSensor);
       const callback = (id) => () => $rootScope.$broadcast('markerSelected', {session_id: id});
 
       const marker = map.drawCustomMarker({
           latLng: latLng,
-          content: content,
           colorClass: heatLevel,
           callback: callback(Session.id(session)),
           type: 'marker'
         });
       session.markers.push(marker);
-      map.markers.push(marker);
     },
 
     drawSessionWithLabel: function(session, selectedSensor) {
@@ -181,7 +178,6 @@ export const mobileSessions = (
           type: 'data-marker'
         });
       session.markers.push(marker);
-      map.markers.push(marker);
     },
 
     _selectSession: function(id, callback) {

--- a/app/assets/javascripts/code/values/session.js
+++ b/app/assets/javascripts/code/values/session.js
@@ -10,11 +10,11 @@ export const formatSessionForList = session => ({
   shortTypes: session.shortTypes
 });
 
-export const average = session => session.average;
+export const average = (session, selectedSensor) => session.streams[selectedSensor].average_value;
 
 export const lastHourAverage = session => session.last_hour_average;
 
-export const averageValueAndUnit = (session, selectedSensor) => roundedAverage(session) + " " + selectedSensorUnit(session, selectedSensor);
+export const averageValueAndUnit = (session, selectedSensor) => roundedAverage(session, selectedSensor) + " " + selectedSensorUnit(session, selectedSensor);
 
 export const lastHourAverageValueAndUnit = (session, selectedSensor) => lastHourRoundedAverage(session) + " " + selectedSensorUnit(session, selectedSensor);
 
@@ -32,7 +32,7 @@ const startingLat = (session, selectedSensor) => session.streams[selectedSensor]
 
 const startingLng = (session, selectedSensor) => session.streams[selectedSensor].start_longitude;
 
-const roundedAverage = session => Math.round(average(session));
+const roundedAverage = (session, selectedSensor) => Math.round(average(session, selectedSensor));
 
 const lastHourRoundedAverage = session => Math.round(lastHourAverage(session));
 

--- a/app/assets/javascripts/tests/_draw_session.test.js
+++ b/app/assets/javascripts/tests/_draw_session.test.js
@@ -4,8 +4,8 @@ import { drawSession } from '../code/services/_draw_session';
 
 test('clearOtherSessions removes all markers expect the selected one', t => {
   const map = mock('removeMarker');
-  const selected_session = { drawed: true, markers: ["selected session marker"] };
-  const other_session = { drawed: true, markers: ["other session marker"] }
+  const selected_session = { markers: ["selected session marker"] };
+  const other_session = { markers: ["other session marker"] }
   const sessions = [other_session, selected_session];
   const drawSessionStub = _drawSession({ map });
 
@@ -23,14 +23,13 @@ test('drawMobileSession draws a session when session is loaded and sensor is sel
   drawSessionStub.drawMobileSession(loadedSession);
 
   t.true(map.wasCalled());
-  t.true(loadedSession.drawed);
 
   t.end();
 });
 
 test('undoDraw removes all session elements from the map', t => {
   const map = mock('removeMarker');
-  const session = { drawed: true, markers: [1], lines: [1], noteDrawings: [1] }
+  const session = { markers: [1], lines: [1], noteDrawings: [1] }
   const drawSessionStub = _drawSession({ map });
 
   drawSessionStub.undoDraw(session)
@@ -39,7 +38,6 @@ test('undoDraw removes all session elements from the map', t => {
   t.deepEqual(session.markers, [])
   t.deepEqual(session.lines , [])
   t.deepEqual(session.noteDrawings, [])
-  t.false(session.drawed)
 
   t.end();
 });

--- a/app/assets/javascripts/tests/_draw_session.test.js
+++ b/app/assets/javascripts/tests/_draw_session.test.js
@@ -5,9 +5,8 @@ import { drawSession } from '../code/services/_draw_session';
 test('drawMobileSession draws a session when session is loaded and sensor is selected', t => {
   const map = mock('drawMarker');
   const drawSessionStub = _drawSession({ map, sensors: selectedSensor });
-  const callback = () => {};
 
-  drawSessionStub.drawMobileSession(loadedSession, callback);
+  drawSessionStub.drawMobileSession(loadedSession, () => {});
 
   t.true(map.wasCalled());
 

--- a/app/assets/javascripts/tests/_draw_session.test.js
+++ b/app/assets/javascripts/tests/_draw_session.test.js
@@ -2,25 +2,12 @@ import test from 'blue-tape';
 import { mock } from './helpers';
 import { drawSession } from '../code/services/_draw_session';
 
-test('clearOtherSessions removes all markers expect the selected one', t => {
-  const map = mock('removeMarker');
-  const selected_session = { markers: ["selected session marker"] };
-  const other_session = { markers: ["other session marker"] }
-  const sessions = [other_session, selected_session];
-  const drawSessionStub = _drawSession({ map });
-
-  drawSessionStub.clearOtherSessions(sessions, selected_session);
-
-  t.true(map.wasCalledWith("other session marker"));
-
-  t.end();
-});
-
 test('drawMobileSession draws a session when session is loaded and sensor is selected', t => {
   const map = mock('drawMarker');
   const drawSessionStub = _drawSession({ map, sensors: selectedSensor });
+  const callback = () => {};
 
-  drawSessionStub.drawMobileSession(loadedSession);
+  drawSessionStub.drawMobileSession(loadedSession, callback);
 
   t.true(map.wasCalled());
 
@@ -54,6 +41,6 @@ const loadedSession = {
 const _drawSession = ({ map, sensors, heat }) => {
   const _map = { drawMarker: () => ({}), drawLine: () => ({}), ...map };
   const _heat = { getLevel: () => {}, outsideOfScope: () => false, ...heat };
-  const _sensors = { ...sensors };
+  const _sensors = { selectedSensorName: () => "sensorName", ...sensors };
   return drawSession(_sensors, _map, _heat);
 };

--- a/app/assets/javascripts/tests/_mobile_sessions.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions.test.js
@@ -165,6 +165,32 @@ test('selectSession after successfully fetching calls drawSession.drawMobileSess
   t.end();
 });
 
+test('selectSession after successfully fetching undraws all sessions', t => {
+  const drawSession = mock('clear');
+  const sessions = []
+  const mobileSessionsService = _mobileSessions({ drawSession, sensors: { sensors: { 123: { sensor_name: 'sensor_name' } } } });
+  mobileSessionsService.sessions = sessions
+
+  mobileSessionsService.selectSession(1);
+
+  t.true(drawSession.wasCalledWith(sessions));
+
+  t.end();
+});
+
+test('selectSession after successfully fetching calls drawSession.drawMobileSession with selected session', t => {
+  const drawSession = mock('drawMobileSession');
+  const session = { id: 1 };
+  const sessionsUtils = { find: () => session }
+  const mobileSessionsService = _mobileSessions({ drawSession, sensors: { sensors: { 123: { sensor_name: 'sensor_name' } } }, sessionsUtils });
+
+  mobileSessionsService.selectSession(1);
+
+  t.true(drawSession.wasCalledWith(session));
+
+  t.end();
+});
+
 test('selectSession after successfully fetching calls map.fitBounds', t => {
   const map = mock('fitBounds');
   const mobileSessionsService = _mobileSessions({ map, sensors: { sensors: { 123: { sensor_name: 'sensor_name' } } } });
@@ -368,7 +394,7 @@ const _mobileSessions = ({ sessionsDownloaderCalls = [], data, drawSession, util
   const _map = { getBounds: () => ({}), fitBounds: () => {}, getZoom: () => {}, markers: [], ...map };
   const _utils = utils || {};
   const _sensors = { selectedId: () => 123, selected: () => {}, sensors: {}, ...sensors };
-  const _drawSession = { clear: () => {}, clearOtherSessions: () => {}, drawMobileSession: () => {}, undoDraw: () => {}, ...drawSession };
+  const _drawSession = { clear: () => {}, drawMobileSession: () => {}, undoDraw: () => {}, ...drawSession };
   const sessionsDownloader = (_, arg) => { sessionsDownloaderCalls.push(arg) };
   const _sessionsUtils = { find: () => ({}), allSelected: () => {}, onSingleSessionFetch: (x, y, callback) => callback(), ...sessionsUtils };
   const $http = { get: () => ({ success: callback => callback() }) };

--- a/app/assets/javascripts/tests/_mobile_sessions.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions.test.js
@@ -299,7 +299,7 @@ test('hasSelectedSessions with selected session returns true', t => {
 
 test('when sensor is selected drawSessionsInLocation calls map.drawCustomMarker to draw marker with label', t => {
   const map = mock('drawCustomMarker');
-  const session = { drawed: false, streams: { sensorName: { unit_symbol: "unit" }}};
+  const session = { streams: { sensorName: { unit_symbol: "unit" }}};
   const sessions = [ session ];
   const sessionsUtils = { get: () => sessions };
   const sensors = { anySelected: () => true, selectedSensorName: () => "sensorName" };
@@ -309,7 +309,6 @@ test('when sensor is selected drawSessionsInLocation calls map.drawCustomMarker 
   mobileSessionsService.drawSessionsInLocation();
 
   t.true(map.wasCalledWithObjIncluding({ type: 'data-marker' }));
-  t.true(session.drawed);
 
   t.end();
 });
@@ -318,8 +317,8 @@ let clusterer
 
 test('when sensor is selected and sessions are located near each other drawSessionsInLocation calls map.drawCustomMarker to draw marker without label', t => {
   const map = mock('drawCustomMarker');
-  const session1 = { drawed: false, streams: { sensorName: { unit_symbol: "unit", start_latitude: 1, start_longitude: 1 }}};
-  const session2 = { drawed: false, streams: { sensorName: { unit_symbol: "unit", start_latitude: 1, start_longitude: 1 }}};
+  const session1 = { streams: { sensorName: { unit_symbol: "unit", start_latitude: 1, start_longitude: 1 }}};
+  const session2 = { streams: { sensorName: { unit_symbol: "unit", start_latitude: 1, start_longitude: 1 }}};
   const sessions = [ session1, session2 ];
   const sessionsUtils = { get: () => sessions };
   const sensors = { anySelected: () => true, selectedSensorName: () => "sensorName" };
@@ -330,8 +329,6 @@ test('when sensor is selected and sessions are located near each other drawSessi
   mobileSessionsService.drawSessionsInLocation();
 
   t.true(map.wasCalledWithObjIncluding({ type: 'marker' }));
-  t.true(session1.drawed);
-  t.true(session2.drawed);
 
   t.end();
 });

--- a/app/assets/javascripts/tests/_mobile_sessions.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions.test.js
@@ -376,6 +376,19 @@ test('when no sensor is selected drawSessionsInLocation doesnt call map.drawCust
   t.end();
 });
 
+test('redrawSelectedSession call drawSession.drawMobileSession with selected session', t => {
+  const drawSession = mock('drawMobileSession');
+  const session = { id: 1 }
+  const sessionsUtils = { find: () => session }
+
+  const mobileSessionsService = _mobileSessions({ drawSession, sessionsUtils });
+  mobileSessionsService.redrawSelectedSession(1);
+
+  t.true(drawSession.wasCalledWith(session));
+
+  t.end();
+});
+
 const buildData = obj => ({ time: {}, location: {}, sensorId: 123, ...obj });
 
 const _mobileSessions = ({ sessionsDownloaderCalls = [], data, drawSession, utils, sessionIds = [], $location, map, sessionsUtils, sensors }) => {

--- a/app/assets/javascripts/tests/_mobile_sessions.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions.test.js
@@ -168,7 +168,7 @@ test('selectSession after successfully fetching calls drawSession.drawMobileSess
 test('selectSession after successfully fetching undraws all sessions', t => {
   const drawSession = mock('clear');
   const sessions = []
-  const mobileSessionsService = _mobileSessions({ drawSession, sensors: { sensors: { 123: { sensor_name: 'sensor_name' } } } });
+  const mobileSessionsService = _mobileSessions({ drawSession, sensors });
   mobileSessionsService.sessions = sessions
 
   mobileSessionsService.selectSession(1);
@@ -182,7 +182,7 @@ test('selectSession after successfully fetching calls drawSession.drawMobileSess
   const drawSession = mock('drawMobileSession');
   const session = { id: 1 };
   const sessionsUtils = { find: () => session }
-  const mobileSessionsService = _mobileSessions({ drawSession, sensors: { sensors: { 123: { sensor_name: 'sensor_name' } } }, sessionsUtils });
+  const mobileSessionsService = _mobileSessions({ drawSession, sensors, sessionsUtils });
 
   mobileSessionsService.selectSession(1);
 
@@ -390,6 +390,7 @@ test('redrawSelectedSession call drawSession.drawMobileSession with selected ses
 });
 
 const buildData = obj => ({ time: {}, location: {}, sensorId: 123, ...obj });
+const sensors = { sensors: { 123: { sensor_name: 'sensor_name' }}};
 
 const _mobileSessions = ({ sessionsDownloaderCalls = [], data, drawSession, utils, sessionIds = [], $location, map, sessionsUtils, sensors }) => {
   const $rootScope = { $new: () => ({}) };

--- a/app/assets/javascripts/tests/session.test.js
+++ b/app/assets/javascripts/tests/session.test.js
@@ -50,9 +50,10 @@ test('when session is outdoor it uses its username', t => {
   t.end();
 });
 
-test('average returns session average', t => {
-  const session = { average: 1 };
-  const actual = Session.average(session);
+test('average returns session average for selected stream', t => {
+  const selectedSensor = "selectedSensor"
+  const session = { streams: { selectedSensor: { average_value: 1 }}};
+  const actual = Session.average(session, selectedSensor);
 
   t.deepEqual(actual, 1);
 
@@ -102,7 +103,7 @@ test('latLng returns latitude and longitude of the session', t => {
 
 test('averageValueAndUnit returns rounded session average value and unit for selected sensor', t => {
   const selectedSensor = "selectedSensor"
-  const session = { average: 1.2, streams: { selectedSensor: { unit_symbol: "dB" } } };
+  const session = { streams: { selectedSensor: { unit_symbol: "dB", average_value: 1.2 } } };
   const actual = Session.averageValueAndUnit(session, selectedSensor);
 
   t.deepEqual(actual, "1 dB");


### PR DESCRIPTION
This PR tries to simplify and fix the logic behind redrawing markers and crowd map when refreshing a page or changing heat levels. 
It also removes some unnecessary code - see commits for more detail.