### PR TITLE
Decouple storage

### DIFF
--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -57,18 +57,18 @@ export const FixedSessionsMapCtrl = (
       .get('data', { sensorId: sensors.defaultSensorId })
       .sensorId;
 
-    storage.updateDefaults({
+    const defaults = {
       sensorId,
       location: {address: "", indoorOnly: false, streaming: true},
       tags: "",
       usernames: "",
       timeFrom: moment().utc().startOf('day').subtract(1, 'year').format('X'),
       timeTo: moment().utc().endOf('day').format('X')
-    });
+    };
 
     if (!params.get('data').heat) sensors.fetchHeatLevels();
 
-    storage.updateFromDefaults();
+    params.updateFromDefaults(defaults);
   };
 
   $scope.searchSessions = function() {

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -54,7 +54,7 @@ export const MobileSessionsMapCtrl = (
       .get('data', { sensorId: sensors.defaultSensorId })
       .sensorId;
 
-    storage.updateDefaults({
+    const defaults = {
       sensorId,
       location: {address: ""},
       tags: "",
@@ -63,11 +63,11 @@ export const MobileSessionsMapCtrl = (
       crowdMap: false,
       timeFrom: moment().utc().startOf('day').subtract(1, 'year').format('X'),
       timeTo: moment().utc().endOf('day').format('X')
-    });
+    };
 
     if (!params.get('data').heat) sensors.fetchHeatLevels();
 
-    storage.updateFromDefaults();
+    params.updateFromDefaults(defaults);
   };
 
   $scope.searchSessions = function() {

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -86,9 +86,9 @@ export const MobileSessionsMapCtrl = (
     console.log("watch - params.get('data').heat - ", newValue, " - ", oldValue);
     if (newValue === oldValue) return;
 
-    if (storage.isCrowdMapLayerOn() && mobileSessions.noOfSelectedSessions() === 0) {
+    if ($scope.params.get('data').crowdMap && mobileSessions.noOfSelectedSessions() === 0) {
       sessionsUtils.updateCrowdMapLayer(mobileSessions.sessionIds());
-    } else if (storage.isCrowdMapLayerOn() && mobileSessions.noOfSelectedSessions() === 1) {
+    } else if ($scope.params.get('data').crowdMap && mobileSessions.noOfSelectedSessions() === 1) {
       sessionsUtils.updateCrowdMapLayer($scope.params.get('selectedSessionIds'));
       mobileSessions.redrawSelectedSession($scope.params.get('selectedSessionIds')[0]);
     } else if (mobileSessions.noOfSelectedSessions() === 1) {
@@ -131,13 +131,13 @@ export const MobileSessionsMapCtrl = (
 
       const elmApp = Elm.MobileSessionsFilters.init({ node: node, flags: flags });
 
-      elmApp.ports.toggleCrowdMap.subscribe(() => {
-        storage.toggleCrowdMapData();
+      elmApp.ports.toggleCrowdMap.subscribe((crowdMap) => {
+        params.updateData({ crowdMap });
         $scope.sessions.fetch();
       });
 
-      elmApp.ports.updateResolution.subscribe((newResolution) => {
-        storage.updateCrowdMapResolution(newResolution);
+      elmApp.ports.updateResolution.subscribe((gridResolution) => {
+        params.updateData({ gridResolution });
         sessionsUtils.updateCrowdMapLayer($scope.sessions.allSessionIds());
       });
 

--- a/app/javascript/angular/code/controllers/usernames_and_tags_filters_ctrl.js
+++ b/app/javascript/angular/code/controllers/usernames_and_tags_filters_ctrl.js
@@ -1,7 +1,0 @@
-function UsernamesAndTagsFiltersCtrl($scope, expandables, storage, storageEvents) {
-  $scope.storage = storage;
-  $scope.storageEvents = storageEvents;
-  $scope.expandables = expandables;
-}
-UsernamesAndTagsFiltersCtrl.$inject = ['$scope', 'expandables', 'storage', 'storageEvents'];
-angular.module('aircasting').controller('UsernamesAndTagsFiltersCtrl', UsernamesAndTagsFiltersCtrl);

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -69,7 +69,7 @@ export const mobileSessions = (
     onSessionsFetch: function() {
       if($location.path() !== constants.mobileMapRoute) return;
 
-      if (!storage.isCrowdMapLayerOn()) {
+      if (!params.isCrowdMapOn()) {
         this.drawSessionsInLocation();
       };
       sessionsUtils.onSessionsFetch(this);

--- a/app/javascript/angular/code/services/_storage.js
+++ b/app/javascript/angular/code/services/_storage.js
@@ -25,6 +25,7 @@ export const storage = (params, $rootScope, utils) => {
       this.data[name] = JSON.parse(JSON.stringify(value));
     },
     setInHash: function(hashName, name, value) {
+      //only used for updating heat; todo - delete when new heat legend implemented
       this.data[hashName][name] = angular.copy(value);
     },
     extend: function(data) {
@@ -42,15 +43,6 @@ export const storage = (params, $rootScope, utils) => {
         obj[name] = this.get(name);
       }
       params.update({data: obj});
-    },
-    updateCrowdMapDataInParams: function() {
-      params.update({
-        data: {
-          ...this.data,
-          gridResolution: this.get('gridResolution'),
-          crowdMap: this.get('crowdMap')
-        }
-      });
     },
     updateWithRefresh: function(name) {
       //be carefull when using this - currently it is only for location data
@@ -71,28 +63,9 @@ export const storage = (params, $rootScope, utils) => {
       this.update('location');
     },
     updateDefaults: function(newData) {
+      //only used for updating heat; todo - delete when new heat legend implemented
       this.defaults = utils.merge(this.defaults, newData);
     },
-    updateFromDefaults: function() {
-      var notUsedDefaults = {};
-      _(this.defaults).each(function(value, key){
-        if(!params.get("data")[key]){
-          notUsedDefaults[key] = value;
-        }
-      });
-      params.update({data: notUsedDefaults});
-    },
-    isCrowdMapLayerOn: function() {
-      return this.data.crowdMap;
-    },
-    toggleCrowdMapData: function() {
-      this.set("crowdMap",!this.isCrowdMapLayerOn());
-      this.updateCrowdMapDataInParams();
-    },
-    updateCrowdMapResolution: function(newResolution) {
-      this.set("gridResolution", newResolution);
-      this.updateCrowdMapDataInParams();
-    }
   };
   return new Storage();
 }

--- a/app/javascript/angular/code/services/_update_crowd_map_layer.js
+++ b/app/javascript/angular/code/services/_update_crowd_map_layer.js
@@ -2,7 +2,6 @@ import _ from 'underscore';
 import constants from '../constants';
 
 export const updateCrowdMapLayer = (
-  storage,
   map,
   $http,
   buildQueryParamsForCrowdMapLayer,
@@ -15,7 +14,7 @@ export const updateCrowdMapLayer = (
 ) => ({
   call: (sessionIds) => {
     map.clearRectangles();
-    if (!storage.isCrowdMapLayerOn()) return;
+    if (!params.get('data').crowdMap) return;
 
     const bounds = map.getBounds();
     const q = buildQueryParamsForCrowdMapLayer.call(sessionIds, bounds);

--- a/app/javascript/angular/code/services/params.js
+++ b/app/javascript/angular/code/services/params.js
@@ -34,8 +34,22 @@ angular.module("aircasting").factory('params', ['$location', '$rootScope', 'util
         newData[key] =  angular.toJson(value);
       });
       $location.search(newData);
+    },
+    updateFromDefaults : function(defaults) {
+      this.update({data: filterAlreadySetParams(defaults, this.paramsData.data)});
     }
   };
   return new Params();
 }]);
 
+
+const filterAlreadySetParams = (defaults, currentParamsData = {}) => {
+  return Object.keys(defaults).reduce((acc, key) => {
+    if (paramNotSet(key, currentParamsData)) {
+      acc[key] = defaults[key];
+    };
+    return acc;
+  }, {});
+};
+
+const paramNotSet = (param, currentParamsData) => !(param in currentParamsData)

--- a/app/javascript/angular/code/services/params.js
+++ b/app/javascript/angular/code/services/params.js
@@ -35,21 +35,15 @@ angular.module("aircasting").factory('params', ['$location', '$rootScope', 'util
       });
       $location.search(newData);
     },
-    updateFromDefaults : function(defaults) {
-      this.update({data: filterAlreadySetParams(defaults, this.paramsData.data)});
-    }
+    updateFromDefaults: function(defaults) {
+      this.update({data: { ...defaults, ...this.paramsData.data }});
+    },
+    updateData: function(newData) {
+      this.update({data: utils.merge(this.paramsData.data || {}, newData)})
+    },
+    isCrowdMapOn: function() {
+      return this.paramsData.data.crowdMap
+    },
   };
   return new Params();
 }]);
-
-
-const filterAlreadySetParams = (defaults, currentParamsData = {}) => {
-  return Object.keys(defaults).reduce((acc, key) => {
-    if (paramNotSet(key, currentParamsData)) {
-      acc[key] = defaults[key];
-    };
-    return acc;
-  }, {});
-};
-
-const paramNotSet = (param, currentParamsData) => !(param in currentParamsData)

--- a/app/javascript/angular/code/services/update_crowd_map_layer.js
+++ b/app/javascript/angular/code/services/update_crowd_map_layer.js
@@ -1,7 +1,6 @@
 import { updateCrowdMapLayer } from './_update_crowd_map_layer';
 
 angular.module("aircasting").factory('updateCrowdMapLayer', [
-  'storage',
   'map',
   '$http',
   'buildQueryParamsForCrowdMapLayer',

--- a/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
@@ -22,13 +22,11 @@ test('it updates defaults', t => {
   let defaults = {};
   const sensorId = "sensor id";
   const params = {
-    get: () => ({ sensorId })
-  };
-  const storage = {
-    updateDefaults: opts => defaults = opts
+    get: () => ({ sensorId }),
+    updateFromDefaults: opts => defaults = opts
   };
 
-  _FixedSessionsMapCtrl({ storage, params });
+  _FixedSessionsMapCtrl({ params });
 
   const expected = {
     sensorId,
@@ -66,20 +64,15 @@ test('does not fetch heat levels if they are already in the params', t => {
   t.end();
 });
 
-const _FixedSessionsMapCtrl = ({ $scope, map, callback, storage, params, sensors }) => {
+const _FixedSessionsMapCtrl = ({ $scope, map, callback, params, sensors }) => {
   const expandables = { show: () => {} };
   const _sensors = { setSensors: () => {}, fetchHeatLevels: () => {}, ...sensors };
   const functionBlocker = { block: () => {} };
-  const _params = { get: () => ({}), ...params };
+  const _params = { get: () => ({}), updateFromDefaults: () => {}, ...params };
   const rectangles = { clear: () => {} };
   const infoWindow = { hide: () => {} };
-  const _storage = {
-    updateDefaults: () => {},
-    updateFromDefaults: () => {},
-    ...storage
-  };
   const _$scope = { $watch: () => {}, ...$scope };
   const _map = { unregisterAll: () => {}, removeAllMarkers: () => {}, ...map };
 
-  return FixedSessionsMapCtrl(_$scope, _params, null, _map, _sensors, expandables, _storage, null, null, null, null, functionBlocker, null, null, rectangles, infoWindow);
+  return FixedSessionsMapCtrl(_$scope, _params, null, _map, _sensors, expandables, null, null, null, null, null, functionBlocker, null, null, rectangles, infoWindow);
 };

--- a/app/javascript/angular/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions_map_ctrl.test.js
@@ -35,13 +35,11 @@ test('it updates defaults', t => {
   let defaults = {};
   const sensorId = "sensor id";
   const params = {
-    get: () => ({ sensorId })
-  };
-  const storage = {
-    updateDefaults: opts => defaults = opts
+    get: () => ({ sensorId }),
+    updateFromDefaults: opts => defaults = opts
   };
 
-  _MobileSessionsMapCtrl({ storage, params });
+  _MobileSessionsMapCtrl({ params });
 
   const expected = {
     sensorId,
@@ -77,17 +75,12 @@ test('does not fetch heat levels if they are already in the params', t => {
   t.end();
 });
 
-const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables, sensors, params }) => {
+const _MobileSessionsMapCtrl = ({ $scope, map, callback, expandables, sensors, params }) => {
   const _expandables = { show: () => {}, ...expandables };
   const _sensors = { setSensors: () => {}, fetchHeatLevels: () => {}, ...sensors };
   const functionBlocker = { block: () => {} };
-  const _params = { get: () => ({}), ...params };
+  const _params = { get: () => ({}), updateFromDefaults: () => {}, ...params };
   const infoWindow = { hide: () => {} };
-  const _storage = {
-    updateDefaults: () => {},
-    updateFromDefaults: () => {},
-    ...storage
-  };
   const _map = {
     goToAddress: () => {},
     unregisterAll: () => {},
@@ -97,5 +90,5 @@ const _MobileSessionsMapCtrl = ({ $scope, map, callback, storage, expandables, s
   };
   const _$scope = { $watch: () => {}, ...$scope };
 
-  return MobileSessionsMapCtrl(_$scope, _params, _map, _sensors, _expandables, _storage, null, null, null, null, functionBlocker, null, infoWindow);
+  return MobileSessionsMapCtrl(_$scope, _params, _map, _sensors, _expandables, null, null, null, null, null, functionBlocker, null, infoWindow);
 };

--- a/app/javascript/angular/tests/_storage.test.js
+++ b/app/javascript/angular/tests/_storage.test.js
@@ -15,47 +15,6 @@ test('resetAddress calls params.update with emptied address', t => {
   t.end();
 });
 
-test('isCrowdMapLayerOn', t => {
-  const service = _storage({});
-  service.set('crowdMap', true);
-
-  const actual = service.isCrowdMapLayerOn();
-
-  t.true(actual);
-
-  t.end();
-});
-
-test('updateCrowdMapDataInParams updates params preserving old values', t => {
-  const params = mock('update');
-  const service = _storage({ params });
-  service.set('crowdMap', true);
-  service.set('gridResolution', 1);
-  service.set('heat', {});
-
-  const actual = service.updateCrowdMapDataInParams();
-
-  const expected = { data: { gridResolution: 1, crowdMap: true, heat: {} } };
-  t.true(params.wasCalledWith(expected));
-
-  t.end();
-});
-
-test('toggleCrowdMapData toggles crowdMap value in params and crowdMap value in storage', t => {
-  const update = sinon.spy();
-  const params = { update };
-  const service = _storage({ params });
-  service.set('crowdMap', false);
-
-  service.toggleCrowdMapData();
-
-  const expected = { data: { gridResolution: undefined, crowdMap: true, heat: {}}};
-  t.true(update.calledWith(expected));
-  t.true(service.get('crowdMap'));
-
-  t.end();
-});
-
 const _storage = ({ params }) => {
   const $rootScope = { $new: () => ({ $watch: () => {} }) };
   const utils = {

--- a/app/javascript/angular/tests/_update_crowd_map_layer.test.js
+++ b/app/javascript/angular/tests/_update_crowd_map_layer.test.js
@@ -3,9 +3,9 @@ import { mock } from './helpers';
 import { updateCrowdMapLayer } from '../code/services/_update_crowd_map_layer';
 
 test('when crowd map layer is off it clears rectangles', t => {
-  const storage = { isCrowdMapLayerOn: () => false };
+  const params = { get: () => ({ crowdMap: false }), };
   const map = mock('clearRectangles');
-  const service = _updateCrowdMapLayer({ storage, map });
+  const service = _updateCrowdMapLayer({ params, map });
 
   service.call()
 
@@ -142,11 +142,7 @@ const mockHttp = ({ shouldFail }) => {
   };
 };
 
-const _updateCrowdMapLayer = ({ storage, map, $http, flash, buildQueryParamsForCrowdMapLayer, $location, infoWindow, rectangles }) => {
-  const _storage = {
-    isCrowdMapLayerOn: () => true,
-    ...storage
-  };
+const _updateCrowdMapLayer = ({params, map, $http, flash, buildQueryParamsForCrowdMapLayer, $location, infoWindow, rectangles }) => {
   const _map = {
     clearRectangles: () => {},
     getBounds: () => {},
@@ -156,8 +152,9 @@ const _updateCrowdMapLayer = ({ storage, map, $http, flash, buildQueryParamsForC
     call: () => ({}),
     ...buildQueryParamsForCrowdMapLayer
   };
-  const params = {
-    get: () => ({})
+  const _params = {
+    get: () => ({crowdMap: true}),
+    ... params
   };
   const utils = {
     heats: x => x
@@ -166,5 +163,5 @@ const _updateCrowdMapLayer = ({ storage, map, $http, flash, buildQueryParamsForC
     position: () => {}
   };
 
-  return updateCrowdMapLayer(_storage, _map, $http, _buildQueryParamsForCrowdMapLayer, flash, params, utils, infoWindow, _rectangles, $location);
+  return updateCrowdMapLayer(_map, $http, _buildQueryParamsForCrowdMapLayer, flash, _params, utils, infoWindow, _rectangles, $location);
 };

--- a/app/javascript/elm/src/MobileSessionsFilters.elm
+++ b/app/javascript/elm/src/MobileSessionsFilters.elm
@@ -73,7 +73,7 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         ToggleCrowdMap ->
-            ( { model | isCrowdMapOn = not model.isCrowdMapOn }, Ports.toggleCrowdMap () )
+            ( { model | isCrowdMapOn = not model.isCrowdMapOn }, Ports.toggleCrowdMap (not model.isCrowdMapOn) )
 
         UpdateCrowdMapResolution resolution ->
             ( { model | crowdMapResolution = resolution }, Ports.updateResolution resolution )

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -12,7 +12,7 @@ port profileSelected : (String -> msg) -> Sub msg
 port timeRangeSelected : (Encode.Value -> msg) -> Sub msg
 
 
-port toggleCrowdMap : () -> Cmd a
+port toggleCrowdMap : Bool -> Cmd a
 
 
 port updateResolution : Int -> Cmd a


### PR DESCRIPTION
I'm trying to disconnect stuff from the storage. When we finish rewriting location filter and heat map I think we will be able to remove storage totally.
The side effect is that we have to access stuff directly from params, but I'm hoping this is temporary, cause we are planning to move params to elm, so I didn't want to put a lot of effort in optimizing that part.

Let me know if you think this is a good idea and if it's going in the right direction.