### PR TITLE
Format dates

### DIFF
--- a/app/javascript/angular/code/services/sessions_downloader.js
+++ b/app/javascript/angular/code/services/sessions_downloader.js
@@ -37,9 +37,8 @@ angular.module("aircasting").factory("sessionsDownloader", ['$rootScope', '$http
 
     _(data).each(function(session){
       if(session.start_time_local && session.end_time_local) {
-        times = [moment(session.start_time_local, "YYYY-MM-DDTHH:mm:ss"), moment(session.end_time_local, "YYYY-MM-DDTHH:mm:ss")];
-        session.startTime = times[0].format('MM/DD/YYYY, HH:mm');
-        session.endTime = times[1].format('MM/DD/YYYY, HH:mm');
+        session.startTime = moment(session.start_time_local).utc().valueOf();
+        session.endTime = moment(session.end_time_local).utc().valueOf();
       }
 
       session.streams = keysToLowerCase(session.streams)

--- a/app/javascript/elm/src/Data/Session.elm
+++ b/app/javascript/elm/src/Data/Session.elm
@@ -1,8 +1,10 @@
-module Data.Session exposing (Session, ShortType, classByValue)
+module Data.Session exposing (Session, ShortType, classByValue, decoder)
 
 import Data.HeatMapThresholds as HeatMapThresholds exposing (HeatMapThresholds, Range(..))
+import Json.Decode as Decode exposing (Decoder(..))
 import Maybe exposing (Maybe)
 import RemoteData exposing (RemoteData(..), WebData)
+import Time exposing (Posix)
 
 
 type alias ShortType =
@@ -14,12 +16,31 @@ type alias ShortType =
 type alias Session =
     { title : String
     , id : Int
-    , startTime : String
-    , endTime : String
+    , startTime : Posix
+    , endTime : Posix
     , username : String
     , shortTypes : List ShortType
     , average : Maybe Float
     }
+
+
+decoder : Decoder Session
+decoder =
+    Decode.map7 Session
+        (Decode.field "title" Decode.string)
+        (Decode.field "id" Decode.int)
+        (Decode.field "startTime" Decode.int |> Decode.map Time.millisToPosix)
+        (Decode.field "endTime" Decode.int |> Decode.map Time.millisToPosix)
+        (Decode.field "username" Decode.string)
+        (Decode.field "shortTypes" <| Decode.list shortTypeDecoder)
+        (Decode.field "average" <| Decode.nullable Decode.float)
+
+
+shortTypeDecoder : Decoder ShortType
+shortTypeDecoder =
+    Decode.map2 ShortType
+        (Decode.field "name" Decode.string)
+        (Decode.field "type_" Decode.string)
 
 
 classByValue : Maybe Float -> WebData HeatMapThresholds -> String

--- a/app/javascript/elm/src/Data/Times.elm
+++ b/app/javascript/elm/src/Data/Times.elm
@@ -1,0 +1,79 @@
+module Data.Times exposing (format)
+
+import Time exposing (Month(..), Posix)
+
+
+format : Posix -> Posix -> ( String, String )
+format start end =
+    let
+        toFullDate p =
+            toMonth p ++ "/" ++ toDay p ++ "/" ++ toYear p ++ ", " ++ toTime p
+
+        toTime p =
+            toHour p ++ ":" ++ toMinute p
+
+        areOnSameDate p1 p2 =
+            toYear p1 == toYear p2 && toMonth p1 == toMonth p2 && toDay p1 == toDay p2
+
+        toYear =
+            String.fromInt << Time.toYear Time.utc
+
+        toMonth =
+            monthToString << Time.toMonth Time.utc
+
+        toDay =
+            String.padLeft 2 '0' << String.fromInt << Time.toDay Time.utc
+
+        toHour =
+            String.padLeft 2 '0' << String.fromInt << Time.toHour Time.utc
+
+        toMinute =
+            String.padLeft 2 '0' << String.fromInt << Time.toMinute Time.utc
+    in
+    ( toFullDate start
+    , if areOnSameDate start end then
+        toTime end
+
+      else
+        toFullDate end
+    )
+
+
+monthToString : Month -> String
+monthToString month =
+    case month of
+        Jan ->
+            "01"
+
+        Feb ->
+            "02"
+
+        Mar ->
+            "03"
+
+        Apr ->
+            "04"
+
+        May ->
+            "05"
+
+        Jun ->
+            "06"
+
+        Jul ->
+            "07"
+
+        Aug ->
+            "08"
+
+        Sep ->
+            "09"
+
+        Oct ->
+            "10"
+
+        Nov ->
+            "11"
+
+        Dec ->
+            "12"

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -60,7 +60,7 @@ port updateResolution : Int -> Cmd a
 port selectSensorId : String -> Cmd a
 
 
-port updateSessions : (List Session -> msg) -> Sub msg
+port updateSessions : (Encode.Value -> msg) -> Sub msg
 
 
 port toggleSession : { deselected : Maybe Int, selected : Maybe Int } -> Cmd msg

--- a/app/javascript/elm/tests/Data/SelectedSessionTests.elm
+++ b/app/javascript/elm/tests/Data/SelectedSessionTests.elm
@@ -1,9 +1,7 @@
 module Data.SelectedSessionTests exposing (suite)
 
-import Data.SelectedSession exposing (sensorNameFromId)
+import Data.SelectedSession exposing (..)
 import Expect
-import Fuzz exposing (int, list, string)
-import Json.Encode as Encode
 import Sensor exposing (..)
 import Test exposing (..)
 

--- a/app/javascript/elm/tests/Data/TimesTests.elm
+++ b/app/javascript/elm/tests/Data/TimesTests.elm
@@ -1,0 +1,97 @@
+module Data.TimesTests exposing (suite)
+
+import Data.Times exposing (..)
+import Expect
+import Fuzz exposing (intRange)
+import Iso8601
+import Sensor exposing (..)
+import Test exposing (..)
+import Time
+
+
+suite : Test
+suite =
+    describe "Data.Times"
+        [ fuzz (intRange 1000 3000) "when on different years format returns full dates" <|
+            \i ->
+                let
+                    startYear =
+                        String.fromInt i
+
+                    endYear =
+                        String.fromInt <| i + 1
+
+                    start =
+                        Iso8601.toTime (startYear ++ "-12-31T13:12:00.000Z")
+                            |> Result.withDefault (Time.millisToPosix 0)
+
+                    end =
+                        Iso8601.toTime (endYear ++ "-12-31T13:12:00.000Z")
+                            |> Result.withDefault (Time.millisToPosix 0)
+
+                    expected =
+                        ( "12/31/" ++ startYear ++ ", 13:12", "12/31/" ++ endYear ++ ", 13:12" )
+                in
+                format start end
+                    |> Expect.equal expected
+        , fuzz (intRange 1 11) "when on different months format returns full dates" <|
+            \i ->
+                let
+                    startMonth =
+                        String.padLeft 2 '0' <| String.fromInt i
+
+                    endMonth =
+                        String.padLeft 2 '0' <| String.fromInt (i + 1)
+
+                    start =
+                        Iso8601.toTime ("2000-" ++ startMonth ++ "-28T13:12:00.000Z")
+                            |> Result.withDefault (Time.millisToPosix 0)
+
+                    end =
+                        Iso8601.toTime ("2000-" ++ endMonth ++ "-28T13:12:00.000Z")
+                            |> Result.withDefault (Time.millisToPosix 0)
+
+                    expected =
+                        ( startMonth ++ "/28/2000, 13:12", endMonth ++ "/28/2000, 13:12" )
+                in
+                format start end
+                    |> Expect.equal expected
+        , fuzz (intRange 1 30) "when on different days format returns full dates" <|
+            \i ->
+                let
+                    startDay =
+                        String.padLeft 2 '0' <| String.fromInt i
+
+                    endDay =
+                        String.padLeft 2 '0' <| String.fromInt (i + 1)
+
+                    start =
+                        Iso8601.toTime ("2000-01-" ++ startDay ++ "T13:12:00.000Z")
+                            |> Result.withDefault (Time.millisToPosix 0)
+
+                    end =
+                        Iso8601.toTime ("2000-01-" ++ endDay ++ "T13:12:00.000Z")
+                            |> Result.withDefault (Time.millisToPosix 0)
+
+                    expected =
+                        ( "01/" ++ startDay ++ "/2000, 13:12", "01/" ++ endDay ++ "/2000, 13:12" )
+                in
+                format start end
+                    |> Expect.equal expected
+        , test "when on same dates format returns the full date for start and just time for end" <|
+            \_ ->
+                let
+                    start =
+                        Iso8601.toTime "2010-12-31T09:08:00.000Z"
+                            |> Result.withDefault (Time.millisToPosix 0)
+
+                    end =
+                        Iso8601.toTime "2010-12-31T13:22:00.000Z"
+                            |> Result.withDefault (Time.millisToPosix 0)
+
+                    expected =
+                        ( "12/31/2010, 09:08", "13:22" )
+                in
+                format start end
+                    |> Expect.equal expected
+        ]

--- a/app/services/api/to_session_hash.rb
+++ b/app/services/api/to_session_hash.rb
@@ -17,16 +17,16 @@ class Api::ToSessionHash
       sensor_name: session.streams.first.sensor_name,
       average: average(measurements(session)),
       measurements: measurements(session),
-      startTime: format_datetime(session.start_time_local),
-      endTime: format_datetime(session.end_time_local),
+      startTime: format_time(session.start_time_local),
+      endTime: format_time(session.end_time_local),
       id: session.id,
     )
   end
 
   private
 
-  def format_datetime(datetime)
-    datetime.strftime("%m/%d/%Y, %H:%M")
+  def format_time(time)
+    time.to_datetime.strftime("%Q").to_i
   end
 
   def average(xs)

--- a/elm.json
+++ b/elm.json
@@ -17,11 +17,13 @@
             "elm-community/html-extra": "3.1.0",
             "elm-community/maybe-extra": "5.0.0",
             "fapian/elm-html-aria": "1.4.0",
-            "krisajenkins/remotedata": "6.0.1"
+            "krisajenkins/remotedata": "6.0.1",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.4",
+            "elm/parser": "1.1.0",
             "elm/virtual-dom": "1.0.2"
         }
     },

--- a/spec/controllers/api/fixed/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/sessions_controller_spec.rb
@@ -26,8 +26,8 @@ describe Api::Fixed::SessionsController do
         "sensor_name" => sensor_name,
         "average" => 1.5,
         "measurements" => [value1, value2],
-        "startTime" => "10/01/2000, 02:03",
-        "endTime" => "11/04/2001, 05:06",
+        "startTime" => 970365780000,
+        "endTime" => 1004850360000,
         "id" => session.id,
       }
       expect(json_response).to eq(expected)

--- a/spec/controllers/api/mobile/sessions_controller_spec.rb
+++ b/spec/controllers/api/mobile/sessions_controller_spec.rb
@@ -26,8 +26,8 @@ describe Api::Mobile::SessionsController do
         "sensor_name" => sensor_name,
         "average" => 1.5,
         "measurements" => [value1, value2],
-        "startTime" => "10/01/2000, 02:03",
-        "endTime" => "11/04/2001, 05:06",
+        "startTime" => 970365780000,
+        "endTime" => 1004850360000,
         "id" => session.id,
       }
       expect(json_response).to eq(expected)


### PR DESCRIPTION
* Whenever dates are on the same date (ie same month, year, day) show "MM/DD/YYYY mm:hh mm:hh" instead of "MM/DD/YYYY mm:hh MM/DD/YYYY mm:hh"

To make that happen I've decided to pass to Elm the time in milliseconds and decide in Elm what to do. Since the times come from Angular for the sessions list and from Rails for the single session this is the best way to avoid rewriting the logic in both Rails and Angular. Also, this way we have more options in the future when it comes to manipulate times in the frontend. 
Read the [readme for elm/time](https://package.elm-lang.org/packages/elm/time/latest/) to see why using Posix is a good idea.

Up until now we were passing `List Session` though the port and leaving to the Elm runtime to translate the JSON into a value of type `List Session`. Now that we are passing times in milliseconds the easy way to get sessions with time in posix is to decode them. Plus having the decoder gives us more options when it comes to handling failures. 