### PR TITLE
Proper color for dots in sessions cards

### DIFF
--- a/app/assets/stylesheets/settings/colors.css.scss
+++ b/app/assets/stylesheets/settings/colors.css.scss
@@ -1,3 +1,7 @@
+.grey-bg {
+  background: grey; // TODO
+}
+
 .green-bg {
   background: $green;
 }

--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -144,4 +144,7 @@ export const SessionsListCtrl = (
 }
 
 const formatSessionForElm = s =>
-  ({ ...s , shortTypes: s.shortTypes.map(({ name, type }) => ({ name, type_: type })) });
+  ({
+    ...s,
+    shortTypes: s.shortTypes.map(({ name, type }) => ({ name, type_: type }))
+  });

--- a/app/javascript/angular/code/values/session.js
+++ b/app/javascript/angular/code/values/session.js
@@ -4,7 +4,10 @@ export const formatSessionForList = session => ({
   id: session.id,
   startTime: session.startTime,
   endTime: session.endTime,
-  shortTypes: session.shortTypes
+  shortTypes: session.shortTypes,
+  // average for mobile sessions, last_hour_average for streaming fixed sessions
+  // non-streaming fixed sessions do not have average
+  average: session.average || session.last_hour_average || null
 });
 
 const average = (session, selectedSensor) => session.streams[selectedSensor].average_value;

--- a/app/javascript/elm/src/Data/HeatMapThresholds.elm
+++ b/app/javascript/elm/src/Data/HeatMapThresholds.elm
@@ -1,4 +1,17 @@
-module Data.HeatMapThresholds exposing (HeatMapThresholdValues, HeatMapThresholds, Threshold, extremes, fetch, resetToDefaults, toValues, updateFromValues, updateMaximum, updateMinimum)
+module Data.HeatMapThresholds exposing
+    ( HeatMapThresholdValues
+    , HeatMapThresholds
+    , Range(..)
+    , Threshold
+    , extremes
+    , fetch
+    , rangeFor
+    , resetToDefaults
+    , toValues
+    , updateFromValues
+    , updateMaximum
+    , updateMinimum
+    )
 
 import Http
 import Json.Decode as Decode exposing (Decoder(..))
@@ -28,6 +41,15 @@ type alias HeatMapThresholdValues =
     }
 
 
+type Range
+    = Range1
+    | Range2
+    | Range3
+    | Range4
+    | Range5
+    | Range6
+
+
 updateThresholdValue : Int -> Threshold -> Threshold
 updateThresholdValue value threshold =
     { threshold | value = value }
@@ -46,6 +68,27 @@ toValues { threshold1, threshold2, threshold3, threshold4, threshold5 } =
     , threshold4 = threshold4.value
     , threshold5 = threshold5.value
     }
+
+
+rangeFor : Int -> HeatMapThresholds -> Range
+rangeFor i thresholds =
+    if i < thresholds.threshold1.value then
+        Range1
+
+    else if i <= thresholds.threshold2.value then
+        Range2
+
+    else if i <= thresholds.threshold3.value then
+        Range3
+
+    else if i <= thresholds.threshold4.value then
+        Range4
+
+    else if i <= thresholds.threshold5.value then
+        Range5
+
+    else
+        Range6
 
 
 resetToDefaults : HeatMapThresholds -> HeatMapThresholds

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -1,10 +1,13 @@
 module Data.SelectedSession exposing (SelectedSession, decoder, fetch, sensorNameFromId, view)
 
+import Data.HeatMapThresholds as HeatMapThresholds exposing (HeatMapThresholds)
 import Data.Page exposing (Page(..))
+import Data.Session
 import Html exposing (Html, div, p, span, text)
 import Html.Attributes exposing (class)
 import Http
 import Json.Decode as Decode exposing (Decoder(..))
+import RemoteData exposing (WebData)
 
 
 type alias SelectedSession =
@@ -67,25 +70,25 @@ fetch sensorId page id toCmd =
         }
 
 
-view : SelectedSession -> Html msg
-view session =
+view : SelectedSession -> WebData HeatMapThresholds -> Html msg
+view session heatMapThresholds =
     div []
         [ p [ class "single-session-name" ] [ text session.title ]
         , p [ class "single-session-username" ] [ text session.username ]
         , p [ class "single-session-sensor" ] [ text session.sensorName ]
         , div []
-            [ div [ class "single-session-avg-color green-bg" ] []
+            [ div [ class "single-session-avg-color", class <| Data.Session.classByValue (Just session.average) heatMapThresholds ] []
             , span [ class "single-session-info" ] [ text "avg. " ]
             , span [ class "single-session-avg" ] [ text <| String.fromInt <| round session.average ]
             ]
         , div [ class "session-numbers-container" ]
             [ div [ class "single-min-max-container" ]
-                [ div [ class "single-session-color green-bg" ] []
+                [ div [ class "single-session-color", class <| Data.Session.classByValue (Just session.min) heatMapThresholds ] []
                 , span [ class "single-session-info" ] [ text "min. " ]
                 , span [ class "single-session-min" ] [ text <| String.fromFloat session.min ]
                 ]
             , div [ class "single-min-max-container" ]
-                [ div [ class "single-session-color green-bg" ] []
+                [ div [ class "single-session-color", class <| Data.Session.classByValue (Just session.max) heatMapThresholds ] []
                 , span [ class "single-session-info" ] [ text "max. " ]
                 , span [ class "single-session-max" ] [ text <| String.fromFloat session.max ]
                 ]

--- a/app/javascript/elm/src/Data/Session.elm
+++ b/app/javascript/elm/src/Data/Session.elm
@@ -1,4 +1,8 @@
-module Data.Session exposing (Session, ShortType)
+module Data.Session exposing (Session, ShortType, classByValue)
+
+import Data.HeatMapThresholds as HeatMapThresholds exposing (HeatMapThresholds, Range(..))
+import Maybe exposing (Maybe)
+import RemoteData exposing (RemoteData(..), WebData)
 
 
 type alias ShortType =
@@ -14,4 +18,32 @@ type alias Session =
     , endTime : String
     , username : String
     , shortTypes : List ShortType
+    , average : Maybe Float
     }
+
+
+classByValue : Maybe Float -> WebData HeatMapThresholds -> String
+classByValue average heatMapThresholds =
+    case ( average, heatMapThresholds ) of
+        ( Just avg, Success thresholds ) ->
+            case HeatMapThresholds.rangeFor (round avg) thresholds of
+                Range1 ->
+                    "grey-bg"
+
+                Range2 ->
+                    "green-bg"
+
+                Range3 ->
+                    "yellow-bg"
+
+                Range4 ->
+                    "orange-bg"
+
+                Range5 ->
+                    "red-bg"
+
+                Range6 ->
+                    "grey-bg"
+
+        ( _, _ ) ->
+            "grey-bg"

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -534,6 +534,7 @@ session =
     , endTime = "end time"
     , username = "username"
     , shortTypes = shortTypes
+    , average = Nothing
     }
 
 


### PR DESCRIPTION
This PR adds changing color to dots in sessions views depending on the heat map values:

- no selections
![Screen Shot 2019-04-18 at 11 45 37](https://user-images.githubusercontent.com/5238698/56352474-9c4e1c00-61cf-11e9-97cd-fe90069bb804.png)

- selected session
![Screen Shot 2019-04-18 at 11 45 28](https://user-images.githubusercontent.com/5238698/56352475-9c4e1c00-61cf-11e9-8e9d-07cb69869545.png)


I'm prolly under the influence of https://rbcs-us.com/documents/Why-Most-Unit-Testing-is-Waste.pdf and https://www.infoq.com/presentations/error-prevention-ethics cause I can't find good reasons for testing lately. 