### PR TITLE
Fix fixed sessions not showing on the map

### DIFF
--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -147,11 +147,17 @@ export const FixedSessionsMapCtrl = (
       });
 
       const resetTimeRangeFilter = () => {
-        FiltersUtils.setupTimeRangeFilter(
-          onTimeRangeChanged,
-          FiltersUtils.defaultTimeFrom(params.get("data").isStreaming),
-          FiltersUtils.defaultTimeTo(params.get("data").isStreaming)
-        );
+        const timeFrom = params.get("data").isStreaming
+          ? FiltersUtils.oneHourAgo()
+          : FiltersUtils.oneYearAgo();
+
+        const timeTo = params.get("data").isStreaming
+          ? FiltersUtils.presentMoment()
+          : FiltersUtils.endOfToday();
+
+        FiltersUtils.setupTimeRangeFilter(onTimeRangeChanged, timeFrom, timeTo);
+
+        onTimeRangeChanged(timeFrom, timeTo);
       };
 
       FiltersUtils.setupClipboard();

--- a/app/javascript/angular/code/filtersUtils.js
+++ b/app/javascript/angular/code/filtersUtils.js
@@ -2,13 +2,13 @@ import tippy from "tippy.js";
 import Clipboard from "clipboard";
 import moment from "moment";
 
-const endOfToday = () =>
+export const endOfToday = () =>
   moment()
     .utc()
     .endOf("day")
     .format("X");
 
-const oneYearAgo = () =>
+export const oneYearAgo = () =>
   moment()
     .utc()
     .startOf("day")
@@ -25,22 +25,6 @@ export const oneHourAgo = () =>
     .utc()
     .subtract(1, "hour")
     .format("X");
-
-export const defaultTimeFrom = isStreaming => {
-  if (isStreaming) {
-    return oneHourAgo();
-  } else {
-    return oneYearAgo();
-  }
-};
-
-export const defaultTimeTo = isStreaming => {
-  if (isStreaming) {
-    return presentMoment();
-  } else {
-    return endOfToday();
-  }
-};
 
 export const setupTimeRangeFilter = (callback, timeFrom, timeTo) => {
   if (document.getElementById("time-range")) {


### PR DESCRIPTION
This fixes the bug where fixed sessions were not showing on the map. The time parameters were not being updated and sessions weren't properly refetched. A call to `onTimeRangeChanged` function was missing, it was mistakenly removed in a previous PR.