### PR TITLE
feat(sensors): select default when parameter changes

### DIFF
--- a/app/javascript/elm/src/Sensor.elm
+++ b/app/javascript/elm/src/Sensor.elm
@@ -14,6 +14,49 @@ import Json.Encode as Encode
 import Set
 
 
+defaultSensorId : String
+defaultSensorId =
+    "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
+
+
+defaultSensorIdByParameter : Dict.Dict String String
+defaultSensorIdByParameter =
+    Dict.fromList
+        [ ( "Particulate Matter", defaultSensorId )
+        , ( "Humidity", "Humidity-airbeam2-rh (%)" )
+        , ( "Sound Level", "Sound Level-phone microphone (dB)" )
+        , ( "Temperature", "Temperature-airbeam2-f (F)" )
+        ]
+
+
+mainSensors : Dict.Dict String (List String)
+mainSensors =
+    Dict.fromList
+        [ ( "Particulate Matter"
+          , [ "AirBeam2-PM2.5 (µg/m³)"
+            , "AirBeam2-PM1 (µg/m³)"
+            , "AirBeam2-PM10 (µg/m³)"
+            , "AirBeam-PM (µg/m³)"
+            ]
+          )
+        , ( "Humidity", [ "AirBeam2-RH (%)", "AirBeam-RH (%)" ] )
+        , ( "Temperature", [ "AirBeam2-F (F)", "AirBeam-F (F)" ] )
+        , ( "Sound Level", [ "Phone Microphone (dB)" ] )
+        ]
+
+
+
+{-
+   { id_ = "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
+   , label = "AirBeam2-PM2.5 (µg/m³)"
+   , parameter = "Particulate Matter"
+   , sensor = "AirBeam2-PM2.5"
+   , session_count = 24
+   , unit = "µg/m³"
+   }
+-}
+
+
 type alias Sensor =
     { id_ : String
     , sensor : String
@@ -103,34 +146,41 @@ labelsForParameter sensors sensorId =
 
 
 idForParameterOrLabel : String -> String -> List Sensor -> String
-idForParameterOrLabel key oldSensorId sensors =
-    sensors
-        |> List.filter (\sensor -> sensor.parameter == key)
-        |> List.sortBy .session_count
-        |> List.reverse
-        |> List.head
-        |> Maybe.map .id_
-        |> Maybe.withDefault
-            (sensors
-                |> List.filter (\sensor -> sensor.label == key && sensor.parameter == parameterForId sensors oldSensorId)
+idForParameterOrLabel parameterOrLabel oldSensorId sensors =
+    let
+        byId id =
+            sensors
+                |> List.filter (\sensor -> sensor.id_ == id)
                 |> List.head
                 |> Maybe.map .id_
-                |> Maybe.withDefault
-                    "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
-            )
 
+        maybeDefault =
+            Dict.get parameterOrLabel defaultSensorIdByParameter
+                |> Maybe.andThen byId
 
-mainSensors : Dict.Dict String (List String)
-mainSensors =
-    Dict.fromList
-        [ ( "Particulate Matter"
-          , [ "AirBeam2-PM2.5 (µg/m³)"
-            , "AirBeam2-PM1 (µg/m³)"
-            , "AirBeam2-PM10 (µg/m³)"
-            , "AirBeam-PM (µg/m³)"
-            ]
-          )
-        , ( "Humidity", [ "AirBeam2-RH (%)", "AirBeam-RH (%)" ] )
-        , ( "Temperature", [ "AirBeam2-F (F)", "AirBeam-F (F)" ] )
-        , ( "Sound Level", [ "Phone Microphone (dB)" ] )
-        ]
+        maybeByParameter =
+            sensors
+                |> List.filter (\sensor -> sensor.parameter == parameterOrLabel)
+                |> List.sortBy .session_count
+                |> List.reverse
+                |> List.head
+                |> Maybe.map .id_
+
+        maybeByLabel =
+            sensors
+                |> List.filter (\sensor -> sensor.label == parameterOrLabel && sensor.parameter == parameterForId sensors oldSensorId)
+                |> List.head
+                |> Maybe.map .id_
+    in
+    case ( maybeDefault, maybeByParameter, maybeByLabel ) of
+        ( Just default, _, _ ) ->
+            default
+
+        ( _, Just byParameter, _ ) ->
+            byParameter
+
+        ( _, _, Just byLabel ) ->
+            byLabel
+
+        _ ->
+            defaultSensorId

--- a/app/javascript/elm/tests/SensorTests.elm
+++ b/app/javascript/elm/tests/SensorTests.elm
@@ -50,6 +50,87 @@ all =
                 sensors
                     |> idForParameterOrLabel "parameter" "parameter2-sensor3 (unit)"
                     |> Expect.equal "parameter-sensor2 (unit)"
+        , test "idForParameterOrLabel always finds airbeam2-pm2.5 for Particulate Matter" <|
+            \_ ->
+                [ { id_ = "Particulate Matter-other label (µg/m³)"
+                  , parameter = "Particulate Matter"
+                  , label = "Other Label (µg/m³)"
+                  , sensor = "Other Label"
+                  , unit = "µg/m³"
+                  , session_count = 1
+                  }
+                , { id_ = "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
+                  , parameter = "Particulate Matter"
+                  , label = "AirBeam2-PM2.5 (µg/m³)"
+                  , sensor = "AirBeam2-PM2.5"
+                  , unit = "µg/m³"
+                  , session_count = 0
+                  }
+                ]
+                    |> idForParameterOrLabel "Particulate Matter" "parameter2-sensor3 (unit)"
+                    |> Expect.equal "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
+        , test "idForParameterOrLabel always finds airbeam2-rh for Humidity" <|
+            \_ ->
+                [ { id_ = "Humidity-other label (%)"
+                  , parameter = "Humidity"
+                  , label = "Other Label (%)"
+                  , sensor = "Other Label"
+                  , unit = "%"
+                  , session_count = 1
+                  }
+                , { id_ = "Humidity-airbeam2-rh (%)"
+                  , parameter = "Humidity"
+                  , label = "AirBeam2-RH (%)"
+                  , sensor = "AirBeam2-RH"
+                  , unit = "%"
+                  , session_count = 0
+                  }
+                ]
+                    |> idForParameterOrLabel "Humidity" "parameter2-sensor3 (unit)"
+                    |> Expect.equal "Humidity-airbeam2-rh (%)"
+        , test "idForParameterOrLabel always finds phone microphone for Sound Levels" <|
+            \_ ->
+                [ { id_ = "Sound Level-other label (dB)"
+                  , parameter = "Sound Level"
+                  , label = "Other Label (dB)"
+                  , sensor = "Other Label"
+                  , unit = "dB"
+                  , session_count = 1
+                  }
+                , { id_ = "Sound Level-phone microphone (dB)"
+                  , parameter = "Sound Level"
+                  , label = "Phone Microphone (dB)"
+                  , sensor = "Phone Microphone"
+                  , unit = "dB"
+                  , session_count = 0
+                  }
+                ]
+                    |> idForParameterOrLabel "Sound Level" "parameter2-sensor3 (unit)"
+                    |> Expect.equal "Sound Level-phone microphone (dB)"
+        , test "idForParameterOrLabel always finds airbeam2-f for Temperature" <|
+            \_ ->
+                [ { id_ = "Temperature-other label (F)"
+                  , parameter = "Temperature"
+                  , label = "Other Label (F)"
+                  , sensor = "Other Label"
+                  , unit = "F"
+                  , session_count = 1
+                  }
+                , { id_ = "Temperature-airbeam2-f (F)"
+                  , parameter = "Temperature"
+                  , label = "Temperature (F)"
+                  , sensor = "Temperature"
+                  , unit = "F"
+                  , session_count = 0
+                  }
+                ]
+                    |> idForParameterOrLabel "Temperature" "parameter2-sensor3 (unit)"
+                    |> Expect.equal "Temperature-airbeam2-f (F)"
+        , test "when the default is missing idForParameterOrLabel returns airbeam2-pm2.5" <|
+            \_ ->
+                []
+                    |> idForParameterOrLabel "Temperature" "parameter2-sensor3 (unit)"
+                    |> Expect.equal "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
         , test "labelsForParameter returns labels divided into main and others" <|
             \_ ->
                 "Particulate Matter-airbeam2-pm2.5 (µg/m³)"


### PR DESCRIPTION
Up until now when selecting a parameter (eg "Particulate Matter") the app was selecting as a sensor the one with the most `session_count`. This PR changes that behaviour.

In particular, when the selected parameter is any of "Particulate Matter", "Temperature", "Sound Level" or "Humidity" we see if we can select the default airbeam2-X sensor.