### PR TITLE
heatlevels: do not update (reset) when selecting a session

### DIFF
--- a/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/_mobile_sessions_map_ctrl.js
@@ -15,7 +15,6 @@ export const MobileSessionsMapCtrl = (
   $window,
   infoWindow,
   sensorsList,
-  heat,
   sessionsUtils
 ) => {
   sensors.setSensors(sensorsList);
@@ -64,9 +63,7 @@ export const MobileSessionsMapCtrl = (
     $scope.minResolution = 10;
     $scope.maxResolution = 50;
 
-    if (!params.get('data').heat) {
-      sensors.fetchHeatLevels($scope.onHeatLevelsFetch);
-    }
+    if (!params.get('data').heat) sensors.fetchHeatLevels();
 
     storage.updateFromDefaults();
   };
@@ -80,13 +77,8 @@ export const MobileSessionsMapCtrl = (
 
   $scope.$watch("sensors.selectedId()", function(newValue, oldValue) {
     console.warn(newValue, oldValue)
-    sensors.onSensorsSelectedIdChange(newValue, oldValue, $scope.onHeatLevelsFetch);
+    sensors.onSensorsSelectedIdChange(newValue, oldValue);
   }, true);
-
-  $scope.onHeatLevelsFetch = function(data, status, headers, config) {
-    storage.updateDefaults({heat: heat.parse(data)});
-    params.update({data: {heat: heat.parse(data)}});
-  };
 
   $scope.$watch("params.get('data').heat", function(newValue, oldValue) {
     console.log("watch - params.get('data').heat - ", newValue, " - ", oldValue);
@@ -103,19 +95,6 @@ export const MobileSessionsMapCtrl = (
       $scope.sessions.drawSessionsInLocation();
     } else {
       console.warn("mobileSessions.noOfSelectedSessions() should be 0 or 1 and is: ", mobileSessions.noOfSelectedSessions())
-    }
-  }, true);
-
-  $scope.heatUpdateCondition = function() {
-    return {sensorId:  sensors.anySelectedId(), sessionId: $scope.singleSession.id()};
-  };
-
-  $scope.$watch("heatUpdateCondition()", function(newValue, oldValue) {
-    console.log("watch - heatUpdateCondition() - ", newValue, " - ", oldValue);
-    if(newValue.sensorId && newValue.sessionId){
-      functionBlocker.use("sessionHeat", function(){
-        $scope.singleSession.updateHeat();
-      });
     }
   }, true);
 

--- a/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
+++ b/app/assets/javascripts/code/controllers/mobile_sessions_map_ctrl.js
@@ -15,7 +15,6 @@ angular.module('aircasting').controller('MobileSessionsMapCtrl', [
   '$window',
   "infoWindow",
   'sensorsList',
-  'heat',
   'sessionsUtils',
   MobileSessionsMapCtrl
 ]);

--- a/app/assets/javascripts/code/services/sensors.js
+++ b/app/assets/javascripts/code/services/sensors.js
@@ -1,3 +1,3 @@
 import { sensors } from './_sensors';
 
-angular.module("aircasting").factory('sensors', ['params', '$http', sensors]);
+angular.module("aircasting").factory('sensors', ['params', 'storage', 'heat', '$http', sensors]);

--- a/app/assets/javascripts/code/services/single_fixed_session.js
+++ b/app/assets/javascripts/code/services/single_fixed_session.js
@@ -23,13 +23,6 @@ angular.module("aircasting").factory('singleFixedSession', [
       get: function() {
         return _(fixedSessions.allSelected()).first();
       },
-      id: function(onlySingle) {
-        if(onlySingle && !this.isSingle()){
-          return;
-        }
-        var el = this.get();
-        return el && el.id;
-      },
       endTime: function() {
         return this.get().end_time_local;
       },

--- a/app/assets/javascripts/code/services/single_mobile_session.js
+++ b/app/assets/javascripts/code/services/single_mobile_session.js
@@ -27,14 +27,6 @@ angular.module("aircasting").factory('singleMobileSession', [
         return _(mobileSessions.allSelected()).first();
       },
 
-      id: function(onlySingle) {
-        if(onlySingle && !this.isSingle()){
-          return;
-        }
-        var el = this.get();
-        return el && el.id;
-      },
-
       availSensors: function() {
         if(!this.get()){
           return [];

--- a/app/assets/javascripts/tests/_fixed_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_fixed_sessions_map_ctrl.test.js
@@ -46,9 +46,28 @@ test('it updates defaults', t => {
   t.end();
 });
 
-const _FixedSessionsMapCtrl = ({ $scope, map, callback, storage, params }) => {
+test('fetches heat levels on first opening map tab', t => {
+  const sensors = mock('fetchHeatLevels');
+  _FixedSessionsMapCtrl({ sensors });
+
+  t.true(sensors.wasCalled())
+
+  t.end();
+});
+
+test('does not fetch heat levels if they are already in the params', t => {
+  const sensors = mock('fetchHeatLevels');
+  const params = { get: () => ({ heat: {}})};
+  _FixedSessionsMapCtrl({ sensors, params });
+
+  t.false(sensors.wasCalled())
+
+  t.end();
+});
+
+const _FixedSessionsMapCtrl = ({ $scope, map, callback, storage, params, sensors }) => {
   const expandables = { show: () => {} };
-  const sensors = { setSensors: () => {} };
+  const _sensors = { setSensors: () => {}, fetchHeatLevels: () => {}, ...sensors };
   const functionBlocker = { block: () => {} };
   const _params = { get: () => ({}), ...params };
   const rectangles = { clear: () => {} };
@@ -61,5 +80,5 @@ const _FixedSessionsMapCtrl = ({ $scope, map, callback, storage, params }) => {
   const _$scope = { $watch: () => {}, ...$scope };
   const _map = { unregisterAll: () => {}, removeAllMarkers: () => {}, ...map };
 
-  return FixedSessionsMapCtrl(_$scope, _params, null, _map, sensors, expandables, _storage, null, null, null, null, functionBlocker, null, null, rectangles, infoWindow);
+  return FixedSessionsMapCtrl(_$scope, _params, null, _map, _sensors, expandables, _storage, null, null, null, null, functionBlocker, null, null, rectangles, infoWindow);
 };

--- a/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/assets/javascripts/tests/_mobile_sessions_map_ctrl.test.js
@@ -57,17 +57,17 @@ test('it updates defaults', t => {
 
 test('fetches heat levels on first opening map tab', t => {
   const sensors = mock('fetchHeatLevels');
-  const mobileSessionsMapCtrl = _MobileSessionsMapCtrl({ sensors });
+  _MobileSessionsMapCtrl({ sensors });
 
   t.true(sensors.wasCalled())
 
   t.end();
 });
 
-test('doesnt fetch heat levels if they are already in the params', t => {
+test('does not fetch heat levels if they are already in the params', t => {
   const sensors = mock('fetchHeatLevels');
   const params = { get: () => ({ heat: {}})};
-  const mobileSessionsMapCtrl = _MobileSessionsMapCtrl({ sensors, params });
+  _MobileSessionsMapCtrl({ sensors, params });
 
   t.false(sensors.wasCalled())
 


### PR DESCRIPTION
When selecting a session heat levels where reset to default. This PR resolves that problem. I had to refactor the code because it was impossible before to know if a session was selected when param / sensor were all / all or not. It the first case we want to update the heat levels in the second we do not