### PR TITLE
Avoid session path below graph when selecting a session

### DIFF
--- a/app/javascript/angular/code/calculateBounds.js
+++ b/app/javascript/angular/code/calculateBounds.js
@@ -1,10 +1,4 @@
-import { pixelsToLength } from "./mapsUtils.js";
-
-// The graph is ~220px high. For whatever reason the OFFSET_IN_PIXEL
-// must be 1000 to not have the session path covered by the graph.
-const OFFSET_IN_PIXEL = 1000;
-
-export const calculateBounds_ = pixelsToLength => (sensors, sessions, zoom) => {
+export const calculateBounds = (sensors, sessions) => {
   const maxLat = [];
   const minLat = [];
   const maxLong = [];
@@ -28,11 +22,7 @@ export const calculateBounds_ = pixelsToLength => (sensors, sessions, zoom) => {
   var west = Math.min.apply(null, minLong);
   var east = Math.max.apply(null, maxLong);
 
-  south = south - pixelsToLength(OFFSET_IN_PIXEL, zoom);
-
   if (!north) return;
 
   return { north, east, south, west };
 };
-
-export const calculateBounds = calculateBounds_(pixelsToLength);

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -105,7 +105,9 @@ export const fixedSessions = (
             bounds: map.getBounds(),
             zoom: map.getZoom()
           };
-          map.fitBounds(calculateBounds(sensors, allSelected, map.getZoom()));
+          map.fitBoundsWithBottomPadding(
+            calculateBounds(sensors, allSelected, map.getZoom())
+          );
         }
       };
       this._selectSession(id, fitBounds);

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -120,7 +120,9 @@ export const mobileSessions = (
           this.drawSessionWithLabel(session, sensorName);
         const draw = () =>
           drawSession.drawMobileSession(session, drawSessionStartingMarker);
-        map.fitBounds(calculateBounds(sensors, allSelected, map.getZoom()));
+        map.fitBoundsWithBottomPadding(
+          calculateBounds(sensors, allSelected, map.getZoom())
+        );
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       };
       this._selectSession(id, callback);

--- a/app/javascript/angular/code/services/google/google_maps.js
+++ b/app/javascript/angular/code/services/google/google_maps.js
@@ -1,3 +1,5 @@
+const SELECTED_SESSION_DIV_HEIGHT = 220;
+
 angular.module("google").factory("googleMaps", [
   () => {
     let onPanOrZoomHandle;
@@ -13,6 +15,14 @@ angular.module("google").factory("googleMaps", [
         status === google.maps.GeocoderStatus.OK,
 
       fitBounds: (mapObj, viewport) => mapObj.fitBounds(viewport),
+
+      fitBoundsWithBottomPadding: (mapObj, viewport) =>
+        mapObj.fitBounds(viewport, {
+          bottom: SELECTED_SESSION_DIV_HEIGHT,
+          top: 0,
+          left: 0,
+          right: 0
+        }),
 
       unlistenPanOrZoom,
 

--- a/app/javascript/angular/tests/_fixed_sessions.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions.test.js
@@ -247,8 +247,8 @@ test("hasSelectedSessions with selected session returns true", t => {
   t.end();
 });
 
-test("selectSession with indoor session after successfully fetching calls map.fitBounds", t => {
-  const map = mock("fitBounds");
+test("selectSession with indoor session after successfully fetching calls map.fitBoundsWithBottomPadding", t => {
+  const map = mock("fitBoundsWithBottomPadding");
   const sessionsUtils = { find: () => ({ is_indoor: false }) };
   const sensors = { sensors: { 123: { sensor_name: "sensor_name" } } };
   const fixedSessionsService = _fixedSessions({ map, sessionsUtils, sensors });

--- a/app/javascript/angular/tests/_map.test.js
+++ b/app/javascript/angular/tests/_map.test.js
@@ -333,6 +333,10 @@ const mockGoogleMaps = ({ successfulGeocoding } = {}) => {
       calls.push(arg);
       count += 1;
     },
+    fitBoundsWithBottomPadding: (_, arg) => {
+      calls.push(arg);
+      count += 1;
+    },
     wasCalled: () => count === 1,
     wasFitBoundsCalledWith: arg => deepEqual(arg, calls[calls.length - 1]),
     listen: event => {

--- a/app/javascript/angular/tests/_mobile_sessions.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions.test.js
@@ -227,8 +227,8 @@ test("selectSession after successfully fetching calls drawSession.drawMobileSess
   t.end();
 });
 
-test("selectSession after successfully fetching calls map.fitBounds", t => {
-  const map = mock("fitBounds");
+test("selectSession after successfully fetching calls map.fitBoundsWithBottomPadding", t => {
+  const map = mock("fitBoundsWithBottomPadding");
   const mobileSessionsService = _mobileSessions({
     map,
     sensors: { sensors: { 123: { sensor_name: "sensor_name" } } }
@@ -507,6 +507,7 @@ const _mobileSessions = ({
   const _map = {
     getBounds: () => ({}),
     fitBounds: () => {},
+    fitBoundsWithBottomPadding: () => {},
     getZoom: () => {},
     markers: [],
     ...map

--- a/app/javascript/angular/tests/calculateBounds.test.js
+++ b/app/javascript/angular/tests/calculateBounds.test.js
@@ -1,10 +1,10 @@
 import test from "blue-tape";
-import { calculateBounds_ } from "../code/calculateBounds";
+import { calculateBounds } from "../code/calculateBounds";
 
 test("with no selected sensors it returns null", t => {
   const sensors = { anySelected: () => null };
 
-  const actual = calculateBounds_()(sensors);
+  const actual = calculateBounds(sensors);
 
   const expected = undefined;
   t.deepEqual(actual, expected);
@@ -37,10 +37,8 @@ test("returns the correct bounds", t => {
       }
     }
   ];
-  const zoom = 1;
-  const pixelsToLength = () => 0;
 
-  const actual = calculateBounds_(pixelsToLength)(sensors, sessions, zoom);
+  const actual = calculateBounds(sensors, sessions);
 
   const expected = { north: 3, east: 3, south: 1, west: 1 };
   t.deepEqual(actual, expected);
@@ -63,10 +61,8 @@ test("it skips streams with different name than the selected sensor", t => {
       }
     }
   ];
-  const zoom = 1;
-  const pixelsToLength = () => 0;
 
-  const actual = calculateBounds_(pixelsToLength)(sensors, sessions, zoom);
+  const actual = calculateBounds(sensors, sessions);
 
   const expected = {
     north: -Infinity,


### PR DESCRIPTION
Turns out https://github.com/HabitatMap/AirCasting/pull/167 does not work. But this will cause turns out [`fitBounds` accepts a (padding as a second arg](https://developers.google.com/maps/documentation/javascript/reference/map#Map.fitBounds)