### PR TITLE
Parameter filter

### DIFF
--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import { Elm } from '../../../elm/src/FixedSessionFilters.elm';
 import moment from 'moment'
+import { buildAvailableParameters } from '../services/_sensors'
 
 import * as FiltersUtils from '../filtersUtils'
 
@@ -113,6 +114,8 @@ export const FixedSessionsMapCtrl = (
       };
 
       const flags = {
+        parametersList: buildAvailableParameters(sensorsList),
+        selectedParameter: sensors.findParameterForSensor(sensors.selected()).id,
         location: $scope.params.get('data').location || "",
         tags: $scope.params.get('data').tags.split(', ').filter((tag) => tag !== "") || [],
         profiles: $scope.params.get('data').usernames.split(', ').filter((tag) => tag !== "") || [],
@@ -120,6 +123,15 @@ export const FixedSessionsMapCtrl = (
       };
 
       const elmApp = Elm.FixedSessionFilters.init({ node: node, flags: flags });
+
+      elmApp.ports.selectParameter.subscribe(parameter =>{
+        const oldValue = sensors.selectedParameter;
+        const newParameter = { label: parameter, id: parameter };
+
+        $scope.sensors.selectedParameter = newParameter
+        sensors.onSelectedParameterChange(newParameter, oldValue);
+        $scope.sessions.fetch();
+      });
 
       elmApp.ports.findLocation.subscribe(location => {
         FiltersUtils.findLocation(location, params, map);

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -2,6 +2,7 @@ import _ from 'underscore';
 import { Elm } from '../../../elm/src/MobileSessionsFilters.elm';
 import moment from 'moment'
 import * as FiltersUtils from '../filtersUtils'
+import { buildAvailableParameters } from '../services/_sensors'
 
 export const MobileSessionsMapCtrl = (
   $scope,
@@ -112,7 +113,7 @@ export const MobileSessionsMapCtrl = (
       };
 
       const flags = {
-        sensorsList,
+        parametersList: buildAvailableParameters(sensorsList),
         selectedParameter: sensors.findParameterForSensor(sensors.selected()).id,
         isCrowdMapOn: $scope.params.get('data').crowdMap || false,
         crowdMapResolution: $scope.params.get('data').gridResolution || 25,

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -112,6 +112,7 @@ export const MobileSessionsMapCtrl = (
       };
 
       const flags = {
+        sensorsList,
         isCrowdMapOn: $scope.params.get('data').crowdMap || false,
         crowdMapResolution: $scope.params.get('data').gridResolution || 25,
         location: $scope.params.get('data').location || "",

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -95,6 +95,7 @@ export const MobileSessionsMapCtrl = (
     }
   }, true);
 
+  // two places in _sensors.js still use that watch
   $scope.$watch("sensors.selectedParameter", function(newValue, oldValue) {
     sensors.onSelectedParameterChange(newValue, oldValue);
   }, true);
@@ -120,6 +121,15 @@ export const MobileSessionsMapCtrl = (
       };
 
       const elmApp = Elm.MobileSessionsFilters.init({ node: node, flags: flags });
+
+      elmApp.ports.selectParameter.subscribe(parameter =>{
+        const oldValue = sensors.selectedParameter;
+        const newParameter = { label: parameter, id: parameter };
+
+        $scope.sensors.selectedParameter = newParameter
+        sensors.onSelectedParameterChange(newParameter, oldValue);
+        $scope.sessions.fetch();
+      });
 
       elmApp.ports.toggleCrowdMap.subscribe(crowdMap => {
         params.updateData({ crowdMap });

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -113,6 +113,7 @@ export const MobileSessionsMapCtrl = (
 
       const flags = {
         sensorsList,
+        selectedParameter: sensors.findParameterForSensor(sensors.selected()).id,
         isCrowdMapOn: $scope.params.get('data').crowdMap || false,
         crowdMapResolution: $scope.params.get('data').gridResolution || 25,
         location: $scope.params.get('data').location || "",

--- a/app/javascript/angular/code/services/_sensors.js
+++ b/app/javascript/angular/code/services/_sensors.js
@@ -52,7 +52,7 @@ export const sensors = (params, storage, heat, $http) => {
       } else {
         console.log('initSelected() - sensorId is NOT null')
       }
-      this.selectedParameter = this.findParameterForSensor(this.selected());
+      this.selectedParameter = this.findParameterForSensor(this.selected()); //uses the watch
       this.availableSensors = findAvailableSensorsForParameter(sort, this.sensors, this.selectedParameter);
     },
 
@@ -92,7 +92,7 @@ export const sensors = (params, storage, heat, $http) => {
       console.log('onSelectedSensorChange() - ', newSensorId, ' - ', oldSensorId);
       var sensor = this.findSensorById(newSensorId);
       var parameterForSensor = this.findParameterForSensor(sensor);
-      this.selectedParameter = parameterForSensor;
+      this.selectedParameter = parameterForSensor; //uses the watch
     },
     buildSensorId: function(sensor) {
       return buildSensorId(sensor);

--- a/app/javascript/angular/code/services/_sensors.js
+++ b/app/javascript/angular/code/services/_sensors.js
@@ -52,7 +52,6 @@ export const sensors = (params, storage, heat, $http) => {
       } else {
         console.log('initSelected() - sensorId is NOT null')
       }
-      this.selectedParameter = this.findParameterForSensor(this.selected()); //uses the watch
       this.availableSensors = findAvailableSensorsForParameter(sort, this.sensors, this.selectedParameter);
     },
 

--- a/app/javascript/elm/src/MobileSessionsFilters.elm
+++ b/app/javascript/elm/src/MobileSessionsFilters.elm
@@ -23,6 +23,7 @@ type alias Model =
     { popup : Popups
     , isPopupExtended : Bool
     , parameters : List String
+    , selectedParameter : String
     , location : String
     , tags : LabelsInput.Model
     , profiles : LabelsInput.Model
@@ -42,6 +43,7 @@ defaultModel =
     { popup = None
     , isPopupExtended = False
     , parameters = []
+    , selectedParameter = "particulate matter"
     , location = ""
     , tags = LabelsInput.empty
     , profiles = LabelsInput.empty
@@ -169,7 +171,7 @@ updateLabels msg model toSubCmd mapper updateModel =
 view : Model -> Html Msg
 view model =
     div []
-        [ viewParameter
+        [ viewParameter model.selectedParameter
         , case model.popup of
             SelectFromItems items ->
                 case model.isPopupExtended of
@@ -194,13 +196,14 @@ view model =
         ]
 
 
-viewParameter : Html Msg
-viewParameter =
+viewParameter : String -> Html Msg
+viewParameter selectedParameter =
     div []
         [ h4 [] [ text "parameter" ]
         , input
             [ Attr.id "parameter-filter"
             , Events.custom "click" (Decode.map preventDefault (Decode.succeed ShowSelectFormItemsPopup))
+            , Attr.value selectedParameter
             ]
             []
         ]

--- a/app/javascript/elm/src/MobileSessionsFilters.elm
+++ b/app/javascript/elm/src/MobileSessionsFilters.elm
@@ -62,6 +62,7 @@ type alias Flags =
     , timeRange : Encode.Value
     , selectedParameter : String
     , sensorsList : Encode.Value
+    , parametersList : Encode.Value
     }
 
 
@@ -69,12 +70,12 @@ init : Flags -> ( Model, Cmd Msg )
 init flags =
     let
         result =
-            Decode.decodeValue (Decode.list parameterDecoder) flags.sensorsList
+            Decode.decodeValue (Decode.list (Decode.field "label" Decode.string)) flags.parametersList
 
-        uniqueParameters =
+        parameters =
             case result of
-                Ok allParameters ->
-                    allParameters |> Set.fromList |> Set.toList
+                Ok values ->
+                    values
 
                 Err _ ->
                     []
@@ -87,7 +88,7 @@ init flags =
         , crowdMapResolution = flags.crowdMapResolution
         , timeRange = TimeRange.update defaultModel.timeRange flags.timeRange
         , selectedParameter = flags.selectedParameter
-        , parameters = uniqueParameters
+        , parameters = parameters
       }
     , Ports.selectParameter flags.selectedParameter
     )

--- a/app/javascript/elm/src/MobileSessionsFilters.elm
+++ b/app/javascript/elm/src/MobileSessionsFilters.elm
@@ -60,6 +60,7 @@ type alias Flags =
     , isCrowdMapOn : Bool
     , crowdMapResolution : Int
     , timeRange : Encode.Value
+    , selectedParameter : String
     , sensorsList : Encode.Value
     }
 
@@ -85,9 +86,10 @@ init flags =
         , isCrowdMapOn = flags.isCrowdMapOn
         , crowdMapResolution = flags.crowdMapResolution
         , timeRange = TimeRange.update defaultModel.timeRange flags.timeRange
+        , selectedParameter = flags.selectedParameter
         , parameters = uniqueParameters
       }
-    , Cmd.none
+    , Ports.selectParameter flags.selectedParameter
     )
 
 

--- a/app/javascript/elm/src/MobileSessionsFilters.elm
+++ b/app/javascript/elm/src/MobileSessionsFilters.elm
@@ -91,6 +91,7 @@ type Msg
     | UpdateTimeRange Encode.Value
     | ShowCopyLinkTooltip
     | ShowSelectFormItemsPopup
+    | SelectParameter String
     | ClosePopup
     | GotSensors (Result Http.Error (List String))
     | TogglePopupState
@@ -148,6 +149,9 @@ update msg model =
                 Err _ ->
                     ( model, Cmd.none )
 
+        SelectParameter parameter ->
+            ( { model | selectedParameter = parameter }, Cmd.none )
+
 
 updateLabels :
     LabelsInput.Msg
@@ -176,10 +180,10 @@ view model =
             SelectFromItems items ->
                 case model.isPopupExtended of
                     True ->
-                        viewPopup model.isPopupExtended items
+                        viewPopup SelectParameter model.isPopupExtended items
 
                     False ->
-                        viewPopup model.isPopupExtended items
+                        viewPopup SelectParameter model.isPopupExtended items
 
             None ->
                 div [] []
@@ -209,8 +213,8 @@ viewParameter selectedParameter =
         ]
 
 
-viewPopup : Bool -> List String -> Html Msg
-viewPopup isPopupExtended items =
+viewPopup : (String -> Msg) -> Bool -> List String -> Html Msg
+viewPopup select isPopupExtended items =
     let
         numberOfMainItems =
             4
@@ -223,7 +227,7 @@ viewPopup isPopupExtended items =
     in
     div [ Attr.id "popup" ]
         [ mainItems
-            |> List.map (\item -> li [] [ button [] [ text item ] ])
+            |> List.map (\item -> li [] [ button [ Events.onClick (select item) ] [ text item ] ])
             |> ul []
         , case isPopupExtended of
             False ->
@@ -235,7 +239,7 @@ viewPopup isPopupExtended items =
             True ->
                 div []
                     [ moreItems
-                        |> List.map (\item -> li [] [ button [] [ text item ] ])
+                        |> List.map (\item -> li [] [ button [ Events.onClick (select item) ] [ text item ] ])
                         |> ul []
                     , button
                         [ Events.custom "click" (Decode.map preventDefault (Decode.succeed TogglePopupState))

--- a/app/javascript/elm/src/MobileSessionsFilters.elm
+++ b/app/javascript/elm/src/MobileSessionsFilters.elm
@@ -150,7 +150,7 @@ update msg model =
                     ( model, Cmd.none )
 
         SelectParameter parameter ->
-            ( { model | selectedParameter = parameter }, Cmd.none )
+            ( { model | selectedParameter = parameter }, Ports.selectParameter parameter )
 
 
 updateLabels :

--- a/app/javascript/elm/src/Popup.elm
+++ b/app/javascript/elm/src/Popup.elm
@@ -1,0 +1,71 @@
+module Popup exposing (Items, Popup(..), clickWithoutDefault, viewPopup)
+
+import Html exposing (Html, button, div, li, text, ul)
+import Html.Attributes as Attr
+import Html.Events as Events
+import Json.Decode as Decode
+
+
+type Popup
+    = SelectFromItems Items
+    | None
+
+
+type alias Items =
+    { main : List String
+    , other : Maybe (List String)
+    }
+
+
+viewPopup : msg -> (String -> msg) -> Bool -> Popup -> Html msg
+viewPopup toggle onSelect isPopupExtended popup =
+    case popup of
+        SelectFromItems items ->
+            div [ Attr.id "popup" ]
+                [ selectableItems items.main onSelect
+                , case items.other of
+                    Just moreItems ->
+                        if isPopupExtended then
+                            div []
+                                [ selectableItems moreItems onSelect
+                                , togglePopupStateButton "less parameters" toggle
+                                ]
+
+                        else
+                            togglePopupStateButton "more parameters" toggle
+
+                    Nothing ->
+                        text ""
+                ]
+
+        None ->
+            text ""
+
+
+togglePopupStateButton : String -> msg -> Html msg
+togglePopupStateButton name toggle =
+    button
+        [ Attr.id "toggle-popup-button"
+        , clickWithoutDefault toggle
+        ]
+        [ text name ]
+
+
+selectableItems : List String -> (String -> msg) -> Html msg
+selectableItems items onSelect =
+    items
+        |> List.map (\item -> li [] [ button [ Events.onClick (onSelect item) ] [ text item ] ])
+        |> ul []
+
+
+clickWithoutDefault : msg -> Html.Attribute msg
+clickWithoutDefault msg =
+    Events.custom "click" (Decode.map preventDefault (Decode.succeed msg))
+
+
+preventDefault : msg -> { message : msg, stopPropagation : Bool, preventDefault : Bool }
+preventDefault msg =
+    { message = msg
+    , stopPropagation = True
+    , preventDefault = True
+    }

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -2,6 +2,7 @@ port module Ports exposing
     ( findLocation
     , locationCleared
     , profileSelected
+    , selectParameter
     , showCopyLinkTooltip
     , tagSelected
     , timeRangeSelected
@@ -42,3 +43,6 @@ port showCopyLinkTooltip : () -> Cmd a
 
 
 port findLocation : String -> Cmd a
+
+
+port selectParameter : String -> Cmd a

--- a/app/javascript/elm/tests/MobileSessionsFiltersTests.elm
+++ b/app/javascript/elm/tests/MobileSessionsFiltersTests.elm
@@ -38,7 +38,7 @@ popups =
                                 (\item -> Slc.containing [ Slc.text item ])
                 in
                 items
-                    |> viewPopup False
+                    |> viewPopup SelectParameter False
                     |> Query.fromHtml
                     |> Query.has [ Slc.all itemsHtml ]
         , fuzz string "popup shows only 4 main items when not extended" <|
@@ -48,14 +48,14 @@ popups =
                         List.map (\index -> itemBase ++ String.fromInt index) (List.range 1 5)
                 in
                 items
-                    |> viewPopup False
+                    |> viewPopup SelectParameter False
                     |> Query.fromHtml
                     |> Query.findAll [ Slc.tag "li" ]
                     |> Query.count (Expect.equal 4)
         , test "popup has a button that triggers TogglePopupState" <|
             \_ ->
                 []
-                    |> viewPopup False
+                    |> viewPopup SelectParameter False
                     |> Query.fromHtml
                     |> Query.find [ Slc.tag "button" ]
                     |> Event.simulate Event.click
@@ -74,10 +74,18 @@ popups =
                         List.map (\index -> itemBase ++ String.fromInt index) (List.range 1 5)
                 in
                 items
-                    |> viewPopup True
+                    |> viewPopup SelectParameter True
                     |> Query.fromHtml
                     |> Query.findAll [ Slc.tag "li" ]
                     |> Query.count (Expect.equal 5)
+        , test "clicking on an item executed select function" <|
+            \_ ->
+                [ "item" ]
+                    |> viewPopup SelectParameter False
+                    |> Query.fromHtml
+                    |> Query.find [ Slc.tag "button", Slc.containing [ Slc.text "item" ] ]
+                    |> Event.simulate Event.click
+                    |> Event.expect (SelectParameter "item")
         ]
 
 

--- a/app/javascript/elm/tests/MobileSessionsFiltersTests.elm
+++ b/app/javascript/elm/tests/MobileSessionsFiltersTests.elm
@@ -1,4 +1,4 @@
-module MobileSessionsFiltersTests exposing (crowdMapArea, locationFilter, profilesArea, tagsArea, timeFilter)
+module MobileSessionsFiltersTests exposing (crowdMapArea, locationFilter, parameterSensorFilter, popups, profilesArea, tagsArea, timeFilter)
 
 import Expect
 import Fuzz exposing (bool, int, list, string)
@@ -13,6 +13,46 @@ import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Slc
 import TimeRange
+
+
+popups : Test
+popups =
+    test "when ClosePopup is triggered the popup is hidden" <|
+        \_ ->
+            { defaultModel | popup = ParametersList }
+                |> update ClosePopup
+                |> Tuple.first
+                |> view
+                |> Query.fromHtml
+                |> Query.hasNot [ Slc.id "parameters-list" ]
+
+
+parameterSensorFilter : Test
+parameterSensorFilter =
+    describe "Parameter filter tests: "
+        [ test "parameter filter is present" <|
+            \_ ->
+                defaultModel
+                    |> view
+                    |> Query.fromHtml
+                    |> Query.has [ Slc.id "parameter-filter" ]
+        , test "Clicking on parameter filter triggers ShowParametersList" <|
+            \_ ->
+                defaultModel
+                    |> view
+                    |> Query.fromHtml
+                    |> Query.find [ Slc.id "parameter-filter" ]
+                    |> Event.simulate Event.click
+                    |> Event.expect ShowParametersList
+        , test "when ShowParametersList is triggered parameters-list is shown" <|
+            \_ ->
+                defaultModel
+                    |> update ShowParametersList
+                    |> Tuple.first
+                    |> view
+                    |> Query.fromHtml
+                    |> Query.has [ Slc.id "parameters-list" ]
+        ]
 
 
 locationFilter : Test

--- a/app/javascript/elm/tests/MobileSessionsFiltersTests.elm
+++ b/app/javascript/elm/tests/MobileSessionsFiltersTests.elm
@@ -84,12 +84,13 @@ popups =
 parameterSensorFilter : Test
 parameterSensorFilter =
     describe "Parameter filter tests: "
-        [ test "parameter filter is present" <|
-            \_ ->
-                defaultModel
+        [ fuzz string "parameter filter shows the selected parameter" <|
+            \parameter ->
+                { defaultModel | selectedParameter = parameter }
                     |> view
                     |> Query.fromHtml
-                    |> Query.has [ Slc.id "parameter-filter" ]
+                    |> Query.find [ Slc.id "parameter-filter" ]
+                    |> Query.has [ Slc.attribute <| Attr.value parameter ]
         , test "Clicking on parameter filter triggers ShowSelectFormItemsPopup" <|
             \_ ->
                 defaultModel

--- a/app/javascript/elm/tests/MobileSessionsFiltersTests.elm
+++ b/app/javascript/elm/tests/MobileSessionsFiltersTests.elm
@@ -78,7 +78,7 @@ popups =
                     |> Query.fromHtml
                     |> Query.findAll [ Slc.tag "li" ]
                     |> Query.count (Expect.equal 5)
-        , test "clicking on an item executed select function" <|
+        , test "clicking on an item executes select function" <|
             \_ ->
                 [ "item" ]
                     |> viewPopup SelectParameter False

--- a/app/javascript/elm/tests/PopupTests.elm
+++ b/app/javascript/elm/tests/PopupTests.elm
@@ -1,0 +1,71 @@
+module PopupTests exposing (popups)
+
+import Expect
+import Fuzz exposing (list, string)
+import Html exposing (text)
+import Popup exposing (..)
+import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Slc
+
+
+type Msg
+    = Toggle
+    | Select String
+
+
+popups : Test
+popups =
+    describe "Popup tests: "
+        [ fuzz (list string) "popup shows main items" <|
+            \items ->
+                let
+                    itemsHtml =
+                        List.map (\item -> Slc.containing [ Slc.text item ]) items
+                in
+                Popup.SelectFromItems { main = items, other = Nothing }
+                    |> viewPopup Toggle Select False
+                    |> Query.fromHtml
+                    |> Query.has [ Slc.all itemsHtml ]
+        , fuzz2 (list string) (list string) "popup shows only main items when not extended" <|
+            \mainItems otherItems ->
+                Popup.SelectFromItems { main = mainItems, other = Just otherItems }
+                    |> viewPopup Toggle Select False
+                    |> Query.fromHtml
+                    |> Query.findAll [ Slc.tag "li" ]
+                    |> Query.count (Expect.equal (List.length mainItems))
+        , test "if there are no other items popup doesn't have a toggle popup button" <|
+            \_ ->
+                Popup.SelectFromItems { main = [], other = Nothing }
+                    |> viewPopup Toggle Select False
+                    |> Query.fromHtml
+                    |> Query.hasNot [ Slc.id "toggle-popup-button" ]
+        , test "if there are other items popup has a button that triggers TogglePopupState" <|
+            \_ ->
+                Popup.SelectFromItems { main = [], other = Just [ "item" ] }
+                    |> viewPopup Toggle Select False
+                    |> Query.fromHtml
+                    |> Query.find [ Slc.id "toggle-popup-button" ]
+                    |> Event.simulate Event.click
+                    |> Event.expect Toggle
+        , fuzz2 (list string) (list string) "popup shows all items when extended" <|
+            \mainItems otherItems ->
+                let
+                    numberOfItems =
+                        List.length mainItems + List.length otherItems
+                in
+                Popup.SelectFromItems { main = mainItems, other = Just otherItems }
+                    |> viewPopup Toggle Select True
+                    |> Query.fromHtml
+                    |> Query.findAll [ Slc.tag "li" ]
+                    |> Query.count (Expect.equal numberOfItems)
+        , test "clicking on an item executes select function" <|
+            \_ ->
+                Popup.SelectFromItems { main = [ "item" ], other = Nothing }
+                    |> viewPopup Toggle Select False
+                    |> Query.fromHtml
+                    |> Query.find [ Slc.tag "button", Slc.containing [ Slc.text "item" ] ]
+                    |> Event.simulate Event.click
+                    |> Event.expect (Select "item")
+        ]

--- a/app/views/layouts/map.html.haml
+++ b/app/views/layouts/map.html.haml
@@ -12,7 +12,7 @@
     = render :partial => 'shared/analytics'
     = render :partial => 'shared/fb_logo'
 
-  %body(id="map" data-version="1.0.22")
+  %body(id="map" data-version="1.0.23")
     .notice(ng-controller="FlashCtrl" ng-cloak ng-show="flash.message" ng-click="clear()") {{flash.message}}
     #mapview(ng-controller="MapCtrl" googlemap="")
     #hud(ng-controller="HudCtrl" ng-cloak ng-hide="map.streetViewVisible()")

--- a/public/partials/fixed_sessions_map.html
+++ b/public/partials/fixed_sessions_map.html
@@ -7,10 +7,6 @@
       <h4 ng-click="expandables.toggle('sensor')" ng-class="expandables.css('sensor')">Parameter - Sensor</h4>
       <section ng-show="expandables.visible('sensor')" >
       <p>
-        <label for="parameters-dropdown" class="visuallyhidden">Parameter</label>
-        <select id="parameters-dropdown" ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id"></select>
-      </p>
-      <p>
         <label for="sensors-dropdown" class="visuallyhidden">Sensor</label>
         <select id="sensors-dropdown" ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for sensor in sensors.availableSensors"></select>
       </p>

--- a/public/partials/mobile_sessions_map.html
+++ b/public/partials/mobile_sessions_map.html
@@ -7,10 +7,6 @@
       <h4 ng-click="expandables.toggle('sensor')" ng-class="expandables.css('sensor')">Parameter - Sensor</h4>
       <section ng-show="expandables.visible('sensor')" >
       <p>
-        <label for="mobile-parameters-dropdown" class="visuallyhidden">Parameter</label>
-        <select id="mobile-parameters-dropdown" ng-model="sensors.selectedParameter" ng-options="parameter as parameter.label for parameter in sensors.availableParameters track by parameter.id"></select>
-      </p>
-      <p>
         <label for="mobile-sensors-dropdown" class="visuallyhidden">Sensor</label>
         <select id="mobile-sensors-dropdown" ng-model="params.get('data').sensorId" ng-options="sensor.id as sensor.select_label for sensor in sensors.availableSensors"></select>
       </p>


### PR DESCRIPTION
I still need to apply this to fixed, but I wanted to get your opinion first, cause it's already a bit complex.

This is the version with popups. The one with dropdown is very the same in logic, just has different views, we can deploy it first if we are not yet able to use this one. I'll push it on a separate branch.


**UPDATE**
I extracted the popup to a separate module and applied the changes to the fixed tab. But I couldn't figure out an easy way to move `isPopupExtended` flag with that module, unless not without complex abstractions. I think I'll move to sensors filter now and then see if something will be clearer then.
