### PR TITLE
Profiles filter

### DIFF
--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -110,7 +110,7 @@ export const MobileSessionsMapCtrl = (
 
   if (process.env.NODE_ENV !== 'test') {
     angular.element(document).ready(function () {
-      const node = document.getElementById('crowdMapLayer');
+      const node = document.getElementById('newFilters');
 
       const flags = {
         isCrowdMapOn: $scope.params.get('data').crowdMap || false,
@@ -130,25 +130,32 @@ export const MobileSessionsMapCtrl = (
         sessionsUtils.updateCrowdMapLayer($scope.sessions.allSessionIds());
       });
 
-      runTagsAutocomplete(elmApp)
+      runAutocomplete(elmApp.ports.profileNameSelected, "profiles-search", "/autocomplete/usernames")
+
+      runAutocomplete(elmApp.ports.tagSelected, "tags-search", "/autocomplete/tags")
 
       elmApp.ports.updateTags.subscribe((tags) => {
         params.update({data: {tags: tags.join(", ")}});
         $scope.sessions.fetch();
-      })
+      });
+
+      elmApp.ports.updateProfiles.subscribe((profiles) => {
+        params.update({data: {usernames: profiles.join(", ")}});
+        $scope.sessions.fetch();
+      });
     });
   }
 }
 
-const runTagsAutocomplete = (elmApp) => {
-  if (document.getElementById('tags-search')) {
-    $( "#tags-search" ).autocomplete({
+const runAutocomplete = (port, divId, sourcePath) => {
+  if (document.getElementById(divId)) {
+    $( "#" + divId ).autocomplete({
       source: function( request, response ) {
         const data = {q: request.term, limit: 10};
-        $.getJSON( "/autocomplete/tags", data, response );
+        $.getJSON( sourcePath, data, response );
       },
       select: function( event, ui) {
-        elmApp.ports.tagSelected.send(ui.item.value);
+        port.send(ui.item.value);
       }
     });
   } else {

--- a/app/javascript/angular/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions_map_ctrl.test.js
@@ -17,7 +17,7 @@ test('registers a callback to map.goToAddress', t => {
   t.end();
 });
 
-test('it shows by default sensor, location, usernames, layers sections and heat legend', t => {
+test('it shows by default sensor, location,  and heat legend', t => {
   const shown = [];
   const expandables = {
     show: name => shown.push(name)
@@ -25,7 +25,7 @@ test('it shows by default sensor, location, usernames, layers sections and heat 
 
   _MobileSessionsMapCtrl({ expandables });
 
-  t.deepEqual(shown, ['sensor', 'location', 'usernames', 'layers', 'heatLegend']);
+  t.deepEqual(shown, ['sensor', 'location', 'heatLegend']);
 
   t.end();
 });

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -27,6 +27,7 @@ type alias Flags =
     { crowdMapResolution : Int
     , isCrowdMapOn : Bool
     , tags : List String
+    , profiles : List String
     }
 
 
@@ -36,6 +37,7 @@ init flags =
         | isCrowdMapOn = flags.isCrowdMapOn
         , crowdMapResolution = flags.crowdMapResolution
         , tags = flags.tags
+        , profiles = Set.fromList flags.profiles
       }
     , Cmd.none
     )

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -1,7 +1,10 @@
-port module Ports exposing (tagSelected, toggleCrowdMap, updateResolutionPort, updateTags)
+port module Ports exposing (profileNameSelected, tagSelected, toggleCrowdMap, updateProfiles, updateResolutionPort, updateTags)
 
 
 port tagSelected : (String -> msg) -> Sub msg
+
+
+port profileNameSelected : (String -> msg) -> Sub msg
 
 
 port toggleCrowdMap : () -> Cmd a
@@ -11,3 +14,6 @@ port updateResolutionPort : Int -> Cmd a
 
 
 port updateTags : List String -> Cmd a
+
+
+port updateProfiles : List String -> Cmd a

--- a/app/views/layouts/map.html.haml
+++ b/app/views/layouts/map.html.haml
@@ -12,7 +12,7 @@
     = render :partial => 'shared/analytics'
     = render :partial => 'shared/fb_logo'
 
-  %body(id="map" data-version="1.0.13")
+  %body(id="map" data-version="1.0.14")
     .notice(ng-controller="FlashCtrl" ng-cloak ng-show="flash.message" ng-click="clear()") {{flash.message}}
     #mapview(ng-controller="MapCtrl" googlemap="")
     #hud(ng-controller="HudCtrl" ng-cloak ng-hide="map.streetViewVisible()")

--- a/public/partials/mobile_sessions_map.html
+++ b/public/partials/mobile_sessions_map.html
@@ -33,9 +33,7 @@
         </div>
       </section>
 
-      <div class="section-divider" ng-include="versioner.path('/partials/usernames_and_tags.html')"></div>
-
-      <div id="crowdMapLayer"></div>
+      <div id="newFilters"></div>
 
       <div class="section-divider" ng-include="versioner.path('/partials/time_filters.html')"></div>
     </div>


### PR DESCRIPTION
What do you think about implementing these tags and usernames as sets? It adds a big more complexity (I need to transfer back and forth from list to set in a few places), and the testing becomes a bit more tricky(eg I can't use `fuzz List String` and it doesn't offer `fuzz Set String`. I would have to stick with normal tests in these examples or create a custom fuzzer). But it represents the correct idea - tags should not be repeated. Is it worth it?

In a similar fashion tags and profiles should not be allowed to be `“”`. Right now they are just `List String` so `""` is a perfectly valid tag. So I’m thinking of changing it to some custom type like:

`type alias Tag = { firstCharacter: Char, rest: String}`

It would really be in the spirit of making impossible states impossible, but it would add complexity to the internal implementation and testing. What do you think?