### PR TITLE
Single session info

### DIFF
--- a/app/controllers/api/fixed/sessions_controller.rb
+++ b/app/controllers/api/fixed/sessions_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  class Fixed::SessionsController < BaseController
+    respond_to :json
+
+    def show
+      form = Api::ParamsForm.new(params: params, schema: Api::Session::Schema, struct: Api::Session::Struct)
+      result = Api::ToSessionHash.new(model: FixedSession).call(form: form)
+
+      if result.success?
+        render json: result.value, status: :ok
+      else
+        render json: result.errors, status: :bad_request
+      end
+    end
+  end
+end

--- a/app/controllers/api/mobile/sessions_controller.rb
+++ b/app/controllers/api/mobile/sessions_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  class Mobile::SessionsController < BaseController
+    respond_to :json
+
+    def show
+      form = Api::ParamsForm.new(params: params, schema: Api::Session::Schema, struct: Api::Session::Struct)
+      result = Api::ToSessionHash.new(model: MobileSession).call(form: form)
+
+      if result.success?
+        render json: result.value, status: :ok
+      else
+        render json: result.errors, status: :bad_request
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/data/sessions_controller.rb
+++ b/app/controllers/api/v2/data/sessions_controller.rb
@@ -3,7 +3,7 @@ module Api
     module Data
       class SessionsController < ActionController::Base
         def last
-          render json: IdSerializer.new(Session.last)
+          render json: IdSerializer.new(::Session.last)
         end
       end
     end

--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -132,4 +132,4 @@ export const SessionsListCtrl = (
 }
 
 const formatSessionForElm = s =>
-  ({ ...s , shortTypes: s.shortTypes.map(({ name, type }) => ({ name, type_: type })) });
+  ({ ...s , timeRange: s.timeframe, shortTypes: s.shortTypes.map(({ name, type }) => ({ name, type_: type })) });

--- a/app/javascript/elm/src/Data/Page.elm
+++ b/app/javascript/elm/src/Data/Page.elm
@@ -1,0 +1,6 @@
+module Data.Page exposing (Page(..))
+
+
+type Page
+    = Fixed
+    | Mobile

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -1,0 +1,78 @@
+module Data.SelectedSession exposing (SelectedSession, decoder, fetch, sensorNameFromId, view)
+
+import Data.Page exposing (Page(..))
+import Html exposing (Html, div, p, text)
+import Html.Attributes as Attr
+import Http
+import Json.Decode as Decode exposing (Decoder(..))
+import RemoteData exposing (RemoteData(..), WebData)
+
+
+type alias SelectedSession =
+    { title : String
+    , username : String
+    , sensorName : String
+    , average : Float
+    , min : Float
+    , max : Float
+    , timeRange : String
+    , measurements : List Float
+    , id : Int
+    }
+
+
+decoder : Decoder SelectedSession
+decoder =
+    Decode.map7 toSelectedSession
+        (Decode.field "title" Decode.string)
+        (Decode.field "username" Decode.string)
+        (Decode.field "sensor_name" Decode.string)
+        (Decode.field "average" (Decode.nullable Decode.float) |> Decode.map (Maybe.withDefault -1))
+        (Decode.field "timeRange" Decode.string)
+        (Decode.field "measurements" (Decode.list Decode.float))
+        (Decode.field "id" Decode.int)
+
+
+toSelectedSession : String -> String -> String -> Float -> String -> List Float -> Int -> SelectedSession
+toSelectedSession title username sensorName average timeRange measurements sessionId =
+    { title = title
+    , username = username
+    , sensorName = sensorName
+    , average = average
+    , min = List.minimum measurements |> Maybe.withDefault -1
+    , max = List.maximum measurements |> Maybe.withDefault -1
+    , timeRange = timeRange
+    , measurements = measurements
+    , id = sessionId
+    }
+
+
+sensorNameFromId : String -> String
+sensorNameFromId =
+    String.split "-" >> List.drop 1 >> String.join "-" >> String.split " " >> List.head >> Maybe.withDefault ""
+
+
+fetch : String -> Page -> Int -> (WebData SelectedSession -> msg) -> Cmd msg
+fetch sensorId page id toMsg =
+    Http.get
+        { url =
+            if page == Mobile then
+                "/api/mobile/sessions/" ++ String.fromInt id ++ ".json?sensor_name=" ++ sensorNameFromId sensorId
+
+            else
+                "/api/fixed/sessions/" ++ String.fromInt id ++ ".json?sensor_name=" ++ sensorNameFromId sensorId
+        , expect = Http.expectJson (RemoteData.fromResult >> toMsg) decoder
+        }
+
+
+view : SelectedSession -> Html msg
+view session =
+    div []
+        [ p [ Attr.class "single-session-TODO" ] [ text session.title ]
+        , p [ Attr.class "single-session-TODO" ] [ text session.username ]
+        , p [ Attr.class "single-session-TODO" ] [ text session.sensorName ]
+        , p [ Attr.class "single-session-TODO" ] [ text <| String.fromFloat session.min ]
+        , p [ Attr.class "single-session-TODO" ] [ text <| String.fromFloat session.max ]
+        , p [ Attr.class "single-session-TODO" ] [ text <| String.fromFloat session.average ]
+        , p [ Attr.class "single-session-TODO" ] [ text session.timeRange ]
+        ]

--- a/app/javascript/elm/src/Data/Session.elm
+++ b/app/javascript/elm/src/Data/Session.elm
@@ -10,7 +10,7 @@ type alias ShortType =
 type alias Session =
     { title : String
     , id : Int
-    , timeframe : String
+    , timeRange : String
     , username : String
     , shortTypes : List ShortType
     }

--- a/app/javascript/elm/tests/Data/SelectedSessionTests.elm
+++ b/app/javascript/elm/tests/Data/SelectedSessionTests.elm
@@ -1,0 +1,25 @@
+module Data.SelectedSessionTests exposing (suite)
+
+import Data.SelectedSession exposing (sensorNameFromId)
+import Expect
+import Fuzz exposing (int, list, string)
+import Json.Encode as Encode
+import Sensor exposing (..)
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    describe "Data.SelectedSession"
+        [ test "sensorNameFromId" <|
+            \_ ->
+                let
+                    id =
+                        "particulate matter-airbeam2-pm2.5 (µg/m3)"
+
+                    expected =
+                        "airbeam2-pm2.5"
+                in
+                sensorNameFromId id
+                    |> Expect.equal expected
+        ]

--- a/app/models/api/session.rb
+++ b/app/models/api/session.rb
@@ -1,0 +1,20 @@
+require 'dry-validation'
+require 'dry-struct'
+
+module Api::Session
+  module Types
+    include Dry::Types.module
+  end
+
+  Schema = Dry::Validation.Schema do
+    required(:id).filled(:str?)
+    required(:sensor_name).filled(:str?)
+  end
+
+  class Struct < Dry::Struct
+    transform_keys(&:to_sym)
+
+    attribute :id, Types::Coercible::Integer
+    attribute :sensor_name, Types::Strict::String
+  end
+end

--- a/app/services/api/calculate_fixed_region_info.rb
+++ b/app/services/api/calculate_fixed_region_info.rb
@@ -1,6 +1,6 @@
 class Api::CalculateFixedRegionInfo
   def call(form)
-    return Failure.new(form.errors) if form.invalid? 
+    return Failure.new(form.errors) if form.invalid?
 
     Success.new(FixedRegionInfo.new.call(form.to_h))
   end

--- a/app/services/api/form.rb
+++ b/app/services/api/form.rb
@@ -1,6 +1,5 @@
 class Api::Form
-  def initialize(json:, schema:, struct:)
-    @json = json || "{}"
+  def initialize(schema:, struct:)
     @schema = schema
     @struct = struct
     @errors = []
@@ -26,14 +25,12 @@ class Api::Form
 
   private
 
-  def params
-    @params ||= ActiveSupport::JSON.decode(@json).symbolize_keys
-  rescue JSON::ParserError
-    raise Errors::Api::CouldNotParseJsonParams
+  def parsed_params
+    raise NotImplementedError
   end
 
   def validated_params
-    @validated_params ||= @schema.call(params)
+    @validated_params ||= @schema.call(parsed_params)
   end
 
   def validation_errors

--- a/app/services/api/json_form.rb
+++ b/app/services/api/json_form.rb
@@ -1,0 +1,14 @@
+class Api::JsonForm < Api::Form
+  def initialize(json:, schema:, struct:)
+    @json = json || "{}"
+    super(schema: schema, struct: struct)
+  end
+
+  private
+
+  def parsed_params
+    @parsed_params ||= ActiveSupport::JSON.decode(@json).symbolize_keys
+  rescue JSON::ParserError
+    raise Errors::Api::CouldNotParseJsonParams
+  end
+end

--- a/app/services/api/params_form.rb
+++ b/app/services/api/params_form.rb
@@ -1,0 +1,12 @@
+class Api::ParamsForm < Api::Form
+  def initialize(params:, schema:, struct:)
+    @params = params
+    super(schema: schema, struct: struct)
+  end
+
+  private
+
+  def parsed_params
+    @params
+  end
+end

--- a/app/services/api/to_session_hash.rb
+++ b/app/services/api/to_session_hash.rb
@@ -1,0 +1,31 @@
+class Api::ToSessionHash
+  def initialize(model:)
+    @model = model
+  end
+
+  def call(form:)
+    return Failure.new(form.errors) if form.invalid?
+
+    session = @model
+      .includes(streams: [:measurements])
+      .where(id: form.to_h[:id], streams: { sensor_name: form.to_h[:sensor_name]})
+      .first!
+
+    Success.new(
+      title: session.title,
+      username: session.user.username,
+      sensor_name: session.streams.first.sensor_name,
+      average: session.streams.first.average_value,
+      measurements: session.streams.first.measurements.map(&:value),
+      timeRange: "#{format_datetime(session.start_time_local)} - #{format_datetime(session.end_time_local)}",
+      id: session.id,
+    )
+  end
+
+  private
+
+  def format_datetime(datetime)
+    datetime.strftime("%d.%m.%Y %H:%M")
+  end
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,14 @@ Rails.application.routes.draw do
       resources :measurements, only: :create
     end
 
+    namespace :fixed do
+      get "sessions/:id" => "sessions#show"
+    end
+
+    namespace :mobile do
+      get "sessions/:id" => "sessions#show"
+    end
+
     resources :short_url, only: [:index]
   end
 

--- a/config/webpack/loaders/elm.js
+++ b/config/webpack/loaders/elm.js
@@ -13,7 +13,9 @@ const elmDefaultOptions = {
 }
 const developmentOptions = Object.assign({}, elmDefaultOptions, {
   verbose: true,
-  debug: true
+  // when running the app in debug mode decoding a long list crashes the app
+  // that happens for example when receiving all measurements for a selected session
+  debug: false
 })
 const productionOptions = Object.assign({}, elmDefaultOptions, {
   optimize: true

--- a/elm.json
+++ b/elm.json
@@ -16,7 +16,8 @@
             "elm/url": "1.0.0",
             "elm-community/html-extra": "3.1.0",
             "elm-community/maybe-extra": "5.0.0",
-            "fapian/elm-html-aria": "1.4.0"
+            "fapian/elm-html-aria": "1.4.0",
+            "krisajenkins/remotedata": "6.0.1"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/spec/controllers/api/fixed/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/sessions_controller_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+describe Api::Fixed::SessionsController do
+  describe "#show" do
+    it "returns session json" do
+      username = "username"
+      title = "session title"
+      start_time_local = DateTime.new(2000, 10, 1, 2, 3)
+      end_time_local = DateTime.new(2001, 11, 4, 5, 6)
+      sensor_name = "sensor-name"
+      average = value = 123
+      user = create_user!(username: username)
+      session = create_fixed_session!(user: user, title: title, start_time_local: start_time_local, end_time_local: end_time_local)
+      create_stream!(session: session, sensor_name: "another-sensor-name", average_value: average)
+      stream = create_stream!(session: session, sensor_name: sensor_name, average_value: average)
+      create_stream!(session: session, sensor_name: "yet another-sensor-name", average_value: average)
+      create_measurement!(stream: stream, sensor_name: sensor_name, value: value)
+
+      get :show, id: session.id, sensor_name: sensor_name
+
+      expected = {
+        "title" => title,
+        "username" => username,
+        "sensor_name" => sensor_name,
+        "average" => average.to_f,
+        "measurements" => [value.to_f],
+        "timeRange" => "01.10.2000 02:03 - 04.11.2001 05:06",
+        "id" => session.id,
+      }
+      expect(json_response).to eq(expected)
+    end
+  end
+
+  private
+
+  def create_user!(username:)
+    User.create!(
+      username: username,
+      email: "email@example.com",
+      password: "password"
+    )
+  end
+
+  def create_fixed_session!(user:, title:, start_time_local:, end_time_local:)
+    FixedSession.create!(
+      title: title,
+      user: user,
+      uuid: SecureRandom.uuid,
+      calibration: 100,
+      offset_60_db: 0,
+      start_time: DateTime.current,
+      start_time_local: start_time_local,
+      end_time: DateTime.current,
+      end_time_local: end_time_local,
+      is_indoor: false,
+      latitude: 123,
+      longitude: 123
+    )
+  end
+
+  def create_stream!(session:, sensor_name:, average_value:)
+    Stream.create!(
+      sensor_package_name: "abc",
+      sensor_name: sensor_name,
+      measurement_type: "abc",
+      average_value: average_value,
+      unit_name: "abc",
+      session: session,
+      measurement_short_type: "dB",
+      unit_symbol: "dB",
+      threshold_very_low: 20,
+      threshold_low: 60,
+      threshold_medium: 70,
+      threshold_high: 80,
+      threshold_very_high: 100
+    )
+  end
+
+  def create_measurement!(stream:, sensor_name:, value:)
+    Measurement.create!(
+      time: DateTime.current,
+      latitude: 123,
+      longitude: 123,
+      value: 123,
+      milliseconds: 123,
+      stream: stream
+    )
+  end
+end

--- a/spec/controllers/api/mobile/sessions_controller_spec.rb
+++ b/spec/controllers/api/mobile/sessions_controller_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+describe Api::Mobile::SessionsController do
+  describe "#show" do
+    it "returns session json" do
+      username = "username"
+      title = "session title"
+      start_time_local = DateTime.new(2000, 10, 1, 2, 3)
+      end_time_local = DateTime.new(2001, 11, 4, 5, 6)
+      sensor_name = "sensor-name"
+      average = value = 123
+      user = create_user!(username: username)
+      session = create_mobile_session!(user: user, title: title, start_time_local: start_time_local, end_time_local: end_time_local)
+      create_stream!(session: session, sensor_name: "another-sensor-name", average_value: average)
+      stream = create_stream!(session: session, sensor_name: sensor_name, average_value: average)
+      create_stream!(session: session, sensor_name: "yet another-sensor-name", average_value: average)
+      create_measurement!(stream: stream, sensor_name: sensor_name, value: value)
+
+      get :show, id: session.id, sensor_name: sensor_name
+
+      expected = {
+        "title" => title,
+        "username" => username,
+        "sensor_name" => sensor_name,
+        "average" => average.to_f,
+        "measurements" => [value.to_f],
+        "timeRange" => "01.10.2000 02:03 - 04.11.2001 05:06",
+        "id" => session.id,
+      }
+      expect(json_response).to eq(expected)
+    end
+  end
+
+  private
+
+  def create_user!(username:)
+    User.create!(
+      username: username,
+      email: "email@example.com",
+      password: "password"
+    )
+  end
+
+  def create_mobile_session!(user:, title:, start_time_local:, end_time_local:)
+    MobileSession.create!(
+      title: title,
+      user: user,
+      uuid: SecureRandom.uuid,
+      calibration: 100,
+      offset_60_db: 0,
+      start_time: DateTime.current,
+      start_time_local: start_time_local,
+      end_time: DateTime.current,
+      end_time_local: end_time_local,
+    )
+  end
+
+  def create_stream!(session:, sensor_name:, average_value:)
+    Stream.create!(
+      sensor_package_name: "abc",
+      sensor_name: sensor_name,
+      measurement_type: "abc",
+      average_value: average_value,
+      unit_name: "abc",
+      session: session,
+      measurement_short_type: "dB",
+      unit_symbol: "dB",
+      threshold_very_low: 20,
+      threshold_low: 60,
+      threshold_medium: 70,
+      threshold_high: 80,
+      threshold_very_high: 100
+    )
+  end
+
+  def create_measurement!(stream:, sensor_name:, value:)
+    Measurement.create!(
+      time: DateTime.current,
+      latitude: 123,
+      longitude: 123,
+      value: 123,
+      milliseconds: 123,
+      stream: stream
+    )
+  end
+end

--- a/spec/controllers/api/v2/data/sessions_controller_spec.rb
+++ b/spec/controllers/api/v2/data/sessions_controller_spec.rb
@@ -1,14 +1,12 @@
 require 'rails_helper'
 
 describe Api::V2::Data::SessionsController do
-  describe "GET 'last'" do
-    before do
+  describe "GET last" do
+    it 'returns id' do
       FactoryGirl.create(:mobile_session)
 
       get :last
-    end
 
-    it 'returns id' do
       expect(json_response).to have_key('id')
     end
   end

--- a/spec/services/api/form_spec.rb
+++ b/spec/services/api/form_spec.rb
@@ -16,29 +16,15 @@ module Test
   end
 end
 
-describe Api::Form do
-  context "when json is invalid" do
-    it "raises" do
-      expect do
-        json = "{"
-        schema = Test::Schema
-        struct = Test::Struct
-
-        form = Api::Form.new(json: json, schema: schema, struct: struct)
-
-        form.invalid?
-      end.to raise_error(Errors::Api::CouldNotParseJsonParams)
-    end
-  end
-
+describe Api::ParamsForm do
   describe "#invalid?" do
     context "when required param is missing" do
       it "returns true" do
-        json = "{}"
+        params = {}
         schema = Test::Schema
         struct = Test::Struct
 
-        form = Api::Form.new(json: json, schema: schema, struct: struct)
+        form = Api::ParamsForm.new(params: params, schema: schema, struct: struct)
 
         expect(form.invalid?).to eq(true)
       end
@@ -46,11 +32,11 @@ describe Api::Form do
 
     context "when required param is present" do
       it "returns true" do
-        json = "{\"name\":\"name\"}"
+        params = { "name": "name" }
         schema = Test::Schema
         struct = Test::Struct
 
-        form = Api::Form.new(json: json, schema: schema, struct: struct)
+        form = Api::ParamsForm.new(params: params, schema: schema, struct: struct)
 
         expect(form.invalid?).to eq(false)
       end
@@ -60,11 +46,11 @@ describe Api::Form do
   describe "#errors" do
     context "when required param is missing" do
       it "returns proper errors" do
-        json = "{}"
+        params = {}
         schema = Test::Schema
         struct = Test::Struct
 
-        form = Api::Form.new(json: json, schema: schema, struct: struct)
+        form = Api::ParamsForm.new(params: params, schema: schema, struct: struct)
 
         expect(form.errors).to eq([ "name is missing" ])
       end
@@ -72,11 +58,11 @@ describe Api::Form do
 
     context "required param is present" do
       it "returns no errors" do
-        json = "{\"name\":\"name\"}"
+        params = { "name": "name" }
         schema = Test::Schema
         struct = Test::Struct
 
-        form = Api::Form.new(json: json, schema: schema, struct: struct)
+        form = Api::ParamsForm.new(params: params, schema: schema, struct: struct)
 
         expect(form.errors).to eq([])
       end
@@ -86,11 +72,11 @@ describe Api::Form do
   describe "#to_h" do
     context "required param is present" do
       it "returns no errors" do
-        json = "{\"name\":\"name\"}"
+        params = { "name": "name" }
         schema = Test::Schema
         struct = Test::Struct
 
-        form = Api::Form.new(json: json, schema: schema, struct: struct)
+        form = Api::ParamsForm.new(params: params, schema: schema, struct: struct)
 
         expect(form.to_h).to eq(Test::Struct.new(name: "name"))
       end
@@ -99,14 +85,30 @@ describe Api::Form do
 
   describe "#add_error" do
     it "adds errors to the form" do
-      json = "{}"
+      params = {}
       schema = Test::Schema
       struct = Test::Struct
 
-      form = Api::Form.new(json: json, schema: schema, struct: struct)
+      form = Api::ParamsForm.new(params: params, schema: schema, struct: struct)
       form.add_error("added error")
 
       expect(form.errors).to eq([ "name is missing", "added error" ])
+    end
+  end
+end
+
+describe Api::JsonForm do
+  context "when json is invalid" do
+    it "raises" do
+      expect do
+        json = "{"
+        schema = Test::Schema
+        struct = Test::Struct
+
+        form = Api::JsonForm.new(json: json, schema: schema, struct: struct)
+
+        form.invalid?
+      end.to raise_error(Errors::Api::CouldNotParseJsonParams)
     end
   end
 end


### PR DESCRIPTION
Sorry for the size of the PR. I guess you can review backend and frontend separately.

This PR adds the session details to the left of the graph when a session is selected. See below

![Screen Shot 2019-04-10 at 12 39 26](https://user-images.githubusercontent.com/5238698/55872622-ba8f9880-5b8d-11e9-90f2-46291b028a21.png)
