### PR TITLE
Fix showing active sessions when active chosen

### DIFF
--- a/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
@@ -22,10 +22,12 @@ test("it updates defaults", t => {
     usernames: "",
     timeFrom: moment()
       .utc()
-      .subtract(1, "hour")
+      .startOf("day")
+      .subtract(1, "year")
       .format("X"),
     timeTo: moment()
       .utc()
+      .endOf("day")
       .format("X")
   };
   t.deepEqual(defaults, expected);

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -301,16 +301,8 @@ update msg model =
                 )
 
         ToggleStreaming ->
-            -- two branches cos choosing streaming will affect time range filter later on
-            if model.isStreaming then
-                ( { model | isStreaming = False }, Ports.toggleStreaming False )
+            ( { model | isStreaming = not model.isStreaming }, Ports.toggleStreaming (not model.isStreaming) )
 
-            else
-                ( { model | isStreaming = True }, Ports.toggleStreaming True )
-
-        --( { model | isStreaming = True }
-        --, Cmd.batch [ Ports.toggleStreaming True, UpdateTimeRange <last hour> ]
-        --)
         DeselectSession ->
             case model.selectedSession of
                 Success selectedSession ->

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -564,14 +564,6 @@ toggleStreamingFilter =
                     |> Query.find [ Slc.attribute <| ariaLabel "dormant" ]
                     |> Event.simulate Event.click
                     |> Event.expect ToggleStreaming
-        , test "clicking active button triggers ToggleStreaming" <|
-            \_ ->
-                { defaultModel | page = Fixed }
-                    |> view
-                    |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| ariaLabel "active" ]
-                    |> Event.simulate Event.click
-                    |> Event.expect ToggleStreaming
         , test "when isStreaming is true ToggleStreaming triggers Ports.toggleStreaming with False" <|
             \_ ->
                 { defaultModel | page = Fixed }


### PR DESCRIPTION
Fixes active sessions not displaying then viewing active sessions.

`timeFrom` and `timeTo` params shouldn't be taken into account when showing streaming sessions. Streaming sessions are selected by checking `last_measurement_at` within the last hour. Setting `timeFrom` and `timeTo` params might disrupt (and did) the filtering, so they shouldn't be updated when showing streaming sessions. We only want to update the time shown in the time range input but without it affecting anything.

This PR doesn't change the fact that active sessions are also shown in the dormant part. This will require either a backend rewrite or possibly leaving the current behaviour and rephrasing the toggle wording.