### PR TITLE
Persistent sessions list

### DIFF
--- a/app/controllers/api/measurement_sessions_controller.rb
+++ b/app/controllers/api/measurement_sessions_controller.rb
@@ -34,7 +34,7 @@ module Api
       data[:time_from] = Time.strptime(data[:time_from].to_s, '%s')
       data[:time_to] = Time.strptime(data[:time_to].to_s, '%s')
 
-      respond_with MobileSession.filtered_json(data, page, page_size)
+      respond_with MobileSession.filtered_json(data, page_size, params[:offset])
     end
 
     def show_multiple
@@ -84,10 +84,6 @@ module Api
     end
 
     private
-
-    def page
-      @page ||= params[:page] || 0
-    end
 
     def page_size
       @page_size ||= params[:page_size] || 50

--- a/app/controllers/api/measurement_sessions_controller.rb
+++ b/app/controllers/api/measurement_sessions_controller.rb
@@ -18,7 +18,7 @@
 
 module Api
   class MeasurementSessionsController < BaseController
-    INT_Q_ATTRS = [:time_from, :time_to, :day_from, :day_to]
+    INT_Q_ATTRS = [:time_from, :time_to, :day_from, :day_to, :limit, :offset]
 
     # TokenAuthenticatable was removed from Devise in 3.1
     # https://gist.github.com/josevalim/fb706b1e933ef01e4fb6
@@ -34,7 +34,7 @@ module Api
       data[:time_from] = Time.strptime(data[:time_from].to_s, '%s')
       data[:time_to] = Time.strptime(data[:time_to].to_s, '%s')
 
-      respond_with MobileSession.filtered_json(data, page_size, params[:offset])
+      respond_with MobileSession.filtered_json(data, data[:limit], data[:offset])
     end
 
     def show_multiple
@@ -84,10 +84,6 @@ module Api
     end
 
     private
-
-    def page_size
-      @page_size ||= params[:page_size] || 50
-    end
 
     def decoded_query_data(query)
       if query.is_a?(String)

--- a/app/controllers/api/realtime/sessions_controller.rb
+++ b/app/controllers/api/realtime/sessions_controller.rb
@@ -21,7 +21,7 @@ module Api
     class SessionsController < BaseController
       require 'uri'
 
-      INT_Q_ATTRS = [:time_from, :time_to, :day_from, :day_to]
+      INT_Q_ATTRS = [:time_from, :time_to, :day_from, :day_to, :limit, :offset]
 
       # TokenAuthenticatable was removed from Devise in 3.1
       # https://gist.github.com/josevalim/fb706b1e933ef01e4fb6
@@ -37,7 +37,7 @@ module Api
         data[:time_from] = Time.strptime(data[:time_from].to_s, '%s')
         data[:time_to] = Time.strptime(data[:time_to].to_s, '%s')
 
-        respond_with FixedSession.filtered_json(data, page_size, params[:offset])
+        respond_with FixedSession.filtered_json(data, data[:limit], data[:offset])
       end
 
       def index_streaming
@@ -92,10 +92,6 @@ module Api
       end
 
       private
-
-      def page_size
-        @page_size ||= params[:page_size] || 100
-      end
 
       def decoded_query_data(query)
         if query.is_a?(String)

--- a/app/controllers/api/realtime/sessions_controller.rb
+++ b/app/controllers/api/realtime/sessions_controller.rb
@@ -37,7 +37,7 @@ module Api
         data[:time_from] = Time.strptime(data[:time_from].to_s, '%s')
         data[:time_to] = Time.strptime(data[:time_to].to_s, '%s')
 
-        respond_with FixedSession.filtered_json(data, page, page_size)
+        respond_with FixedSession.filtered_json(data, page_size, params[:offset])
       end
 
       def index_streaming
@@ -92,10 +92,6 @@ module Api
       end
 
       private
-
-      def page
-        @page ||= params[:page] || 0
-      end
 
       def page_size
         @page_size ||= params[:page_size] || 100

--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -85,6 +85,7 @@ export const FixedSessionsMapCtrl = (
       elmApp.ports.selectSensorId.subscribe(sensorId => {
         params.update({ selectedSessionIds: [] });
         params.update({ data: { sensorId } });
+        params.update({ fetchedSessionsCount: 0 });
         sensors.fetchHeatLevels();
         $scope.sessions.fetch();
       });
@@ -95,11 +96,13 @@ export const FixedSessionsMapCtrl = (
 
       elmApp.ports.toggleIndoor.subscribe(isIndoor => {
         params.update({ data: { isIndoor: isIndoor } });
+        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
       elmApp.ports.toggleStreaming.subscribe(isStreaming => {
         params.update({ data: { isStreaming } });
+        params.update({ fetchedSessionsCount: 0 });
         resetTimeRangeFilter();
         $scope.sessions.fetch();
       });
@@ -122,18 +125,21 @@ export const FixedSessionsMapCtrl = (
 
       elmApp.ports.updateTags.subscribe(tags => {
         params.update({ data: { tags: tags.join(", ") } });
+        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
       elmApp.ports.updateProfiles.subscribe(profiles => {
         params.update({ data: { usernames: profiles.join(", ") } });
+        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
       const onTimeRangeChanged = (timeFrom, timeTo) => {
         elmApp.ports.timeRangeSelected.send({ timeFrom, timeTo });
         params.update({ data: { timeFrom, timeTo } });
-        sessions.fetch();
+        params.update({ fetchedSessionsCount: 0 });
+        $scope.sessions.fetch();
       };
 
       const setupStreamingTimeRangeFilter = (timeFrom, timeTo) => {

--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -85,7 +85,6 @@ export const FixedSessionsMapCtrl = (
       elmApp.ports.selectSensorId.subscribe(sensorId => {
         params.update({ selectedSessionIds: [] });
         params.update({ data: { sensorId } });
-        params.update({ fetchedSessionsCount: 0 });
         sensors.fetchHeatLevels();
         $scope.sessions.fetch();
       });
@@ -96,13 +95,11 @@ export const FixedSessionsMapCtrl = (
 
       elmApp.ports.toggleIndoor.subscribe(isIndoor => {
         params.update({ data: { isIndoor: isIndoor } });
-        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
       elmApp.ports.toggleStreaming.subscribe(isStreaming => {
         params.update({ data: { isStreaming } });
-        params.update({ fetchedSessionsCount: 0 });
         resetTimeRangeFilter();
         $scope.sessions.fetch();
       });
@@ -125,20 +122,17 @@ export const FixedSessionsMapCtrl = (
 
       elmApp.ports.updateTags.subscribe(tags => {
         params.update({ data: { tags: tags.join(", ") } });
-        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
       elmApp.ports.updateProfiles.subscribe(profiles => {
         params.update({ data: { usernames: profiles.join(", ") } });
-        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
       const onTimeRangeChanged = (timeFrom, timeTo) => {
         elmApp.ports.timeRangeSelected.send({ timeFrom, timeTo });
         params.update({ data: { timeFrom, timeTo } });
-        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       };
 

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -123,14 +123,12 @@ export const MobileSessionsMapCtrl = (
       elmApp.ports.selectSensorId.subscribe(sensorId => {
         params.update({ selectedSessionIds: [] });
         params.update({ data: { sensorId } });
-        params.update({ fetchedSessionsCount: 0 });
         sensors.fetchHeatLevels();
         $scope.sessions.fetch();
       });
 
       elmApp.ports.toggleCrowdMap.subscribe(crowdMap => {
         params.updateData({ crowdMap });
-        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
@@ -161,13 +159,11 @@ export const MobileSessionsMapCtrl = (
 
       elmApp.ports.updateTags.subscribe(tags => {
         params.update({ data: { tags: tags.join(", ") } });
-        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
       elmApp.ports.updateProfiles.subscribe(profiles => {
         params.update({ data: { usernames: profiles.join(", ") } });
-        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
@@ -175,7 +171,6 @@ export const MobileSessionsMapCtrl = (
         elmApp.ports.timeRangeSelected.send({ timeFrom, timeTo });
 
         params.update({ data: { timeFrom, timeTo } });
-        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       };
 

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -123,11 +123,14 @@ export const MobileSessionsMapCtrl = (
       elmApp.ports.selectSensorId.subscribe(sensorId => {
         params.update({ selectedSessionIds: [] });
         params.update({ data: { sensorId } });
+        params.update({ fetchedSessionsCount: 0 });
         sensors.fetchHeatLevels();
+        $scope.sessions.fetch();
       });
 
       elmApp.ports.toggleCrowdMap.subscribe(crowdMap => {
         params.updateData({ crowdMap });
+        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
@@ -158,11 +161,13 @@ export const MobileSessionsMapCtrl = (
 
       elmApp.ports.updateTags.subscribe(tags => {
         params.update({ data: { tags: tags.join(", ") } });
+        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
       elmApp.ports.updateProfiles.subscribe(profiles => {
         params.update({ data: { usernames: profiles.join(", ") } });
+        params.update({ fetchedSessionsCount: 0 });
         $scope.sessions.fetch();
       });
 
@@ -170,8 +175,8 @@ export const MobileSessionsMapCtrl = (
         elmApp.ports.timeRangeSelected.send({ timeFrom, timeTo });
 
         params.update({ data: { timeFrom, timeTo } });
-
-        sessions.fetch();
+        params.update({ fetchedSessionsCount: 0 });
+        $scope.sessions.fetch();
       };
 
       FiltersUtils.setupTimeRangeFilter(

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -124,7 +124,6 @@ export const MobileSessionsMapCtrl = (
         params.update({ selectedSessionIds: [] });
         params.update({ data: { sensorId } });
         sensors.fetchHeatLevels();
-        $scope.sessions.fetch();
       });
 
       elmApp.ports.toggleCrowdMap.subscribe(crowdMap => {

--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -49,7 +49,7 @@ export const SessionsListCtrl = (
       console.log("watch - params.get('map')");
       if (sessions.hasSelectedSessions()) return;
       if ($scope.firstLoad || hasChangedProgrammatically) {
-        sessions.fetch({ numberToFetch: params.get("fetchedSessionsCount") });
+        sessions.fetch({ amount: params.get("fetchedSessionsCount") });
       } else {
         sessions.fetch();
       }
@@ -127,7 +127,7 @@ export const SessionsListCtrl = (
 
       elmApp.ports.loadMoreSessions.subscribe(() => {
         sessions.fetch({
-          fetchedSessionsCount: params.get("fetchedSessionsCount")
+          fetchedSessionsCount: sessions.sessions.length
         });
       });
 

--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -56,18 +56,6 @@ export const SessionsListCtrl = (
       console.log("watch - params.get('map')");
       if (sessions.hasSelectedSessions()) return;
       if (!hasChangedProgrammatically) params.update({ fetchedSessionsCount: 0 });
-      sessions.fetch();
-    },
-    true
-  );
-
-  $scope.$watch(
-    "sessionFetchCondition()",
-    (newValue, oldValue) => {
-      console.log("watch - sessionFetchCondition()", newValue, oldValue);
-      if (sessions.hasSelectedSessions()) return;
-      params.update({ fetchedSessionsCount: 0 });
-      sessions.fetch();
     },
     true
   );

--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -21,7 +21,6 @@ export const SessionsListCtrl = (
     $scope.storage = storage;
     $scope.$window = $window;
     $scope.sensors = sensors;
-    $scope.page = 0;
     $scope.markerSelected = markerSelected;
     $window.sessions = sessions = $scope.sessions;
     $scope.sessionsForList = [];
@@ -32,6 +31,7 @@ export const SessionsListCtrl = (
     }
 
     sessions.reSelectAllSessions();
+    if (params.paramsData.fetchedSessionsCount === undefined) params.update({ fetchedSessionsCount: 0 });
   };
 
   $scope.isSessionDisabled = function(sessionId) {
@@ -50,26 +50,13 @@ export const SessionsListCtrl = (
     };
   };
 
-  $scope.updateSessionsPage = function() {
-    $scope.page++;
-  };
-
-  $scope.$watch(
-    "page",
-    () => {
-      console.log("watch - page");
-      sessions.fetch($scope.page);
-    },
-    true
-  );
-
   $scope.$watch(
     "params.get('map')",
     ({ hasChangedProgrammatically }) => {
       console.log("watch - params.get('map')");
       if (sessions.hasSelectedSessions()) return;
-      if (!hasChangedProgrammatically) $scope.page = 0;
-      sessions.fetch($scope.page);
+      if (!hasChangedProgrammatically) params.update({ fetchedSessionsCount: 0 });
+      sessions.fetch();
     },
     true
   );
@@ -79,8 +66,8 @@ export const SessionsListCtrl = (
     (newValue, oldValue) => {
       console.log("watch - sessionFetchCondition()", newValue, oldValue);
       if (sessions.hasSelectedSessions()) return;
-      $scope.page = 0;
-      sessions.fetch($scope.page);
+      params.update({ fetchedSessionsCount: 0 });
+      sessions.fetch();
     },
     true
   );
@@ -153,8 +140,7 @@ export const SessionsListCtrl = (
       });
 
       elmApp.ports.loadMoreSessions.subscribe(() => {
-        $scope.updateSessionsPage();
-        $scope.$apply();
+        sessions.fetch();
       });
 
       elmApp.ports.updateHeatMapThresholds.subscribe(

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -223,9 +223,11 @@ export const fixedSessions = (
       session.markers.push(customMarker);
     },
 
-    _fetch: function(numberToFetch, fetchedSessionsCount) {
+    _fetch: function(values = {}) {
       // if _fetch is called after the route has changed (eg debounced)
       if ($window.location.pathname !== constants.fixedMapRoute) return;
+      const limit = values.amount || 50;
+      const offset = values.fetchedSessionsCount || 0;
 
       const data = params.get("data");
 
@@ -250,8 +252,8 @@ export const fixedSessions = (
           east: map.getBounds().east,
           south: map.getBounds().south,
           north: map.getBounds().north,
-          limit: numberToFetch,
-          offset: fetchedSessionsCount
+          limit,
+          offset
         });
       }
 
@@ -268,7 +270,7 @@ export const fixedSessions = (
       if (params.get("selectedSessionIds").length === 1) {
         this.downloadSessions("/api/realtime/multiple_sessions.json", reqData);
       } else {
-        if (fetchedSessionsCount === 0) this.sessions = [];
+        if (offset === 0) this.sessions = [];
 
         if (data.isStreaming) {
           this.downloadSessions(
@@ -281,11 +283,8 @@ export const fixedSessions = (
       }
     },
 
-    fetch: debounce(function(values = {}) {
-      const numberToFetch = values.numberToFetch || 50;
-      const fetchedSessionsCount = values.fetchedSessionsCount || 0;
-
-      this._fetch(numberToFetch, fetchedSessionsCount);
+    fetch: debounce(function(values) {
+      this._fetch(values);
     }, 750)
   };
   return new FixedSessions();

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -236,7 +236,7 @@ export const mobileSessions = (
         .success(callback(session, allSelected));
     },
 
-    _fetch: function(page) {
+    _fetch: function() {
       // if _fetch is called after the route has changed (eg debounced)
       if ($window.location.pathname !== constants.mobileMapRoute) return;
 
@@ -267,11 +267,9 @@ export const mobileSessions = (
         });
       }
 
-      _(params).extend({ page: page });
-
       drawSession.clear(this.sessions);
 
-      if (page === 0) {
+      if (params.paramsData.fetchedSessionsCount === 0) {
         this.sessions = [];
         // seems to be called for selected sessions; thus, only when loading the app with selections in the url
         sessionsDownloader(
@@ -294,8 +292,8 @@ export const mobileSessions = (
       );
     },
 
-    fetch: debounce(function(page) {
-      this._fetch(page);
+    fetch: debounce(function() {
+      this._fetch();
     }, 750)
   };
   return new MobileSessions();

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -24,10 +24,15 @@ export const mobileSessions = (
     this.scope.params = params;
   };
 
-  let prevMapPosition = {
-    bounds: map.getBounds(),
-    zoom: map.getZoom()
-  };
+  let prevMapPosition = {};
+  if (params.get("selectedSessionIds").length === 1) {
+    prevMapPosition = params.get("prevMapPosition");
+  } else {
+    prevMapPosition = {
+      bounds: map.getBounds(),
+      zoom: map.getZoom()
+    };
+  }
 
   const TIMEOUT_DELAY = process.env.NODE_ENV === "test" ? 0 : 3000;
 
@@ -106,6 +111,7 @@ export const mobileSessions = (
       if (!session) return;
       session.loaded = false;
       session.alreadySelected = false;
+      params.update({ prevMapPosition: {} });
       drawSession.undoDraw(session, prevMapPosition);
     },
 
@@ -116,6 +122,8 @@ export const mobileSessions = (
           bounds: map.getBounds(),
           zoom: map.getZoom()
         };
+        params.update({ prevMapPosition: prevMapPosition });
+
         const drawSessionStartingMarker = (session, sensorName) =>
           this.drawSessionWithLabel(session, sensorName);
         const draw = () =>
@@ -271,7 +279,7 @@ export const mobileSessions = (
 
       drawSession.clear(this.sessions);
 
-      if (params.get("selectedSessionIds").length == 1) {
+      if (params.get("selectedSessionIds").length === 1) {
         sessionsDownloader(
           "/api/multiple_sessions.json",
           reqData,

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -244,9 +244,11 @@ export const mobileSessions = (
         .success(callback(session, allSelected));
     },
 
-    _fetch: function(numberToFetch, fetchedSessionsCount) {
+    _fetch: function(values = {}) {
       // if _fetch is called after the route has changed (eg debounced)
       if ($window.location.pathname !== constants.mobileMapRoute) return;
+      const limit = values.amount || 50;
+      const offset = values.fetchedSessionsCount || 0;
 
       var bounds = map.getBounds();
       var data = params.get("data");
@@ -265,8 +267,8 @@ export const mobileSessions = (
         east: bounds.east,
         south: bounds.south,
         north: bounds.north,
-        limit: numberToFetch,
-        offset: fetchedSessionsCount
+        limit: limit,
+        offset: offset
       });
 
       if (sensors.selected()) {
@@ -289,7 +291,7 @@ export const mobileSessions = (
           _(this.onSessionsFetchError).bind(this)
         );
       } else {
-        if (fetchedSessionsCount === 0) this.sessions = [];
+        if (offset === 0) this.sessions = [];
 
         sessionsDownloader(
           "/api/sessions.json",
@@ -302,11 +304,8 @@ export const mobileSessions = (
       }
     },
 
-    fetch: debounce(function(values = {}) {
-      const numberToFetch = values.numberToFetch || 50;
-      const fetchedSessionsCount = values.fetchedSessionsCount || 0;
-
-      this._fetch(numberToFetch, fetchedSessionsCount);
+    fetch: debounce(function(values) {
+      this._fetch(values);
     }, 750)
   };
   return new MobileSessions();

--- a/app/javascript/angular/code/services/sessions_downloader.js
+++ b/app/javascript/angular/code/services/sessions_downloader.js
@@ -18,14 +18,15 @@ angular.module("aircasting").factory("sessionsDownloader", [
         preprocessData(data, sessions, params);
         refreshSessionsCallback();
       };
-      fetchPage(url, reqData, params.page, successCallback, errorCallback);
+      fetchPage(url, reqData, params.paramsData.fetchedSessionsCount, successCallback, errorCallback);
     };
 
-    var fetchPage = function(url, reqData, page, success, error) {
+    var fetchPage = function(url, reqData, offset, success, error) {
+      console.warn("offset:   ", offset)
       $http
         .get(url, {
           cache: true,
-          params: { q: reqData, page_size: reqData.page_size, page: page }
+          params: { q: {offset: offset, ...reqData}, page_size: reqData.page_size, offset: offset }
         })
         .success(success)
         .error(error);
@@ -79,8 +80,10 @@ angular.module("aircasting").factory("sessionsDownloader", [
 
         setDefaultSessionAttributes(session);
       });
+      console.warn("new: ", sessions, data)
       sessions.push.apply(sessions, data);
       sessions = orderBy(sessions, "end_time_local");
+      params.update({ fetchedSessionsCount: sessions.length });
     };
 
     return fetch;

--- a/app/javascript/angular/code/services/sessions_downloader.js
+++ b/app/javascript/angular/code/services/sessions_downloader.js
@@ -81,7 +81,10 @@ angular.module("aircasting").factory("sessionsDownloader", [
       });
       sessions.push.apply(sessions, data);
       sessions = orderBy(sessions, "end_time_local");
-      params.update({ fetchedSessionsCount: sessions.length });
+
+      if (params.get("selectedSessionIds").length === 0) {
+        params.update({ fetchedSessionsCount: sessions.length });
+      }
     };
 
     return fetch;

--- a/app/javascript/angular/code/services/sessions_downloader.js
+++ b/app/javascript/angular/code/services/sessions_downloader.js
@@ -18,15 +18,14 @@ angular.module("aircasting").factory("sessionsDownloader", [
         preprocessData(data, sessions, params);
         refreshSessionsCallback();
       };
-      fetchPage(url, reqData, params.paramsData.fetchedSessionsCount, successCallback, errorCallback);
+      fetchPage(url, reqData, successCallback, errorCallback);
     };
 
-    var fetchPage = function(url, reqData, offset, success, error) {
-      console.warn("offset:   ", offset)
+    var fetchPage = function(url, reqData, success, error) {
       $http
         .get(url, {
           cache: true,
-          params: { q: {offset: offset, ...reqData}, page_size: reqData.page_size, offset: offset }
+          params: { q: reqData }
         })
         .success(success)
         .error(error);
@@ -80,7 +79,6 @@ angular.module("aircasting").factory("sessionsDownloader", [
 
         setDefaultSessionAttributes(session);
       });
-      console.warn("new: ", sessions, data)
       sessions.push.apply(sessions, data);
       sessions = orderBy(sessions, "end_time_local");
       params.update({ fetchedSessionsCount: sessions.length });

--- a/app/javascript/angular/tests/_fixed_sessions.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions.test.js
@@ -510,7 +510,8 @@ const _fixedSessions = ({
       } else {
         throw new Error(`unexpected param ${what}`);
       }
-    }
+    },
+    update: () => {}
   };
   const _map = {
     getBounds: () => ({}),

--- a/app/javascript/angular/tests/_mobile_sessions.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions.test.js
@@ -502,7 +502,8 @@ const _mobileSessions = ({
       } else {
         throw new Error(`unexpected param ${what}`);
       }
-    }
+    },
+    update: () => {}
   };
   const _map = {
     getBounds: () => ({}),

--- a/app/javascript/angular/tests/_mobile_sessions.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions.test.js
@@ -169,6 +169,63 @@ test("fetch passes map corner coordinates to sessionsDownloader", t => {
   t.end();
 });
 
+test("fetch called without arguments assigns default values", t => {
+  const sessionsDownloaderCalls = [];
+  const mobileSessionsService = _mobileSessions({
+    sessionsDownloaderCalls
+  });
+
+  mobileSessionsService._fetch();
+
+  t.deepEqual(sessionsDownloaderCalls[0].limit, 50);
+  t.deepEqual(sessionsDownloaderCalls[0].offset, 0);
+
+  t.end();
+});
+
+test("fetch called with values passes them to session downloader", t => {
+  const sessionsDownloaderCalls = [];
+  const mobileSessionsService = _mobileSessions({
+    sessionsDownloaderCalls
+  });
+
+  mobileSessionsService._fetch({
+    amount: 100,
+    fetchedSessionsCount: 50
+  });
+
+  t.deepEqual(sessionsDownloaderCalls[0].limit, 100);
+  t.deepEqual(sessionsDownloaderCalls[0].offset, 50);
+
+  t.end();
+});
+
+test("fetch resets sessions list if offset equal 0", t => {
+  const mobileSessionsService = _mobileSessions({});
+
+  mobileSessionsService._fetch({
+    fetchedSessionsCount: 0
+  });
+
+  t.deepEqual(mobileSessionsService.sessions, []);
+
+  t.end();
+});
+
+test("fetch keeps the previous sessions list if offset does not equal 0", t => {
+  const mobileSessionsService = _mobileSessions({});
+
+  mobileSessionsService.sessions = ["someSession"];
+
+  mobileSessionsService._fetch({
+    fetchedSessionsCount: 50
+  });
+
+  t.deepEqual(mobileSessionsService.sessions, ["someSession"]);
+
+  t.end();
+});
+
 test("selectSession after successfully fetching calls sessionsUtils.onSingleSessionFetch", t => {
   const sessionsUtils = mock("onSingleSessionFetch");
   const mobileSessionsService = _mobileSessions({

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -138,8 +138,8 @@ class Session < ActiveRecord::Base
       .local_minutes_range(Utils.minutes_of_day(time_from), Utils.minutes_of_day(time_to))
   end
 
-  def self.filtered_json(data, page, page_size)
-    offset(page.to_i * page_size.to_i)
+  def self.filtered_json(data, page_size, offset)
+    offset(offset)
     .limit(page_size)
     .with_user_and_streams
     .filter(data).as_json(

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -138,9 +138,9 @@ class Session < ActiveRecord::Base
       .local_minutes_range(Utils.minutes_of_day(time_from), Utils.minutes_of_day(time_to))
   end
 
-  def self.filtered_json(data, page_size, offset)
+  def self.filtered_json(data, limit, offset)
     offset(offset)
-    .limit(page_size)
+    .limit(limit)
     .with_user_and_streams
     .filter(data).as_json(
       only: filtered_json_fields,

--- a/doc/api.md
+++ b/doc/api.md
@@ -16,8 +16,8 @@ Endpoints
 
 | name           | type              | default value |
 | :------------- | :---------------- | :------------ |
-| page           | number            | 0             |
-| page_size      | number            | 50            |
+| limit          | number            |               |
+| offset         | number            |               |
 | q[time_from]   | number            |               |
 | q[time_to]     | number            |               |
 | q[tags]        | text              |               |
@@ -35,7 +35,7 @@ Where time_from and time_to are seconds since epoch.
 ### Example request
 
 ```
-curl http://aircasting.org/api/sessions.json?page=0&page_size=50&q[measurements]=true&q[time_from]=0&q[time_to]=1552648500&q[usernames]=HHHDenver&q[location]=Denver&q[sensor_name]=AirBeam-PM&q[unit_symbol]=µg/m³
+curl http://aircasting.org/api/sessions.json?limit=50&offset=0&q[measurements]=true&q[time_from]=0&q[time_to]=1552648500&q[usernames]=HHHDenver&q[location]=Denver&q[sensor_name]=AirBeam-PM&q[unit_symbol]=µg/m³
 ```
 
 ### Example response


### PR DESCRIPTION
Now the number of loaded sessions is saved in the params, so links with more than 50 work.
The map position before selecting a session is saved in the params, so links with preselected session allow a user to deselect it and see the original list (works even when more than 50 was loaded).

