### PR TITLE
Formatting dates

### DIFF
--- a/app/assets/stylesheets/modules/single-session.css.scss
+++ b/app/assets/stylesheets/modules/single-session.css.scss
@@ -47,8 +47,7 @@
   margin-bottom: 16px;
 }
 
-.single-session-start,
-.single-session-end {
+.single-session-date {
   font-size: $tiny-font;
 }
 

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -106,10 +106,6 @@ fetch sensors sensorId page id toCmd =
 
 view : SelectedSession -> WebData HeatMapThresholds -> Html msg
 view session heatMapThresholds =
-    let
-        ( start, end ) =
-            Times.format session.startTime session.endTime
-    in
     div []
         [ p [ class "single-session-name" ] [ text session.title ]
         , p [ class "single-session-username" ] [ text session.username ]
@@ -131,6 +127,5 @@ view session heatMapThresholds =
                 , span [ class "single-session-max" ] [ text <| String.fromFloat session.max ]
                 ]
             ]
-        , span [ class "single-session-start" ] [ text start, text " " ]
-        , span [ class "single-session-end" ] [ text end ]
+        , span [ class "single-session-date" ] [ text <| Times.format session.startTime session.endTime ]
         ]

--- a/app/javascript/elm/src/Data/Times.elm
+++ b/app/javascript/elm/src/Data/Times.elm
@@ -3,11 +3,11 @@ module Data.Times exposing (format)
 import Time exposing (Month(..), Posix)
 
 
-format : Posix -> Posix -> ( String, String )
+format : Posix -> Posix -> String
 format start end =
     let
         toFullDate p =
-            toMonth p ++ "/" ++ toDay p ++ "/" ++ toYear p ++ ", " ++ toTime p
+            toMonth p ++ "/" ++ toDay p ++ "/" ++ toYear p ++ " " ++ toTime p
 
         toTime p =
             toHour p ++ ":" ++ toMinute p
@@ -16,7 +16,7 @@ format start end =
             toYear p1 == toYear p2 && toMonth p1 == toMonth p2 && toDay p1 == toDay p2
 
         toYear =
-            String.fromInt << Time.toYear Time.utc
+            String.right 2 << String.fromInt << Time.toYear Time.utc
 
         toMonth =
             monthToString << Time.toMonth Time.utc
@@ -30,13 +30,13 @@ format start end =
         toMinute =
             String.padLeft 2 '0' << String.fromInt << Time.toMinute Time.utc
     in
-    ( toFullDate start
-    , if areOnSameDate start end then
-        toTime end
+    toFullDate start
+        ++ (if areOnSameDate start end then
+                "-" ++ toTime end
 
-      else
-        toFullDate end
-    )
+            else
+                " - " ++ toFullDate end
+           )
 
 
 monthToString : Month -> String

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -695,10 +695,6 @@ viewLoadMore sessionCount =
 
 viewSessionCard : WebData HeatMapThresholds -> Session -> Html Msg
 viewSessionCard heatMapThresholds session =
-    let
-        ( start, end ) =
-            Times.format session.startTime session.endTime
-    in
     div
         [ class "session"
         , Events.onClick <| ToggleSessionSelection session.id
@@ -715,9 +711,7 @@ viewSessionCard heatMapThresholds session =
         , p [ class "session-owner" ]
             [ text session.username ]
         , span [ class "session-dates" ]
-            [ text start ]
-        , span [ class "session-dates" ]
-            [ text end ]
+            [ text <| Times.format session.startTime session.endTime ]
         ]
 
 

--- a/app/javascript/elm/tests/Data/TimesTests.elm
+++ b/app/javascript/elm/tests/Data/TimesTests.elm
@@ -30,7 +30,7 @@ suite =
                             |> Result.withDefault (Time.millisToPosix 0)
 
                     expected =
-                        ( "12/31/" ++ startYear ++ ", 13:12", "12/31/" ++ endYear ++ ", 13:12" )
+                        "12/31/" ++ String.right 2 startYear ++ " 13:12 - 12/31/" ++ String.right 2 endYear ++ " 13:12"
                 in
                 format start end
                     |> Expect.equal expected
@@ -52,7 +52,7 @@ suite =
                             |> Result.withDefault (Time.millisToPosix 0)
 
                     expected =
-                        ( startMonth ++ "/28/2000, 13:12", endMonth ++ "/28/2000, 13:12" )
+                        startMonth ++ "/28/00 13:12 - " ++ endMonth ++ "/28/00 13:12"
                 in
                 format start end
                     |> Expect.equal expected
@@ -74,7 +74,7 @@ suite =
                             |> Result.withDefault (Time.millisToPosix 0)
 
                     expected =
-                        ( "01/" ++ startDay ++ "/2000, 13:12", "01/" ++ endDay ++ "/2000, 13:12" )
+                        "01/" ++ startDay ++ "/00 13:12 - 01/" ++ endDay ++ "/00 13:12"
                 in
                 format start end
                     |> Expect.equal expected
@@ -90,7 +90,7 @@ suite =
                             |> Result.withDefault (Time.millisToPosix 0)
 
                     expected =
-                        ( "12/31/2010, 09:08", "13:22" )
+                        "12/31/10 09:08-13:22"
                 in
                 format start end
                     |> Expect.equal expected

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -735,15 +735,11 @@ viewTests =
 
                     selectedSession_ =
                         { selectedSession | startTime = start, endTime = end }
-
-                    expected =
-                        List.map (\x -> Slc.containing [ Slc.text x ])
-                            [ "12/31/2010, 09:08", "12/31/2011, 13:22" ]
                 in
                 { defaultModel | selectedSession = Success selectedSession_ }
                     |> view
                     |> Query.fromHtml
-                    |> Query.has [ Slc.all expected ]
+                    |> Query.contains [ text "12/31/10 09:08 - 12/31/11 13:22" ]
         , fuzz string "when heatmap minimum input changes UpdateHeatMapMinimum is triggered" <|
             \min ->
                 defaultModel


### PR DESCRIPTION
Small formatting changes to sessions dates as requested by Michael: 
```
-remove the first two digits from the year, i.e. "4/23/2019" should be "4/23/19"

-put a dash between the times and don't use extra spaces, i.e. "13:10-13:48"

-here's an example with everything as it should be for a session that occurs on the same day: 
"4/23/19 13:10-13:48"

-here's an example with everything as it should be for a session that occurs across multiple days:
"4/1/19 13:10 - 4/23/19 9:34"
```