### PR TITLE
Use unqualified imports from Html and Html.Attributes

### DIFF
--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -2,7 +2,7 @@ module Data.SelectedSession exposing (SelectedSession, decoder, fetch, sensorNam
 
 import Data.Page exposing (Page(..))
 import Html exposing (Html, div, p, text)
-import Html.Attributes as Attr
+import Html.Attributes exposing (class)
 import Http
 import Json.Decode as Decode exposing (Decoder(..))
 import RemoteData exposing (RemoteData(..), WebData)
@@ -71,12 +71,12 @@ fetch sensorId page id toMsg =
 view : SelectedSession -> Html msg
 view session =
     div []
-        [ p [ Attr.class "single-session-TODO" ] [ text session.title ]
-        , p [ Attr.class "single-session-TODO" ] [ text session.username ]
-        , p [ Attr.class "single-session-TODO" ] [ text session.sensorName ]
-        , p [ Attr.class "single-session-TODO" ] [ text <| String.fromFloat session.min ]
-        , p [ Attr.class "single-session-TODO" ] [ text <| String.fromFloat session.max ]
-        , p [ Attr.class "single-session-TODO" ] [ text <| String.fromInt <| round session.average ]
-        , p [ Attr.class "single-session-TODO" ] [ text session.startTime ]
-        , p [ Attr.class "single-session-TODO" ] [ text session.endTime ]
+        [ p [ class "single-session-TODO" ] [ text session.title ]
+        , p [ class "single-session-TODO" ] [ text session.username ]
+        , p [ class "single-session-TODO" ] [ text session.sensorName ]
+        , p [ class "single-session-TODO" ] [ text <| String.fromFloat session.min ]
+        , p [ class "single-session-TODO" ] [ text <| String.fromFloat session.max ]
+        , p [ class "single-session-TODO" ] [ text <| String.fromInt <| round session.average ]
+        , p [ class "single-session-TODO" ] [ text session.startTime ]
+        , p [ class "single-session-TODO" ] [ text session.endTime ]
         ]

--- a/app/javascript/elm/src/LabelsInput.elm
+++ b/app/javascript/elm/src/LabelsInput.elm
@@ -1,7 +1,7 @@
 module LabelsInput exposing (Model, Msg(..), empty, fromList, init, subscriptions, update, view, withCandidate)
 
 import Html exposing (Html, button, div, h4, input, label, text)
-import Html.Attributes as Attr
+import Html.Attributes exposing (class, disabled, for, id, name, placeholder, type_, value)
 import Html.Events as Events
 import Html.Events.Extra as ExtraEvents
 import Set exposing (Set)
@@ -69,22 +69,22 @@ update msg model toCmd =
 
 
 view : Model -> String -> String -> String -> Bool -> Html Msg
-view model text_ inputId placeholder isDisabled =
+view model text_ inputId placeholderText isDisabled =
     div []
-        [ label [ Attr.for inputId ] [ text text_ ]
-        , div [ Attr.class "tag-container" ]
+        [ label [ for inputId ] [ text text_ ]
+        , div [ class "tag-container" ]
             [ input
-                [ Attr.id inputId
-                , Attr.class "input-dark"
-                , Attr.class "input-filters"
-                , Attr.class "input-filters-tag"
-                , Attr.placeholder placeholder
-                , Attr.type_ "text"
-                , Attr.name inputId
+                [ id inputId
+                , class "input-dark"
+                , class "input-filters"
+                , class "input-filters-tag"
+                , placeholder placeholderText
+                , type_ "text"
+                , name inputId
                 , ExtraEvents.onEnter (Add <| getCandidate model)
                 , Events.onInput UpdateCandidate
-                , Attr.value <| getCandidate model
-                , Attr.disabled isDisabled
+                , value <| getCandidate model
+                , disabled isDisabled
                 ]
                 []
             , div [] (List.map viewLabel <| asList model)
@@ -94,11 +94,11 @@ view model text_ inputId placeholder isDisabled =
 
 viewLabel : String -> Html Msg
 viewLabel label =
-    div [ Attr.class "filters-tag" ]
+    div [ class "filters-tag" ]
         [ text label
         , button
-            [ Attr.id label
-            , Attr.class "filters-tag-close"
+            [ id label
+            , class "filters-tag-close"
             , Events.onClick <| Remove label
             ]
             []

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -7,8 +7,8 @@ import Data.Page exposing (Page(..))
 import Data.SelectedSession as SelectedSession exposing (SelectedSession)
 import Data.Session exposing (..)
 import Html exposing (Html, a, button, dd, div, dl, dt, form, h2, h3, img, input, label, li, main_, nav, p, span, text, ul)
-import Html.Attributes as Attr
-import Html.Attributes.Aria exposing (..)
+import Html.Attributes exposing (attribute, autocomplete, checked, class, classList, disabled, for, href, id, max, min, name, placeholder, rel, src, target, type_, value)
+import Html.Attributes.Aria exposing (ariaLabel)
 import Html.Events as Events
 import Json.Decode as Decode exposing (Decoder(..))
 import Json.Encode as Encode
@@ -323,61 +323,61 @@ viewDocument model =
 
 view : Model -> Html Msg
 view model =
-    div [ Attr.id "elm-app" ]
-        [ nav [ Attr.class "nav" ]
-            [ div [ Attr.class "nav-logo" ]
-                [ img [ Attr.src model.logoNav ] [] ]
+    div [ id "elm-app" ]
+        [ nav [ class "nav" ]
+            [ div [ class "nav-logo" ]
+                [ img [ src model.logoNav ] [] ]
             , ul []
-                [ li [ Attr.class "" ]
-                    [ a [ Attr.href "/" ]
+                [ li [ class "" ]
+                    [ a [ href "/" ]
                         [ text "Home" ]
                     ]
-                , li [ Attr.class "" ]
-                    [ a [ Attr.href "/about" ]
+                , li [ class "" ]
+                    [ a [ href "/about" ]
                         [ text "About" ]
                     ]
-                , li [ Attr.class "active" ]
-                    [ a [ Attr.href "/map" ]
+                , li [ class "active" ]
+                    [ a [ href "/map" ]
                         [ text "Maps" ]
                     ]
                 , li []
-                    [ a [ Attr.href "http://www.takingspace.org/", Attr.rel "noreferrer", Attr.target "_blank" ]
+                    [ a [ href "http://www.takingspace.org/", rel "noreferrer", target "_blank" ]
                         [ text "Blog" ]
                     ]
-                , li [ Attr.class "" ]
-                    [ a [ Attr.href "/donate" ]
+                , li [ class "" ]
+                    [ a [ href "/donate" ]
                         [ text "Donate" ]
                     ]
                 ]
             ]
         , main_
             []
-            [ div [ Attr.class "maps-page-container" ]
-                [ div [ Attr.class "map-filters" ]
+            [ div [ class "maps-page-container" ]
+                [ div [ class "map-filters" ]
                     [ viewSessionTypes model
                     , viewFilters model
                     , viewFiltersButtons model.selectedSession model.sessions model.linkIcon
                     ]
                 , Popup.view TogglePopupState SelectSensorId model.isPopupExtended model.popup
-                , div [ Attr.class "maps-content-container" ]
+                , div [ class "maps-content-container" ]
                     [ if model.isHttping then
-                        div [ Attr.class "overlay" ]
-                            [ div [ Attr.class "lds-dual-ring" ] []
+                        div [ class "overlay" ]
+                            [ div [ class "lds-dual-ring" ] []
                             ]
 
                       else
                         text ""
-                    , div [ Attr.class "map-container" ]
+                    , div [ class "map-container" ]
                         [ if model.isIndoor && not model.isHttping then
-                            div [ Attr.class "overlay" ]
-                                [ div [ Attr.class "change-this-classname-Pina" ] [ text "Indoor sessions aren't mapped." ] ]
+                            div [ class "overlay" ]
+                                [ div [ class "change-this-classname-Pina" ] [ text "Indoor sessions aren't mapped." ] ]
 
                           else
                             text ""
-                        , div [ Attr.class "map", Attr.id "map11", Attr.attribute "ng-controller" "MapCtrl", Attr.attribute "googlemap" "" ]
+                        , div [ class "map", id "map11", attribute "ng-controller" "MapCtrl", attribute "googlemap" "" ]
                             []
                         , div
-                            [ Attr.attribute "ng-controller"
+                            [ attribute "ng-controller"
                                 (if model.page == Mobile then
                                     "MobileSessionsMapCtrl"
 
@@ -385,11 +385,11 @@ view model =
                                     "FixedSessionsMapCtrl"
                                 )
                             ]
-                            [ div [ Attr.class "sessions", Attr.attribute "ng-controller" "SessionsGraphCtrl" ]
-                                [ div [ Attr.attribute "ng-controller" "SessionsListCtrl" ] (viewSessionsOrSelectedSession model.selectedSession model.sessions) ]
+                            [ div [ class "sessions", attribute "ng-controller" "SessionsGraphCtrl" ]
+                                [ div [ attribute "ng-controller" "SessionsListCtrl" ] (viewSessionsOrSelectedSession model.selectedSession model.sessions) ]
                             ]
                         ]
-                    , div [ Attr.class "heatmap" ]
+                    , div [ class "heatmap" ]
                         [ text "A place for heatmap    " ]
                     ]
                 ]
@@ -415,8 +415,8 @@ viewSessionsOrSelectedSession selectedSession sessions =
 
 viewSelectedSession : Maybe SelectedSession -> Html Msg
 viewSelectedSession maybeSession =
-    div [ Attr.class "single-session-container" ]
-        [ div [ Attr.class "single-session-info" ]
+    div [ class "single-session-container" ]
+        [ div [ class "single-session-info" ]
             (case maybeSession of
                 Nothing ->
                     [ text "loading" ]
@@ -425,10 +425,10 @@ viewSelectedSession maybeSession =
                     [ SelectedSession.view session ]
             )
         , div
-            [ Attr.class "single-session-graph", Attr.id "graph-box" ]
-            [ div [ Attr.id "graph" ] []
+            [ class "single-session-graph", id "graph-box" ]
+            [ div [ id "graph" ] []
             ]
-        , div [ Attr.class "single-session-close" ] [ button [ Events.onClick DeselectSession ] [ text "X" ] ]
+        , div [ class "single-session-close" ] [ button [ Events.onClick DeselectSession ] [ text "X" ] ]
         ]
 
 
@@ -436,10 +436,10 @@ viewFiltersButtons : WebData SelectedSession -> List Session -> String -> Html M
 viewFiltersButtons selectedSession sessions linkIcon =
     case selectedSession of
         NotAsked ->
-            div [ Attr.class "filters-buttons" ]
-                [ a [ Attr.class "filters-button export-button", Attr.target "_blank", Attr.href <| exportLink sessions ] [ text "export sessions" ]
-                , button [ Attr.class "filters-button circular-button", Events.onClick ShowCopyLinkTooltip, Attr.id "copy-link-tooltip" ]
-                    [ img [ Attr.src linkIcon ] [] ]
+            div [ class "filters-buttons" ]
+                [ a [ class "filters-button export-button", target "_blank", href <| exportLink sessions ] [ text "export sessions" ]
+                , button [ class "filters-button circular-button", Events.onClick ShowCopyLinkTooltip, id "copy-link-tooltip" ]
+                    [ img [ src linkIcon ] [] ]
                 ]
 
         _ ->
@@ -457,10 +457,10 @@ exportLink sessions =
 
 viewSessionTypes : Model -> Html Msg
 viewSessionTypes model =
-    div [ Attr.class "sessions-type" ]
-        [ a [ Attr.href "/mobile_map", Attr.classList [ ( "session-type-mobile", True ), ( "selected", model.page == Mobile ) ] ]
+    div [ class "sessions-type" ]
+        [ a [ href "/mobile_map", classList [ ( "session-type-mobile", True ), ( "selected", model.page == Mobile ) ] ]
             [ text "mobile" ]
-        , a [ Attr.href "/fixed_map", Attr.classList [ ( "session-type-fixed", True ), ( "selected", model.page == Fixed ) ] ]
+        , a [ href "/fixed_map", classList [ ( "session-type-fixed", True ), ( "selected", model.page == Fixed ) ] ]
             [ text "fixed" ]
         ]
 
@@ -472,18 +472,18 @@ viewSessions sessions =
 
     else
         div []
-            [ h2 [ Attr.class "sessions-header" ]
+            [ h2 [ class "sessions-header" ]
                 [ text "Sessions" ]
-            , span [ Attr.class "sessions-number" ]
+            , span [ class "sessions-number" ]
                 [ text "showing 6 of 500 reuslts" ]
-            , div [ Attr.class "sessions-container" ]
+            , div [ class "sessions-container" ]
                 (List.map viewSessionCard sessions ++ [ viewLoadMore <| List.length sessions ])
             ]
 
 
 viewShortType : Int -> Int -> ShortType -> Html msg
 viewShortType length index shortType =
-    span [ Attr.class shortType.type_ ]
+    span [ class shortType.type_ ]
         [ text shortType.name
         , span []
             [ if index == length - 1 then
@@ -507,20 +507,20 @@ viewLoadMore sessionCount =
 viewSessionCard : Session -> Html Msg
 viewSessionCard session =
     div
-        [ Attr.class "session"
+        [ class "session"
         , Events.onClick <| ToggleSessionSelection session.id
         ]
-        [ div [ Attr.class "session-header-container" ]
-            [ div [ Attr.class "session-color heat-lvl1-bg" ]
+        [ div [ class "session-header-container" ]
+            [ div [ class "session-color heat-lvl1-bg" ]
                 []
-            , h3 [ Attr.class "session-name" ]
+            , h3 [ class "session-name" ]
                 [ text session.title ]
             ]
-        , p [ Attr.class "session-owner" ]
+        , p [ class "session-owner" ]
             [ text session.username ]
-        , p [ Attr.class "session-dates" ]
+        , p [ class "session-dates" ]
             [ text session.startTime ]
-        , p [ Attr.class "session-dates" ]
+        , p [ class "session-dates" ]
             [ text session.endTime ]
         ]
 
@@ -537,14 +537,14 @@ viewFilters model =
 
 viewMobileFilters : Model -> Html Msg
 viewMobileFilters model =
-    form [ Attr.class "filters-form" ]
+    form [ class "filters-form" ]
         [ viewParameterFilter model.sensors model.selectedSensorId
         , viewSensorFilter model.sensors model.selectedSensorId
         , viewLocation model.location model.isIndoor
         , TimeRange.view RefreshTimeRange
         , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" False
         , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False
-        , div [ Attr.class "filter-separator" ] []
+        , div [ class "filter-separator" ] []
         , viewCrowdMapCheckBox model.isCrowdMapOn
         , if model.isCrowdMapOn then
             viewCrowdMapSlider (String.fromInt model.crowdMapResolution)
@@ -556,7 +556,7 @@ viewMobileFilters model =
 
 viewFixedFilters : Model -> Html Msg
 viewFixedFilters model =
-    form [ Attr.class "filters-form" ]
+    form [ class "filters-form" ]
         [ viewParameterFilter model.sensors model.selectedSensorId
         , viewSensorFilter model.sensors model.selectedSensorId
         , viewLocation model.location model.isIndoor
@@ -574,12 +574,12 @@ viewFixedFilters model =
 viewToggleButton : String -> Bool -> Msg -> Html Msg
 viewToggleButton label isPressed callback =
     button
-        [ Attr.type_ "button"
+        [ type_ "button"
         , if isPressed then
-            Attr.class "toggle-button toggle-button--pressed"
+            class "toggle-button toggle-button--pressed"
 
           else
-            Attr.class "toggle-button"
+            class "toggle-button"
         , ariaLabel label
         , Events.onClick callback
         ]
@@ -589,17 +589,17 @@ viewToggleButton label isPressed callback =
 viewParameterFilter : List Sensor -> String -> Html Msg
 viewParameterFilter sensors selectedSensorId =
     div []
-        [ label [ Attr.for "parameter" ] [ text "parameter:" ]
+        [ label [ for "parameter" ] [ text "parameter:" ]
         , input
-            [ Attr.id "parameter"
-            , Attr.class "input-dark"
-            , Attr.class "input-filters"
-            , Attr.placeholder "parameter"
-            , Attr.type_ "text"
-            , Attr.name "parameter"
+            [ id "parameter"
+            , class "input-dark"
+            , class "input-filters"
+            , placeholder "parameter"
+            , type_ "text"
+            , name "parameter"
             , Popup.clickWithoutDefault (ShowPopup (Sensor.parameters sensors) "parameters" (Sensor.parameterForId sensors selectedSensorId))
-            , Attr.value (Sensor.parameterForId sensors selectedSensorId)
-            , Attr.autocomplete False
+            , value (Sensor.parameterForId sensors selectedSensorId)
+            , autocomplete False
             ]
             []
         ]
@@ -608,17 +608,17 @@ viewParameterFilter sensors selectedSensorId =
 viewSensorFilter : List Sensor -> String -> Html Msg
 viewSensorFilter sensors selectedSensorId =
     div []
-        [ label [ Attr.for "sensor" ] [ text "sensor:" ]
+        [ label [ for "sensor" ] [ text "sensor:" ]
         , input
-            [ Attr.id "sensor"
-            , Attr.class "input-dark"
-            , Attr.class "input-filters"
-            , Attr.placeholder "sensor"
-            , Attr.type_ "text"
-            , Attr.name "sensor"
+            [ id "sensor"
+            , class "input-dark"
+            , class "input-filters"
+            , placeholder "sensor"
+            , type_ "text"
+            , name "sensor"
             , Popup.clickWithoutDefault (ShowPopup (Sensor.labelsForParameter sensors selectedSensorId) "sensors" (Sensor.sensorLabelForId sensors selectedSensorId))
-            , Attr.value (Sensor.sensorLabelForId sensors selectedSensorId)
-            , Attr.autocomplete False
+            , value (Sensor.sensorLabelForId sensors selectedSensorId)
+            , autocomplete False
             ]
             []
         ]
@@ -629,30 +629,30 @@ viewCrowdMapCheckBox isCrowdMapOn =
     div []
         [ p []
             [ input
-                [ Attr.id "checkbox-crowd-map"
-                , Attr.type_ "checkbox"
-                , Attr.checked isCrowdMapOn
+                [ id "checkbox-crowd-map"
+                , type_ "checkbox"
+                , checked isCrowdMapOn
                 , Events.onClick ToggleCrowdMap
                 ]
                 []
-            , label [ Attr.for "checkbox-crowd-map" ] [ text "Crowd Map" ]
+            , label [ for "checkbox-crowd-map" ] [ text "Crowd Map" ]
             ]
         ]
 
 
 viewCrowdMapSlider : String -> Html Msg
 viewCrowdMapSlider resolution =
-    div [ Attr.id "crowd-map-slider" ]
+    div [ id "crowd-map-slider" ]
         [ p []
             [ text "Resolution" ]
         , div []
             [ input
-                [ Attr.class "crowd-map-slider"
+                [ class "crowd-map-slider"
                 , onChange (String.toInt >> Maybe.withDefault 25 >> UpdateCrowdMapResolution)
-                , Attr.value resolution
-                , Attr.max "50"
-                , Attr.min "10"
-                , Attr.type_ "range"
+                , value resolution
+                , max "50"
+                , min "10"
+                , type_ "range"
                 ]
                 []
             , span []
@@ -664,16 +664,16 @@ viewCrowdMapSlider resolution =
 viewLocation : String -> Bool -> Html Msg
 viewLocation location isIndoor =
     div []
-        [ label [ Attr.for "location" ] [ text "location:" ]
+        [ label [ for "location" ] [ text "location:" ]
         , input
-            [ Attr.id "location"
-            , Attr.value location
-            , Attr.class "input-dark"
-            , Attr.class "input-filters"
-            , Attr.placeholder "location"
-            , Attr.type_ "text"
-            , Attr.name "location"
-            , Attr.disabled isIndoor
+            [ id "location"
+            , value location
+            , class "input-dark"
+            , class "input-filters"
+            , placeholder "location"
+            , type_ "text"
+            , name "location"
+            , disabled isIndoor
             , Events.onInput UpdateLocationInput
             , onEnter SubmitLocation
             ]

--- a/app/javascript/elm/src/Popup.elm
+++ b/app/javascript/elm/src/Popup.elm
@@ -1,7 +1,7 @@
 module Popup exposing (Popup(..), clickWithoutDefault, view)
 
 import Html exposing (Html, button, div, li, text, ul)
-import Html.Attributes as Attr
+import Html.Attributes exposing (class, classList, id)
 import Html.Events as Events
 import Json.Decode as Decode
 
@@ -22,22 +22,22 @@ view toggle onSelect isPopupExtended popup =
         SelectFrom ( main, others ) itemType selectedItem ->
             case ( List.isEmpty main, List.isEmpty others ) of
                 ( True, _ ) ->
-                    div [ Attr.id "popup", Attr.class "parameter-filters-popup" ]
+                    div [ id "popup", class "parameter-filters-popup" ]
                         [ selectableItems MainPart others onSelect selectedItem ]
 
                 ( False, True ) ->
-                    div [ Attr.id "popup", Attr.class "parameter-filters-popup" ]
+                    div [ id "popup", class "parameter-filters-popup" ]
                         [ selectableItems MainPart main onSelect selectedItem
                         ]
 
                 ( False, False ) ->
-                    div [ Attr.id "popup", Attr.class "parameter-filters-popup" ]
+                    div [ id "popup", class "parameter-filters-popup" ]
                         [ selectableItems MainPart main onSelect selectedItem
                         , if List.isEmpty others then
                             text ""
 
                           else if isPopupExtended then
-                            div [ Attr.class "parameter-more-container" ]
+                            div [ class "parameter-more-container" ]
                                 [ selectableItems OtherPart others onSelect selectedItem
                                 , togglePopupStateButton ("less " ++ itemType) toggle
                                 ]
@@ -53,8 +53,8 @@ view toggle onSelect isPopupExtended popup =
 togglePopupStateButton : String -> msg -> Html msg
 togglePopupStateButton name toggle =
     button
-        [ Attr.id "toggle-popup-button"
-        , Attr.class "parameters-toggle-open"
+        [ id "toggle-popup-button"
+        , class "parameters-toggle-open"
         , clickWithoutDefault toggle
         ]
         [ text name ]
@@ -74,7 +74,7 @@ selectableItems part items onSelect selectedItem =
         toButton item =
             button
                 [ Events.onClick (onSelect item)
-                , Attr.classList
+                , classList
                     [ ( "active", item == selectedItem )
                     , ( childClass, True )
                     , ( "test-parameter-filters-button", True )
@@ -82,7 +82,7 @@ selectableItems part items onSelect selectedItem =
                 ]
                 [ text item ]
     in
-    div [ Attr.class parentClass ] (List.map toButton items)
+    div [ class parentClass ] (List.map toButton items)
 
 
 clickWithoutDefault : msg -> Html.Attribute msg

--- a/app/javascript/elm/tests/LabelsInputTests.elm
+++ b/app/javascript/elm/tests/LabelsInputTests.elm
@@ -1,7 +1,7 @@
 module LabelsInputTests exposing (all)
 
 import Fuzz exposing (bool, string)
-import Html.Attributes as Attr
+import Html.Attributes exposing (disabled, type_, value)
 import LabelsInput
 import Test exposing (..)
 import Test.Html.Event as Event
@@ -21,8 +21,8 @@ all =
             \isDisabled ->
                 LabelsInput.view LabelsInput.empty "description" "input-id" "placeholder" isDisabled
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute (Attr.type_ "text") ]
-                    |> Query.has [ Slc.attribute (Attr.disabled isDisabled) ]
+                    |> Query.find [ Slc.attribute (type_ "text") ]
+                    |> Query.has [ Slc.attribute (disabled isDisabled) ]
         , fuzz string "when user types, updateLabelsSearch is triggered with the input" <|
             \input ->
                 LabelsInput.view LabelsInput.empty "description" "input-id" "placeholder" False
@@ -39,7 +39,7 @@ all =
                 LabelsInput.view labels "description" "input-id" "placeholder" False
                     |> Query.fromHtml
                     |> Query.find [ Slc.tag "input" ]
-                    |> Query.has [ Slc.attribute <| Attr.value candidate ]
+                    |> Query.has [ Slc.attribute <| value candidate ]
         , fuzz string "label has button that deletes the label" <|
             \label ->
                 let

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -6,8 +6,8 @@ import Data.Session exposing (..)
 import Expect
 import Fuzz exposing (bool, float, int, intRange, list, string)
 import Html exposing (text)
-import Html.Attributes as Attr
-import Html.Attributes.Aria exposing (..)
+import Html.Attributes exposing (checked, class, disabled, for, href, id, value)
+import Html.Attributes.Aria exposing (ariaLabel)
 import Json.Encode as Encode
 import LabelsInput
 import Main exposing (..)
@@ -67,7 +67,7 @@ parameterSensorFilter =
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.id "parameter" ]
-                    |> Query.has [ Slc.attribute <| Attr.value "parameter" ]
+                    |> Query.has [ Slc.attribute <| value "parameter" ]
         , test "sensor filter shows sensor label based on selectedSensorId" <|
             \_ ->
                 { defaultModel
@@ -77,7 +77,7 @@ parameterSensorFilter =
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.id "sensor" ]
-                    |> Query.has [ Slc.attribute <| Attr.value "Sensor (unit)" ]
+                    |> Query.has [ Slc.attribute <| value "Sensor (unit)" ]
         , test "when ShowPopup is triggered popup is shown" <|
             \_ ->
                 defaultModel
@@ -114,7 +114,7 @@ locationFilter =
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.id "location" ]
-                    |> Query.has [ Slc.attribute <| Attr.value locationValue ]
+                    |> Query.has [ Slc.attribute <| value locationValue ]
         , test "when Enter key is pressed SubmitLocation is triggered" <|
             \_ ->
                 let
@@ -140,7 +140,7 @@ locationFilter =
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.id "location" ]
-                    |> Query.has [ Slc.attribute <| Attr.disabled True ]
+                    |> Query.has [ Slc.attribute <| disabled True ]
         ]
 
 
@@ -339,7 +339,7 @@ profilesArea =
                         |> view
                         |> Query.fromHtml
                         |> Query.find [ Slc.id "profile-names" ]
-                        |> Query.has [ Slc.attribute <| Attr.disabled True ]
+                        |> Query.has [ Slc.attribute <| disabled True ]
             ]
         ]
 
@@ -366,7 +366,7 @@ crowdMapArea =
                 defaultModel
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| Attr.for "checkbox-crowd-map" ]
+                    |> Query.find [ Slc.attribute <| for "checkbox-crowd-map" ]
                     |> Query.contains
                         [ text "Crowd Map" ]
         , test "checkbox is not checked as default" <|
@@ -374,9 +374,9 @@ crowdMapArea =
                 defaultModel
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| Attr.id "checkbox-crowd-map" ]
+                    |> Query.find [ Slc.attribute <| id "checkbox-crowd-map" ]
                     |> Query.has
-                        [ Slc.attribute <| Attr.checked False ]
+                        [ Slc.attribute <| checked False ]
         , fuzz bool "checkbox state depends on model.isCrowdMapOn" <|
             \onOffValue ->
                 let
@@ -386,15 +386,15 @@ crowdMapArea =
                 model
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| Attr.id "checkbox-crowd-map" ]
+                    |> Query.find [ Slc.attribute <| id "checkbox-crowd-map" ]
                     |> Query.has
-                        [ Slc.attribute <| Attr.checked model.isCrowdMapOn ]
+                        [ Slc.attribute <| checked model.isCrowdMapOn ]
         , test "clicking the checkbox sends ToggleCrowdMap message" <|
             \_ ->
                 defaultModel
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| Attr.id "checkbox-crowd-map" ]
+                    |> Query.find [ Slc.attribute <| id "checkbox-crowd-map" ]
                     |> Event.simulate Event.click
                     |> Event.expect ToggleCrowdMap
         , test "slider has a description" <|
@@ -402,7 +402,7 @@ crowdMapArea =
                 { defaultModel | isCrowdMapOn = True }
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| Attr.id "crowd-map-slider" ]
+                    |> Query.find [ Slc.attribute <| id "crowd-map-slider" ]
                     |> Query.contains
                         [ text "Resolution" ]
         , test "slider has a description with current crowd map resolution" <|
@@ -410,7 +410,7 @@ crowdMapArea =
                 { defaultModel | isCrowdMapOn = True }
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| Attr.id "crowd-map-slider" ]
+                    |> Query.find [ Slc.attribute <| id "crowd-map-slider" ]
                     |> Query.contains
                         [ text (String.fromInt defaultModel.crowdMapResolution) ]
         , test "slider default value is 25" <|
@@ -418,9 +418,9 @@ crowdMapArea =
                 { defaultModel | isCrowdMapOn = True }
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| Attr.class "crowd-map-slider" ]
+                    |> Query.find [ Slc.attribute <| class "crowd-map-slider" ]
                     |> Query.has
-                        [ Slc.attribute <| Attr.value "25" ]
+                        [ Slc.attribute <| value "25" ]
         , fuzz int "slider value depends on model.crowdMapResolution" <|
             \resolution ->
                 let
@@ -430,9 +430,9 @@ crowdMapArea =
                 model
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| Attr.class "crowd-map-slider" ]
+                    |> Query.find [ Slc.attribute <| class "crowd-map-slider" ]
                     |> Query.has
-                        [ Slc.attribute <| Attr.value (String.fromInt resolution) ]
+                        [ Slc.attribute <| value (String.fromInt resolution) ]
         , fuzz int "moving the slider updates crowd map resolution" <|
             \resolution ->
                 let
@@ -445,7 +445,7 @@ crowdMapArea =
                 { defaultModel | isCrowdMapOn = True }
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| Attr.class "crowd-map-slider" ]
+                    |> Query.find [ Slc.attribute <| class "crowd-map-slider" ]
                     |> Event.simulate (Event.custom "change" simulatedEventObject)
                     |> Event.expect (UpdateCrowdMapResolution resolution)
         ]
@@ -469,7 +469,7 @@ toggleIndoorFilter =
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute <| ariaLabel "outdoor" ]
-                    |> Query.has [ Slc.attribute <| Attr.class "toggle-button--pressed" ]
+                    |> Query.has [ Slc.attribute <| class "toggle-button--pressed" ]
         , test "clicking indoor button triggers ToggleIndoor" <|
             \_ ->
                 { defaultModel | page = Fixed }
@@ -581,7 +581,7 @@ viewTests =
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.containing [ Slc.text "export sessions" ] ]
-                    |> Query.has [ Slc.attribute <| Attr.href expected ]
+                    |> Query.has [ Slc.attribute <| href expected ]
         , fuzz int "with no selection and 2 sessions in the model the export link is correctly generated" <|
             \id ->
                 let
@@ -592,7 +592,7 @@ viewTests =
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.containing [ Slc.text "export sessions" ] ]
-                    |> Query.has [ Slc.attribute <| Attr.href expected ]
+                    |> Query.has [ Slc.attribute <| href expected ]
         , test "with selection graph is shown" <|
             \_ ->
                 { defaultModel | selectedSession = Success selectedSession }


### PR DESCRIPTION
We decided to expose Html and Html.Attributes so that we don't have to qualify them. This way the views will look less cluttered and be easier to read and write. The functions closely resemble HTML tags and attributes so it seems to only make sense to do it in the case of those 2 packages.