### PR TITLE
Zoom in on a selected cluster

### DIFF
--- a/app/javascript/angular/code/controllers/_info_window_ctrl.js
+++ b/app/javascript/angular/code/controllers/_info_window_ctrl.js
@@ -1,0 +1,13 @@
+export const InfoWindowCtrl = (
+  $scope,
+  sensors,
+  infoWindow,
+  map
+) => {
+  $scope.sensors = sensors;
+  $scope.infoWindow = infoWindow;
+
+  $scope.zoomIn = () => {
+    map.zoomToSelectedCluster()
+  }
+};

--- a/app/javascript/angular/code/controllers/info_window_ctrl.js
+++ b/app/javascript/angular/code/controllers/info_window_ctrl.js
@@ -1,6 +1,9 @@
-function InfoWindowCtrl($scope, sensors, infoWindow ) {
-  $scope.sensors = sensors;
-  $scope.infoWindow = infoWindow;
-}
-InfoWindowCtrl.$inject = ['$scope', 'sensors', 'infoWindow'];
-angular.module('aircasting').controller('InfoWindowCtrl', InfoWindowCtrl);
+import { InfoWindowCtrl } from './_info_window_ctrl'
+
+angular.module('aircasting').controller('InfoWindowCtrl', [
+  '$scope',
+  'sensors',
+  'infoWindow',
+  'map',
+  InfoWindowCtrl
+]);

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -117,6 +117,8 @@ export const fixedSessions = (
     },
 
     drawSessionsInLocation: function() {
+      map.removeAllMarkers();
+
       if (params.get('data').location.indoorOnly) return;
 
       const sessions = this.get();
@@ -128,16 +130,7 @@ export const fixedSessions = (
 
       (sessions).forEach(session => this.drawColorCodedMarkers(session, sensors.selectedSensorName()));
 
-      const callback = (cluster) => {
-        const data = {q: {
-          session_ids: cluster.getMarkers().map((marker) => marker.objectId()),
-          sensor_name: sensors.selectedSensorName()
-        }};
-
-        infoWindow.show("/api/region", data, cluster.getCenter(), constants.fixedSession);
-      }
-
-      map.clusterMarkers(callback);
+      map.clusterMarkers(showClusterInfo(sensors.selectedSensorName(), map, infoWindow));
     },
 
     drawColorCodedMarkers: function(session, selectedSensor) {
@@ -237,3 +230,14 @@ export const fixedSessions = (
   };
   return new FixedSessions();
 };
+
+export const showClusterInfo = (sensorName, map, infoWindow) => (cluster) => {
+  map.setSelectedCluster(cluster);
+
+  const data = { q: {
+    session_ids: cluster.getMarkers().map((marker) => marker.objectId()),
+    sensor_name: sensorName
+  }};
+
+  infoWindow.show("/api/region", data, cluster.getCenter(), constants.fixedSession);
+}

--- a/app/javascript/angular/code/services/google/_map.js
+++ b/app/javascript/angular/code/services/google/_map.js
@@ -182,6 +182,14 @@ export const map = (
       this.clusterer = markerClusterer;
     },
 
+    setSelectedCluster: function(cluster) {
+      this.selectedCluster = cluster;
+    },
+
+    zoomToSelectedCluster: function() {
+      googleMaps.fitBounds(this.mapObj,  this.selectedCluster.bounds_)
+    },
+
     removeMarker: function(marker) {
       if(!marker){
         return;

--- a/app/javascript/angular/tests/_info_window_ctrl.test.js
+++ b/app/javascript/angular/tests/_info_window_ctrl.test.js
@@ -1,0 +1,17 @@
+import test from 'blue-tape';
+import { InfoWindowCtrl } from '../code/controllers/_info_window_ctrl';
+import sinon from 'sinon';
+
+test('zoomIn calls map.zoomToSelectedCluster', t => {
+  const zoomToSelectedCluster = sinon.spy();
+  const map = { zoomToSelectedCluster };
+  const scope = {}
+  const service = InfoWindowCtrl(scope, null, null, map);
+
+  scope.zoomIn();
+
+  sinon.assert.called(zoomToSelectedCluster)
+
+
+  t.end();
+})

--- a/app/javascript/angular/tests/_map.test.js
+++ b/app/javascript/angular/tests/_map.test.js
@@ -285,6 +285,33 @@ test('drawRectangles sets a listener on rectangle click', t => {
   t.end();
 });
 
+test('setSelectedCluster sets the passed argument as a selected cluster', t => {
+  const cluster = { id:1 }
+  const service = _map({});
+
+  service.setSelectedCluster(cluster);
+
+  t.deepEqual(service.selectedCluster, cluster);
+  t.end();
+})
+
+test('zoomToSelectedCluster calls fitBounds with current map object and bound of selected cluster', t => {
+  const fitBounds = sinon.spy();
+  const mapObj = sinon.stub();
+  const bounds = sinon.stub();
+  const googleMaps = { fitBounds };
+
+  const service = _map({ googleMaps });
+  service.selectedCluster = { bounds_: bounds };
+  service.mapObj = mapObj;
+
+  service.zoomToSelectedCluster();
+
+  sinon.assert.calledWith(fitBounds, mapObj, bounds);
+
+  t.end();
+})
+
 const mockGeocoder = () => ({
   get: (_, callback) => callback([ { geometry: { getBounds: null } } ])
 });

--- a/public/partials/fixed_info_window.html
+++ b/public/partials/fixed_info_window.html
@@ -6,5 +6,6 @@
     <li>{{infoWindow.data.number_of_instruments }} instruments</li>
     <li>{{infoWindow.data.number_of_samples }} measurements</li>
     <li>{{infoWindow.data.number_of_contributors }} contribitors</li>
+    <button ng-click="zoomIn()">zoom in and show sessions -></button>
   </ul>
 </div>


### PR DESCRIPTION
An info window for fixed sessions clusters has a button that allows to zoom in on the selected cluster. As on this beautiful design: 
![Screen Shot 2019-03-13 at 16 54 25](https://user-images.githubusercontent.com/30773137/54293682-b2edcb80-45b0-11e9-8e66-4d10d2643dfb.png)
