### PR TITLE
Heat

### DIFF
--- a/app/controllers/api/thresholds_controller.rb
+++ b/app/controllers/api/thresholds_controller.rb
@@ -21,7 +21,7 @@ module Api
     respond_to :json
 
     def show
-      respond_with Stream.thresholds(params[:id], params[:unit_symbol])
+      render json: Stream.thresholds(params[:id], params[:unit_symbol])
     end
   end
 end

--- a/app/javascript/elm/src/Data/HeatMapThresholds.elm
+++ b/app/javascript/elm/src/Data/HeatMapThresholds.elm
@@ -1,0 +1,59 @@
+module Data.HeatMapThresholds exposing (HeatMapThresholds, fetch)
+
+import Http
+import Json.Decode as Decode exposing (Decoder(..))
+import Sensor exposing (Sensor)
+
+
+type alias HeatMapThresholds =
+    { h1 : Int
+    , h2 : Int
+    , h3 : Int
+    , h4 : Int
+    , h5 : Int
+    }
+
+
+fetch : List Sensor -> String -> (Result Http.Error HeatMapThresholds -> msg) -> Maybe (Cmd msg)
+fetch sensors sensorId toCmd =
+    let
+        maybeSensorName =
+            Sensor.nameForSensorId sensorId sensors
+
+        maybeUnit =
+            Sensor.unitForSensorId sensorId sensors
+
+        fetch_ sensorName unit =
+            Http.get
+                { url = "/api/thresholds/" ++ sensorName ++ "?unit_symbol=" ++ unit
+                , expect = Http.expectJson toCmd decoder
+                }
+    in
+    Maybe.map2 fetch_ maybeSensorName maybeUnit
+
+
+maybeIntDecoder : Maybe Int -> Decoder Int
+maybeIntDecoder m =
+    case m of
+        Nothing ->
+            Decode.fail "threshold must be an Int"
+
+        Just i ->
+            Decode.succeed i
+
+
+intAsStringDecoder : Decoder Int
+intAsStringDecoder =
+    Decode.string
+        |> Decode.map String.toInt
+        |> Decode.andThen maybeIntDecoder
+
+
+decoder : Decoder HeatMapThresholds
+decoder =
+    Decode.map5 HeatMapThresholds
+        (Decode.index 0 intAsStringDecoder)
+        (Decode.index 1 intAsStringDecoder)
+        (Decode.index 2 intAsStringDecoder)
+        (Decode.index 3 intAsStringDecoder)
+        (Decode.index 4 intAsStringDecoder)

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -5,7 +5,6 @@ import Html exposing (Html, div, p, span, text)
 import Html.Attributes exposing (class)
 import Http
 import Json.Decode as Decode exposing (Decoder(..))
-import RemoteData exposing (RemoteData(..), WebData)
 
 
 type alias SelectedSession =
@@ -55,8 +54,8 @@ sensorNameFromId =
     String.split "-" >> List.drop 1 >> String.join "-" >> String.split " " >> List.head >> Maybe.withDefault ""
 
 
-fetch : String -> Page -> Int -> (WebData SelectedSession -> msg) -> Cmd msg
-fetch sensorId page id toMsg =
+fetch : String -> Page -> Int -> (Result Http.Error SelectedSession -> msg) -> Cmd msg
+fetch sensorId page id toCmd =
     Http.get
         { url =
             if page == Mobile then
@@ -64,7 +63,7 @@ fetch sensorId page id toMsg =
 
             else
                 "/api/fixed/sessions/" ++ String.fromInt id ++ ".json?sensor_name=" ++ sensorNameFromId sensorId
-        , expect = Http.expectJson (RemoteData.fromResult >> toMsg) decoder
+        , expect = Http.expectJson toCmd decoder
         }
 
 

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -119,13 +119,18 @@ init flags url key =
         , logoNav = flags.logoNav
         , linkIcon = flags.linkIcon
       }
-    , case flags.selectedSessionId of
+    , fetchSelectedSession flags.selectedSessionId flags.selectedSensorId page
+    )
+
+
+fetchSelectedSession : Maybe Int -> String -> Page -> Cmd Msg
+fetchSelectedSession maybeId selectedSensorId page =
+    case maybeId of
         Nothing ->
             Cmd.none
 
         Just id ->
-            SelectedSession.fetch flags.selectedSensorId page id GotSession
-    )
+            SelectedSession.fetch selectedSensorId page id GotSession
 
 
 

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -12,6 +12,7 @@ port module Ports exposing
     , toggleIndoor
     , toggleSession
     , toggleSessionSelection
+    , updateHeatMapThresholds
     , updateIsHttping
     , updateProfiles
     , updateResolution
@@ -19,7 +20,8 @@ port module Ports exposing
     , updateTags
     )
 
-import Data.Session exposing (..)
+import Data.HeatMapThresholds exposing (HeatMapThresholds)
+import Data.Session exposing (Session)
 import Json.Encode as Encode
 
 
@@ -75,3 +77,6 @@ port toggleSessionSelection : (Maybe Int -> msg) -> Sub msg
 
 
 port refreshTimeRange : () -> Cmd a
+
+
+port updateHeatMapThresholds : HeatMapThresholds -> Cmd a

--- a/app/javascript/elm/src/Sensor.elm
+++ b/app/javascript/elm/src/Sensor.elm
@@ -3,9 +3,11 @@ module Sensor exposing
     , decodeSensors
     , idForParameterOrLabel
     , labelsForParameter
+    , nameForSensorId
     , parameterForId
     , parameters
     , sensorLabelForId
+    , unitForSensorId
     )
 
 import Dict
@@ -50,7 +52,7 @@ mainSensors =
    { id_ = "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
    , label = "AirBeam2-PM2.5 (µg/m³)"
    , parameter = "Particulate Matter"
-   , sensor = "AirBeam2-PM2.5"
+   , name = "AirBeam2-PM2.5"
    , session_count = 24
    , unit = "µg/m³"
    }
@@ -59,7 +61,7 @@ mainSensors =
 
 type alias Sensor =
     { id_ : String
-    , sensor : String
+    , name : String
     , parameter : String
     , unit : String
     , label : String
@@ -83,12 +85,12 @@ decodeSensors sensors =
 
 
 toSensor : String -> String -> String -> Int -> Sensor
-toSensor sensor parameter unit session_count =
-    { id_ = parameter ++ "-" ++ String.toLower sensor ++ " (" ++ unit ++ ")"
-    , sensor = sensor
+toSensor name parameter unit session_count =
+    { id_ = parameter ++ "-" ++ String.toLower name ++ " (" ++ unit ++ ")"
+    , name = name
     , parameter = parameter
     , unit = unit
-    , label = sensor ++ " (" ++ unit ++ ")"
+    , label = name ++ " (" ++ unit ++ ")"
     , session_count = session_count
     }
 
@@ -184,3 +186,19 @@ idForParameterOrLabel parameterOrLabel oldSensorId sensors =
 
         _ ->
             defaultSensorId
+
+
+nameForSensorId : String -> List Sensor -> Maybe String
+nameForSensorId id sensors =
+    sensors
+        |> List.filter (\sensor -> sensor.id_ == id)
+        |> List.head
+        |> Maybe.map .name
+
+
+unitForSensorId : String -> List Sensor -> Maybe String
+unitForSensorId id sensors =
+    sensors
+        |> List.filter (\sensor -> sensor.id_ == id)
+        |> List.head
+        |> Maybe.map .unit

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -48,7 +48,7 @@ sensors =
     [ { id_ = "parameter-sensor (unit)"
       , parameter = "parameter"
       , label = "Sensor (unit)"
-      , sensor = "Sensor"
+      , name = "Sensor"
       , unit = "unit"
       , session_count = 1
       }

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -45,9 +45,7 @@ popups =
 
 sensors : List Sensor.Sensor
 sensors =
-    [ { id_ = "parameter-sensor (unit)"
-      , parameter = "parameter"
-      , label = "Sensor (unit)"
+    [ { parameter = "parameter"
       , name = "Sensor"
       , unit = "unit"
       , session_count = 1

--- a/app/javascript/elm/tests/SensorTests.elm
+++ b/app/javascript/elm/tests/SensorTests.elm
@@ -55,14 +55,14 @@ all =
                 [ { id_ = "Particulate Matter-other label (µg/m³)"
                   , parameter = "Particulate Matter"
                   , label = "Other Label (µg/m³)"
-                  , sensor = "Other Label"
+                  , name = "Other Label"
                   , unit = "µg/m³"
                   , session_count = 1
                   }
                 , { id_ = "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
                   , parameter = "Particulate Matter"
                   , label = "AirBeam2-PM2.5 (µg/m³)"
-                  , sensor = "AirBeam2-PM2.5"
+                  , name = "AirBeam2-PM2.5"
                   , unit = "µg/m³"
                   , session_count = 0
                   }
@@ -74,14 +74,14 @@ all =
                 [ { id_ = "Humidity-other label (%)"
                   , parameter = "Humidity"
                   , label = "Other Label (%)"
-                  , sensor = "Other Label"
+                  , name = "Other Label"
                   , unit = "%"
                   , session_count = 1
                   }
                 , { id_ = "Humidity-airbeam2-rh (%)"
                   , parameter = "Humidity"
                   , label = "AirBeam2-RH (%)"
-                  , sensor = "AirBeam2-RH"
+                  , name = "AirBeam2-RH"
                   , unit = "%"
                   , session_count = 0
                   }
@@ -93,14 +93,14 @@ all =
                 [ { id_ = "Sound Level-other label (dB)"
                   , parameter = "Sound Level"
                   , label = "Other Label (dB)"
-                  , sensor = "Other Label"
+                  , name = "Other Label"
                   , unit = "dB"
                   , session_count = 1
                   }
                 , { id_ = "Sound Level-phone microphone (dB)"
                   , parameter = "Sound Level"
                   , label = "Phone Microphone (dB)"
-                  , sensor = "Phone Microphone"
+                  , name = "Phone Microphone"
                   , unit = "dB"
                   , session_count = 0
                   }
@@ -112,14 +112,14 @@ all =
                 [ { id_ = "Temperature-other label (F)"
                   , parameter = "Temperature"
                   , label = "Other Label (F)"
-                  , sensor = "Other Label"
+                  , name = "Other Label"
                   , unit = "F"
                   , session_count = 1
                   }
                 , { id_ = "Temperature-airbeam2-f (F)"
                   , parameter = "Temperature"
                   , label = "Temperature (F)"
-                  , sensor = "Temperature"
+                  , name = "Temperature"
                   , unit = "F"
                   , session_count = 0
                   }
@@ -143,7 +143,44 @@ all =
                           ]
                         , [ "Other Label (µg/m³)" ]
                         )
+        , test "nameForSensorId returns the name given the sensorId" <|
+            \_ ->
+                [ { sensor
+                    | id_ = "id"
+                    , name = "name"
+                  }
+                , { sensor
+                    | id_ = "other id"
+                    , name = "other name"
+                  }
+                ]
+                    |> nameForSensorId "id"
+                    |> Expect.equal (Just "name")
+        , test "unitForSensorId returns the unit given the sensorId" <|
+            \_ ->
+                [ { sensor
+                    | id_ = "id"
+                    , unit = "unit"
+                  }
+                , { sensor
+                    | id_ = "other id"
+                    , unit = "other unit"
+                  }
+                ]
+                    |> unitForSensorId "id"
+                    |> Expect.equal (Just "unit")
         ]
+
+
+sensor : Sensor
+sensor =
+    { id_ = "parameter-sensor (unit)"
+    , parameter = "parameter"
+    , label = "Sensor (unit)"
+    , name = "Sensor"
+    , unit = "unit"
+    , session_count = 1
+    }
 
 
 sensors : List Sensor
@@ -151,21 +188,21 @@ sensors =
     [ { id_ = "parameter-sensor (unit)"
       , parameter = "parameter"
       , label = "Sensor (unit)"
-      , sensor = "Sensor"
+      , name = "Sensor"
       , unit = "unit"
       , session_count = 1
       }
     , { id_ = "parameter-sensor2 (unit)"
       , parameter = "parameter"
       , label = "Sensor2 (unit)"
-      , sensor = "Sensor2"
+      , name = "Sensor2"
       , unit = "unit"
       , session_count = 2
       }
     , { id_ = "parameter2-sensor3 (unit)"
       , parameter = "parameter2"
       , label = "Sensor3 (unit)"
-      , sensor = "Sensor3"
+      , name = "Sensor3"
       , unit = "unit"
       , session_count = 1
       }
@@ -177,35 +214,35 @@ sensorsWithPriority =
     [ { id_ = "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
       , parameter = "Particulate Matter"
       , label = "AirBeam2-PM2.5 (µg/m³)"
-      , sensor = "AirBeam2-PM2.5"
+      , name = "AirBeam2-PM2.5"
       , unit = "µg/m³"
       , session_count = 1
       }
     , { id_ = "Particulate Matter-airbeam2-pm1 (µg/m³)"
       , parameter = "Particulate Matter"
       , label = "AirBeam2-PM1 (µg/m³)"
-      , sensor = "AirBeam2-PM1"
+      , name = "AirBeam2-PM1"
       , unit = "µg/m³"
       , session_count = 1
       }
     , { id_ = "Particulate Matter-airbeam2-pm10 (µg/m³)"
       , parameter = "Particulate Matter"
       , label = "AirBeam2-PM10 (µg/m³)"
-      , sensor = "AirBeam2-PM10"
+      , name = "AirBeam2-PM10"
       , unit = "µg/m³"
       , session_count = 1
       }
     , { id_ = "Particulate Matter-airbeam-pm (µg/m³)"
       , parameter = "Particulate Matter"
       , label = "AirBeam-PM (µg/m³)"
-      , sensor = "AirBeam-PM"
+      , name = "AirBeam-PM"
       , unit = "µg/m³"
       , session_count = 1
       }
     , { id_ = "Particulate Matter-other label (µg/m³)"
       , parameter = "Particulate Matter"
       , label = "Other Label (µg/m³)"
-      , sensor = "Other Label"
+      , name = "Other Label"
       , unit = "µg/m³"
       , session_count = 1
       }

--- a/app/javascript/elm/tests/SensorTests.elm
+++ b/app/javascript/elm/tests/SensorTests.elm
@@ -52,16 +52,12 @@ all =
                     |> Expect.equal "parameter-sensor2 (unit)"
         , test "idForParameterOrLabel always finds airbeam2-pm2.5 for Particulate Matter" <|
             \_ ->
-                [ { id_ = "Particulate Matter-other label (µg/m³)"
-                  , parameter = "Particulate Matter"
-                  , label = "Other Label (µg/m³)"
+                [ { parameter = "Particulate Matter"
                   , name = "Other Label"
                   , unit = "µg/m³"
                   , session_count = 1
                   }
-                , { id_ = "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
-                  , parameter = "Particulate Matter"
-                  , label = "AirBeam2-PM2.5 (µg/m³)"
+                , { parameter = "Particulate Matter"
                   , name = "AirBeam2-PM2.5"
                   , unit = "µg/m³"
                   , session_count = 0
@@ -71,16 +67,12 @@ all =
                     |> Expect.equal "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
         , test "idForParameterOrLabel always finds airbeam2-rh for Humidity" <|
             \_ ->
-                [ { id_ = "Humidity-other label (%)"
-                  , parameter = "Humidity"
-                  , label = "Other Label (%)"
+                [ { parameter = "Humidity"
                   , name = "Other Label"
                   , unit = "%"
                   , session_count = 1
                   }
-                , { id_ = "Humidity-airbeam2-rh (%)"
-                  , parameter = "Humidity"
-                  , label = "AirBeam2-RH (%)"
+                , { parameter = "Humidity"
                   , name = "AirBeam2-RH"
                   , unit = "%"
                   , session_count = 0
@@ -90,16 +82,12 @@ all =
                     |> Expect.equal "Humidity-airbeam2-rh (%)"
         , test "idForParameterOrLabel always finds phone microphone for Sound Levels" <|
             \_ ->
-                [ { id_ = "Sound Level-other label (dB)"
-                  , parameter = "Sound Level"
-                  , label = "Other Label (dB)"
+                [ { parameter = "Sound Level"
                   , name = "Other Label"
                   , unit = "dB"
                   , session_count = 1
                   }
-                , { id_ = "Sound Level-phone microphone (dB)"
-                  , parameter = "Sound Level"
-                  , label = "Phone Microphone (dB)"
+                , { parameter = "Sound Level"
                   , name = "Phone Microphone"
                   , unit = "dB"
                   , session_count = 0
@@ -109,17 +97,13 @@ all =
                     |> Expect.equal "Sound Level-phone microphone (dB)"
         , test "idForParameterOrLabel always finds airbeam2-f for Temperature" <|
             \_ ->
-                [ { id_ = "Temperature-other label (F)"
-                  , parameter = "Temperature"
-                  , label = "Other Label (F)"
+                [ { parameter = "Temperature"
                   , name = "Other Label"
                   , unit = "F"
                   , session_count = 1
                   }
-                , { id_ = "Temperature-airbeam2-f (F)"
-                  , parameter = "Temperature"
-                  , label = "Temperature (F)"
-                  , name = "Temperature"
+                , { parameter = "Temperature"
+                  , name = "AirBeam2-F"
                   , unit = "F"
                   , session_count = 0
                   }
@@ -145,38 +129,34 @@ all =
                         )
         , test "nameForSensorId returns the name given the sensorId" <|
             \_ ->
-                [ { sensor
-                    | id_ = "id"
-                    , name = "name"
-                  }
-                , { sensor
-                    | id_ = "other id"
-                    , name = "other name"
-                  }
-                ]
-                    |> nameForSensorId "id"
+                let
+                    sensor1 =
+                        { sensor | name = "name" }
+
+                    sensor2 =
+                        { sensor | name = "other name" }
+                in
+                [ sensor1, sensor2 ]
+                    |> nameForSensorId (toId sensor1)
                     |> Expect.equal (Just "name")
         , test "unitForSensorId returns the unit given the sensorId" <|
             \_ ->
-                [ { sensor
-                    | id_ = "id"
-                    , unit = "unit"
-                  }
-                , { sensor
-                    | id_ = "other id"
-                    , unit = "other unit"
-                  }
-                ]
-                    |> unitForSensorId "id"
+                let
+                    sensor1 =
+                        { sensor | unit = "unit" }
+
+                    sensor2 =
+                        { sensor | unit = "other unit" }
+                in
+                [ sensor1, sensor2 ]
+                    |> unitForSensorId (toId sensor1)
                     |> Expect.equal (Just "unit")
         ]
 
 
 sensor : Sensor
 sensor =
-    { id_ = "parameter-sensor (unit)"
-    , parameter = "parameter"
-    , label = "Sensor (unit)"
+    { parameter = "parameter"
     , name = "Sensor"
     , unit = "unit"
     , session_count = 1
@@ -185,23 +165,17 @@ sensor =
 
 sensors : List Sensor
 sensors =
-    [ { id_ = "parameter-sensor (unit)"
-      , parameter = "parameter"
-      , label = "Sensor (unit)"
+    [ { parameter = "parameter"
       , name = "Sensor"
       , unit = "unit"
       , session_count = 1
       }
-    , { id_ = "parameter-sensor2 (unit)"
-      , parameter = "parameter"
-      , label = "Sensor2 (unit)"
+    , { parameter = "parameter"
       , name = "Sensor2"
       , unit = "unit"
       , session_count = 2
       }
-    , { id_ = "parameter2-sensor3 (unit)"
-      , parameter = "parameter2"
-      , label = "Sensor3 (unit)"
+    , { parameter = "parameter2"
       , name = "Sensor3"
       , unit = "unit"
       , session_count = 1
@@ -211,37 +185,27 @@ sensors =
 
 sensorsWithPriority : List Sensor
 sensorsWithPriority =
-    [ { id_ = "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
-      , parameter = "Particulate Matter"
-      , label = "AirBeam2-PM2.5 (µg/m³)"
+    [ { parameter = "Particulate Matter"
       , name = "AirBeam2-PM2.5"
       , unit = "µg/m³"
       , session_count = 1
       }
-    , { id_ = "Particulate Matter-airbeam2-pm1 (µg/m³)"
-      , parameter = "Particulate Matter"
-      , label = "AirBeam2-PM1 (µg/m³)"
+    , { parameter = "Particulate Matter"
       , name = "AirBeam2-PM1"
       , unit = "µg/m³"
       , session_count = 1
       }
-    , { id_ = "Particulate Matter-airbeam2-pm10 (µg/m³)"
-      , parameter = "Particulate Matter"
-      , label = "AirBeam2-PM10 (µg/m³)"
+    , { parameter = "Particulate Matter"
       , name = "AirBeam2-PM10"
       , unit = "µg/m³"
       , session_count = 1
       }
-    , { id_ = "Particulate Matter-airbeam-pm (µg/m³)"
-      , parameter = "Particulate Matter"
-      , label = "AirBeam-PM (µg/m³)"
+    , { parameter = "Particulate Matter"
       , name = "AirBeam-PM"
       , unit = "µg/m³"
       , session_count = 1
       }
-    , { id_ = "Particulate Matter-other label (µg/m³)"
-      , parameter = "Particulate Matter"
-      , label = "Other Label (µg/m³)"
+    , { parameter = "Particulate Matter"
       , name = "Other Label"
       , unit = "µg/m³"
       , session_count = 1

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -69,5 +69,9 @@ const setupHeatMap = () => {
     for (var i = 0; i < connect.length; i++) {
       connect[i].classList.add(classes[i]);
     }
+
+    window.__elmApp.ports.updateHeatMapThresholds.subscribe(({ h1, h2, h3, h4, h5 }) => {
+      node.noUiSlider.set([h2, h3, h4]);
+    });
   }
 };


### PR DESCRIPTION
* fetch heat levels for sensor on app init
* refactor sensor to remove `label` and `id_`. The rationale is that those two can be calculated with the other properties of a `Sensor`. "Caching" them poses the risk of getting out of sync