### PR TITLE
Sessions list in Elm

### DIFF
--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -122,18 +122,6 @@ export const SessionsListCtrl = (
     });
   }, true);
 
-  $scope.toggleAll = function(){
-    if(sessions.hasSelectedSessions()) {
-      sessions.deselectAllSessions();
-    } else {
-      flash.set(CANNOT_SELECT_MULTIPLE_SESSIONS);
-    }
-  };
-
-  $scope.allSelectionText = function() {
-    return sessions.hasSelectedSessions() ? "none" : "all";
-  };
-
   $scope.toggleSession = function(sessionId, markerSelected) {
     if(this.isSessionDisabled(sessionId)){
       flash.set(CANNOT_SELECT_MULTIPLE_SESSIONS);

--- a/app/javascript/elm/src/SessionsList.elm
+++ b/app/javascript/elm/src/SessionsList.elm
@@ -7,6 +7,7 @@ import Html.Events as Events
 import String exposing (fromInt)
 
 
+
 ---- MODEL ----
 
 
@@ -69,6 +70,7 @@ update msg model =
                 ( { model | selectedSessionId = Nothing }
                 , checkedSession { deselected = model.selectedSessionId, selected = Nothing }
                 )
+
             else
                 ( { model | selectedSessionId = Just id }
                 , checkedSession { deselected = model.selectedSessionId, selected = Just id }
@@ -79,7 +81,7 @@ update msg model =
                 selectedSessionId =
                     List.head << List.map .id << List.filter .selected
             in
-                ( { model | sessions = sessions, selectedSessionId = selectedSessionId sessions }, Cmd.none )
+            ( { model | sessions = sessions, selectedSessionId = selectedSessionId sessions }, Cmd.none )
 
         LoadMoreSessions ->
             ( model, loadMoreSessions () )
@@ -95,12 +97,12 @@ viewSession selectedSessionId session =
         [ Attr.style "padding" "5px 10px"
         , Attr.style "clear" "both"
         , Attr.style "overflow" "hidden"
+        , Events.onClick <| ToggleSessionSelection session.id
         ]
         [ input
             [ Attr.type_ "radio"
             , Attr.id <| "radio-" ++ fromInt session.id
             , Attr.checked <| selectedSessionId == Just session.id
-            , Events.onClick <| ToggleSessionSelection session.id
             , Attr.style "float" "left"
             , Attr.style "margin" "3px 0 0"
             ]
@@ -119,7 +121,6 @@ viewSession selectedSessionId session =
                     , Attr.style "display" "block"
                     , Attr.style "cursor" "pointer"
                     , Attr.style "width" "170px"
-                    , Attr.for <| "radio-" ++ fromInt session.id
                     ]
                     [ text session.title ]
                 ]
@@ -151,6 +152,7 @@ viewShortType length index shortType =
         , span []
             [ if index == length - 1 then
                 text ""
+
               else
                 text "/"
             ]
@@ -170,6 +172,7 @@ viewLoadMore : Int -> Html Msg
 viewLoadMore sessionCount =
     if sessionCount /= 0 && modBy 50 sessionCount == 0 then
         li [] [ button [ Events.onClick LoadMoreSessions ] [ text "Load More..." ] ]
+
     else
         text ""
 

--- a/app/javascript/elm/src/SessionsList.elm
+++ b/app/javascript/elm/src/SessionsList.elm
@@ -1,0 +1,188 @@
+port module SessionsList exposing (Model, Msg(..), Session, ShortType, checkedSession, init, loadMoreSessions, main, subscriptions, update, updateSessions, view, viewSession, viewShortType)
+
+import Browser
+import Html exposing (Html, button, dd, div, dl, dt, input, label, li, span, text, ul)
+import Html.Attributes as Attr
+import Html.Events as Events
+import String exposing (fromInt)
+
+
+---- MODEL ----
+
+
+type alias ShortType =
+    { name : String
+    , type_ : String
+    }
+
+
+type alias Session =
+    { title : String
+    , id : Int
+    , timeframe : String
+    , username : String
+    , shortTypes : List ShortType
+    , selected : Bool -- THIS IS USED IN JS, IN ELM WE TRACK SELECTION IN selectedSessionId. REMOVE WHEN MOVING FETCHING FROM JS TO ELM
+    }
+
+
+type alias Model =
+    { sessions : List Session
+    , selectedSessionId : Maybe Int
+    }
+
+
+init : List Session -> ( Model, Cmd Msg )
+init flags =
+    ( { sessions = flags, selectedSessionId = Nothing }, Cmd.none )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.batch [ updateSessions UpdateSessions ]
+
+
+
+---- UPDATE ----
+
+
+port updateSessions : (List Session -> msg) -> Sub msg
+
+
+port checkedSession : { deselected : Maybe Int, selected : Maybe Int } -> Cmd msg
+
+
+port loadMoreSessions : () -> Cmd msg
+
+
+type Msg
+    = ToggleSessionSelection Int
+    | UpdateSessions (List Session)
+    | LoadMoreSessions
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        ToggleSessionSelection id ->
+            if model.selectedSessionId == Just id then
+                ( { model | selectedSessionId = Nothing }
+                , checkedSession { deselected = model.selectedSessionId, selected = Nothing }
+                )
+            else
+                ( { model | selectedSessionId = Just id }
+                , checkedSession { deselected = model.selectedSessionId, selected = Just id }
+                )
+
+        UpdateSessions sessions ->
+            let
+                selectedSessionId =
+                    List.head << List.map .id << List.filter .selected
+            in
+                ( { model | sessions = sessions, selectedSessionId = selectedSessionId sessions }, Cmd.none )
+
+        LoadMoreSessions ->
+            ( model, loadMoreSessions () )
+
+
+
+---- VIEW ----
+
+
+viewSession : Maybe Int -> Session -> Html Msg
+viewSession selectedSessionId session =
+    li
+        [ Attr.style "padding" "5px 10px"
+        , Attr.style "clear" "both"
+        , Attr.style "overflow" "hidden"
+        ]
+        [ input
+            [ Attr.type_ "radio"
+            , Attr.id <| "radio-" ++ fromInt session.id
+            , Attr.checked <| selectedSessionId == Just session.id
+            , Events.onClick <| ToggleSessionSelection session.id
+            , Attr.style "float" "left"
+            , Attr.style "margin" "3px 0 0"
+            ]
+            []
+        , dl
+            [ Attr.style "float" "left"
+            , Attr.style "margin" "0 0 0 10px"
+            ]
+            [ dt
+                [ Attr.style "font-size" "14px"
+                , Attr.style "color" "#000"
+                , Attr.style "font-weight" "normal"
+                ]
+                [ label
+                    [ Attr.class "narrow"
+                    , Attr.style "display" "block"
+                    , Attr.style "cursor" "pointer"
+                    , Attr.style "width" "170px"
+                    , Attr.for <| "radio-" ++ fromInt session.id
+                    ]
+                    [ text session.title ]
+                ]
+            , dd
+                [ Attr.style "font-size" "11px"
+                , Attr.style "margin" "0"
+                , Attr.style "color" "#000"
+                , Attr.style "font-weight" "normal"
+                ]
+                [ label
+                    [ Attr.class "narrow"
+                    , Attr.style "display" "block"
+                    , Attr.style "cursor" "pointer"
+                    , Attr.style "width" "170px"
+                    ]
+                    ([ div [] [ text <| session.username ++ ", " ++ session.timeframe ]
+                     ]
+                        ++ List.indexedMap (viewShortType <| List.length session.shortTypes) session.shortTypes
+                    )
+                ]
+            ]
+        ]
+
+
+viewShortType : Int -> Int -> ShortType -> Html msg
+viewShortType length index shortType =
+    span [ Attr.class shortType.type_ ]
+        [ text shortType.name
+        , span []
+            [ if index == length - 1 then
+                text ""
+              else
+                text "/"
+            ]
+        ]
+
+
+view : Model -> Html Msg
+view model =
+    ul
+        []
+        (List.map (viewSession model.selectedSessionId) model.sessions
+            ++ [ viewLoadMore <| List.length model.sessions ]
+        )
+
+
+viewLoadMore : Int -> Html Msg
+viewLoadMore sessionCount =
+    if sessionCount /= 0 && modBy 50 sessionCount == 0 then
+        li [] [ button [ Events.onClick LoadMoreSessions ] [ text "Load More..." ] ]
+    else
+        text ""
+
+
+
+---- PROGRAM ----
+
+
+main : Program (List Session) Model Msg
+main =
+    Browser.element
+        { view = view
+        , init = init
+        , update = update
+        , subscriptions = subscriptions
+        }

--- a/app/javascript/elm/tests/SessionsListTests.elm
+++ b/app/javascript/elm/tests/SessionsListTests.elm
@@ -1,0 +1,201 @@
+module SessionsListTests exposing (session, sessionWithId, sessionWithTitle, shortTypes, updateTests, viewTests)
+
+import Expect
+import Fuzz exposing (int, intRange, string)
+import Html
+import Json.Encode as Encode
+import Ports
+import SessionsList exposing (..)
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Slc
+import TimeRange
+
+
+shortTypes : List ShortType
+shortTypes =
+    [ { name = "name", type_ = "type_" } ]
+
+
+session : Session
+session =
+    { title = "title"
+    , id = 1
+    , timeframe = "timeframe"
+    , username = "username"
+    , shortTypes = shortTypes
+    , selected = False
+    }
+
+
+sessionWithId : Int -> Session
+sessionWithId id =
+    { session | id = id }
+
+
+sessionWithTitle : String -> Session
+sessionWithTitle title =
+    { session | title = title }
+
+
+viewTests : Test
+viewTests =
+    describe "view"
+        [ fuzz2 string string "session titles are displayed in the list" <|
+            \title1 title2 ->
+                { sessions = [ sessionWithTitle title1, sessionWithTitle title2 ], selectedSessionId = Nothing }
+                    |> view
+                    |> Query.fromHtml
+                    |> Query.contains
+                        [ Html.text title1
+                        , Html.text title2
+                        ]
+        , fuzz int "selected session is selected in the list" <|
+            \id ->
+                { sessions = [ sessionWithId id, sessionWithId (id + 1) ], selectedSessionId = Just (id + 1) }
+                    |> view
+                    |> Query.fromHtml
+                    |> Query.findAll [ Slc.all [ Slc.tag "input", Slc.checked True ] ]
+                    |> Query.count (Expect.equal 1)
+        , fuzz (intRange 1 10) "with modulo 50 sessions in the model the load more button is shown" <|
+            \times ->
+                { sessions = List.repeat (50 * times) session, selectedSessionId = Nothing }
+                    |> view
+                    |> Query.fromHtml
+                    |> Query.contains [ Html.text "Load More..." ]
+        , test "with 0 sessions in the model the load more button is not shown" <|
+            \times ->
+                { sessions = [], selectedSessionId = Nothing }
+                    |> view
+                    |> Query.fromHtml
+                    |> Query.findAll [ Slc.text "Load More..." ]
+                    |> Query.count (Expect.equal 0)
+        ]
+
+
+updateTests : Test
+updateTests =
+    describe "update"
+        [ fuzz int "with no selections ToggleSessionSelection selects the session" <|
+            \id ->
+                let
+                    model =
+                        { sessions = [ sessionWithId id, sessionWithId (id + 1) ], selectedSessionId = Nothing }
+
+                    expected =
+                        { model | selectedSessionId = Just (id + 1) }
+                in
+                model
+                    |> update (ToggleSessionSelection (id + 1))
+                    |> Tuple.first
+                    |> Expect.equal expected
+        , fuzz int "when session was selected ToggleSessionSelection deselects it" <|
+            \id ->
+                let
+                    model =
+                        { sessions = [ sessionWithId id, sessionWithId (id + 1) ], selectedSessionId = Just (id + 1) }
+
+                    expected =
+                        { model | selectedSessionId = Nothing }
+                in
+                model
+                    |> update (ToggleSessionSelection (id + 1))
+                    |> Tuple.first
+                    |> Expect.equal expected
+        , fuzz int "when another session was selected ToggleSessionSelection selects the new one" <|
+            \id ->
+                let
+                    model =
+                        { sessions = [ sessionWithId id, sessionWithId (id + 1) ], selectedSessionId = Just (id + 1) }
+
+                    expected =
+                        { model | selectedSessionId = Just id }
+                in
+                model
+                    |> update (ToggleSessionSelection id)
+                    |> Tuple.first
+                    |> Expect.equal expected
+        , fuzz int "with no selections ToggleSessionSelection tells javascript what was selected" <|
+            \id ->
+                let
+                    model =
+                        { sessions = [ sessionWithId id, sessionWithId (id + 1) ], selectedSessionId = Nothing }
+
+                    expected =
+                        checkedSession { selected = Just (id + 1), deselected = Nothing }
+                in
+                model
+                    |> update (ToggleSessionSelection (id + 1))
+                    |> Tuple.second
+                    |> Expect.equal expected
+        , fuzz int "when session was selected ToggleSessionSelection tells javascript what was deselected" <|
+            \id ->
+                let
+                    model =
+                        { sessions = [ sessionWithId id, sessionWithId (id + 1) ], selectedSessionId = Just (id + 1) }
+
+                    expected =
+                        checkedSession { selected = Nothing, deselected = Just (id + 1) }
+                in
+                model
+                    |> update (ToggleSessionSelection (id + 1))
+                    |> Tuple.second
+                    |> Expect.equal expected
+        , fuzz int "when another session was selected ToggleSessionSelection tells javascript what was selected and what was deselected" <|
+            \id ->
+                let
+                    model =
+                        { sessions = [ sessionWithId id, sessionWithId (id + 1) ], selectedSessionId = Just (id + 1) }
+
+                    expected =
+                        checkedSession { selected = Just id, deselected = Just (id + 1) }
+                in
+                model
+                    |> update (ToggleSessionSelection id)
+                    |> Tuple.second
+                    |> Expect.equal expected
+        , fuzz int "UpdateSessions replaces sessions in the model" <|
+            \id ->
+                let
+                    model =
+                        { sessions = [ sessionWithId id ], selectedSessionId = Nothing }
+
+                    newSessions =
+                        [ sessionWithId (id + 1) ]
+                in
+                model
+                    |> update (UpdateSessions newSessions)
+                    |> Tuple.first
+                    |> .sessions
+                    |> Expect.equal newSessions
+        , fuzz int "UpdateSessions selects the proper session in the model" <|
+            \id ->
+                let
+                    model =
+                        { sessions = [], selectedSessionId = Nothing }
+
+                    selectedSession =
+                        { session | id = id, selected = True }
+
+                    unselectedSession =
+                        { session | id = id + 1, selected = False }
+
+                    newSessions =
+                        [ selectedSession, unselectedSession ]
+                in
+                model
+                    |> update (UpdateSessions newSessions)
+                    |> Tuple.first
+                    |> .selectedSessionId
+                    |> Expect.equal (Just id)
+        , fuzz int "LoadMoreSessions delegates to javascript" <|
+            \id ->
+                let
+                    model =
+                        { sessions = [], selectedSessionId = Nothing }
+                in
+                model
+                    |> update LoadMoreSessions
+                    |> Tuple.second
+                    |> Expect.equal (loadMoreSessions ())
+        ]

--- a/app/views/layouts/map.html.haml
+++ b/app/views/layouts/map.html.haml
@@ -12,7 +12,7 @@
     = render :partial => 'shared/analytics'
     = render :partial => 'shared/fb_logo'
 
-  %body(id="map" data-version="1.0.20")
+  %body(id="map" data-version="1.0.21")
     .notice(ng-controller="FlashCtrl" ng-cloak ng-show="flash.message" ng-click="clear()") {{flash.message}}
     #mapview(ng-controller="MapCtrl" googlemap="")
     #hud(ng-controller="HudCtrl" ng-cloak ng-hide="map.streetViewVisible()")

--- a/config/webpack/loaders/elm.js
+++ b/config/webpack/loaders/elm.js
@@ -9,7 +9,8 @@ const elmDefaultOptions = {
   pathToElm: elmBinary,
   files: [
     resolve(__dirname, "../../../app/javascript/elm/src/MobileSessionsFilters.elm"),
-    resolve(__dirname, "../../../app/javascript/elm/src/FixedSessionFilters.elm")
+    resolve(__dirname, "../../../app/javascript/elm/src/FixedSessionFilters.elm"),
+    resolve(__dirname, "../../../app/javascript/elm/src/SessionsList.elm")
   ]
 }
 const developmentOptions = Object.assign({}, elmDefaultOptions, {

--- a/public/partials/sessions_list.html
+++ b/public/partials/sessions_list.html
@@ -3,7 +3,6 @@
     <div class="name"><span>Sessions</span></div>
     <ul class="buttons">
       <li><button ng-click="exportSessions()" ng-show="canExportSessions()">export</button></li>
-      <li><button ng-click="toggleAll()">{{allSelectionText()}}</button></li>
     </ul>
   </div>
   <div class="nomargin">

--- a/public/partials/sessions_list.html
+++ b/public/partials/sessions_list.html
@@ -8,26 +8,7 @@
   </div>
   <div class="nomargin">
     <div id="sessions-bottom" ng-style="{height: $window.innerHeight - 300}">
-      <ul>
-        <li ng:repeat="session in sessionsForList" ng-class="sessionCssClass(session.$selected)">
-          <input type="checkbox" collection-condition="canSelectSession(session.id)" collection="selectedSessionIds" collection-id="session.id" ng-model="session.$selected" ng-disabled="isSessionDisabled(session.id)">
-          <dl ng-click="toggleSession(session.id, false)">
-            <dt><label class="narrow">{{session.title}}</label></dt>
-            <dd>
-              <label class="narrow">
-                {{session.username}},
-                {{session.timeframe}}
-                <span ng-class="shortTypeCss(shortType.type, session.$selected)" ng-repeat="shortType in session.shortTypes">{{shortType.name}}<span ng-hide="$index==session.shortTypes.length-1">/</span></span>
-              </label>
-            </dd>
-          </dl>
-        </li>
-
-        <li ng-show = "sessionsCount === 50 || sessionsCount === 100">
-          <button ng-click="updateSessionsPage()">Load More...</button>
-        </li>
-
-      </ul>
+      <div id="sessions-bottom-elm"></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This is the first PR on the sessions list. It introduces what was in the proof of concept with added tests. In particular:
- list in Elm
- radio buttons instead of checkboxes