### PR TITLE
Endpoint to return only dormant sessions

### DIFF
--- a/app/controllers/api/fixed/dormant/sessions_controller.rb
+++ b/app/controllers/api/fixed/dormant/sessions_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module Fixed
+    module Dormant
+      class SessionsController < BaseController
+        respond_to :json
+
+        def index
+          q = ActiveSupport::JSON.decode(params[:q]).symbolize_keys
+          q[:time_from] = Time.strptime(q[:time_from].to_s, "%s")
+          q[:time_to] = Time.strptime(q[:time_to].to_s, "%s")
+
+          form = Api::ParamsForm.new(params: q, schema: Api::DormantSessions::Schema, struct: Api::DormantSessions::Struct)
+
+          result = Api::ToDormantSessionsArray.new(form: form).call
+
+          if result.success?
+            render json: result.value, status: :ok
+          else
+            render json: result.errors, status: :bad_request
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/realtime/sessions_controller.rb
+++ b/app/controllers/api/realtime/sessions_controller.rb
@@ -30,24 +30,12 @@ module Api
 
       respond_to :json
 
-      def index
-        data = decoded_query_data(params[:q])
-        INT_Q_ATTRS.each { |key| data[key] = data[key].to_i if data.key?(key) }
-
-        data[:time_from] = Time.strptime(data[:time_from].to_s, '%s')
-        data[:time_to] = Time.strptime(data[:time_to].to_s, '%s')
-
-        respond_with sessions: FixedSession.filtered_json(data, data[:limit], data[:offset]),
-                     fetchableSessionsCount: FixedSession.filter(data).count
-      end
-
       def index_streaming
         data = decoded_query_data(params[:q])
         INT_Q_ATTRS.each { |key| data[key] = data[key].to_i if data.key?(key) }
 
         data[:time_from] = Time.strptime(data[:time_from].to_s, '%s')
         data[:time_to] = Time.strptime(data[:time_to].to_s, '%s')
-        
         sessions = FixedSession.filtered_streaming_json(data)
 
         respond_with sessions: sessions,

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -280,7 +280,7 @@ export const fixedSessions = (
             reqData
           );
         } else {
-          this.downloadSessions("/api/realtime/sessions.json", reqData);
+          this.downloadSessions("/api/fixed/dormant/sessions.json", reqData);
         }
       }
     },

--- a/app/models/api/dormant_sessions.rb
+++ b/app/models/api/dormant_sessions.rb
@@ -1,0 +1,46 @@
+require 'dry-validation'
+require 'dry-struct'
+
+module Api::DormantSessions
+  module Types
+    include Dry::Types.module
+  end
+
+  Schema = Dry::Validation.Schema do
+    required(:time_from).filled(:time?)
+    required(:time_to).filled(:time?)
+    required(:west).filled(:float?)
+    required(:east).filled(:float?)
+    required(:south).filled(:float?)
+    required(:north).filled(:float?)
+    required(:limit).filled(:int?)
+    required(:offset).filled(:int?)
+    required(:sensor_name).filled(:str?)
+    required(:measurement_type).filled(:str?)
+    required(:unit_symbol).filled(:str?)
+    required(:tags)
+    required(:usernames)
+    required(:session_ids).each(:str?)
+    optional(:is_indoor).filled(:bool?)
+  end
+
+  class Struct < Dry::Struct
+    transform_keys(&:to_sym)
+
+    attribute :time_from, Types::Strict::Time
+    attribute :time_to, Types::Strict::Time
+    attribute :west, Types::Coercible::Float
+    attribute :east, Types::Coercible::Float
+    attribute :south, Types::Coercible::Float
+    attribute :north, Types::Coercible::Float
+    attribute :limit, Types::Coercible::Integer
+    attribute :offset, Types::Coercible::Integer
+    attribute :sensor_name, Types::Strict::String
+    attribute :measurement_type, Types::Strict::String
+    attribute :unit_symbol, Types::Strict::String
+    attribute :tags, Types::Strict::String
+    attribute :usernames, Types::Strict::String
+    attribute :session_ids, Types::Strict::Array.of(Types::Coercible::Integer)
+    attribute :is_indoor, Types::Bool.meta(omittable: true)
+  end
+end

--- a/app/models/fixed_session.rb
+++ b/app/models/fixed_session.rb
@@ -24,6 +24,22 @@ class FixedSession < Session
     where("last_measurement_at > ?", Time.current - 1.hour)
   end
 
+  def self.dormant
+    where("last_measurement_at <= ?", Time.current - 1.hour)
+  end
+
+  def self.all_dormant(data, limit, offset)
+    dormant
+    .offset(offset)
+    .limit(limit)
+    .with_user_and_streams
+    .filter(data)
+    .as_json(
+      only: filtered_json_fields,
+      methods: [:username, :streams]
+    )
+  end
+
   def self.filtered_json_fields
     [:id, :title, :start_time_local, :end_time_local, :is_indoor, :latitude, :longitude]
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -94,10 +94,6 @@ class Session < ActiveRecord::Base
       sessions = filter_by_time_range(sessions, data[:time_from], data[:time_to])
     end
 
-    if (id = data[:include_session_id]).present?
-      sessions = (sessions + [Session.find(id)]).uniq
-    end
-
     sessions
   end
 

--- a/app/services/api/to_dormant_sessions_array.rb
+++ b/app/services/api/to_dormant_sessions_array.rb
@@ -1,0 +1,38 @@
+class Api::ToDormantSessionsArray
+  def initialize(form:)
+    @form = form
+  end
+
+  def call
+    return Failure.new(form.errors) if form.invalid?
+
+    Success.new(
+      sessions: FixedSession.all_dormant(data, limit, offset),
+      fetchableSessionsCount: FixedSession.dormant.filter(data).count
+    )
+  end
+
+  private
+
+  attr_reader :form
+
+  def data
+    # dry-struct allows for missing key using `meta(omittable: true)`
+    # This `form` has such a key named `is_indoor`. Unfortunately, when
+    # `is_indoor` in `nil` if accessed with `form.to_h[:is_indoor]`, the
+    # library raises. The solutions are:
+    #   - Using `form.is_indoor`; this in not viable at the moment cause
+    #     the code that is accessing the struct (Session.filter) is used
+    #     by other callers that are passing a vanilla Ruby hash.
+    #   - Passing a vanilla Ruby hash with `form.to_h.to_h`
+    form.to_h.to_h
+  end
+
+  def limit
+    data[:limit]
+  end
+
+  def offset
+    data[:offset]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,12 +54,16 @@ Rails.application.routes.draw do
       get 'multiple_sessions'   => 'sessions#show_multiple'
       get 'streaming_sessions'  => 'sessions#index_streaming'
       get 'sync_measurements'   => 'sessions#sync_measurements'
-      resources :sessions, only: [:create, :index, :show]
+      resources :sessions, only: [:create, :show]
       resources :measurements, only: :create
     end
 
     namespace :fixed do
       get "sessions/:id" => "sessions#show"
+
+      namespace :dormant do
+        get "sessions" => "sessions#index"
+      end
     end
 
     namespace :mobile do

--- a/doc/api.md
+++ b/doc/api.md
@@ -7,7 +7,7 @@ Every response is returned in JSON format.
 Endpoints
 
 - GET `/api/realtime/streaming_sessions.json` -> streaming fixed sessions
-- GET `/api/realtime/sessions.json` -> fixed sessions
+- GET `/api/fixed/dormant/sessions.json` -> fixed dormant sessions
 - GET `/api/sessions.json` -> mobile sessions
 
 **Remember:** this call will not return measurements data for requested sessions. To do that, use either the single session or measurements endpoint below.

--- a/spec/controllers/api/fixed/dormant/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/dormant/sessions_controller_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+
+describe Api::Fixed::Dormant::SessionsController do
+  describe "#index" do
+    it "returns dormant sessions json" do
+      user = create_user!
+      session_time = DateTime.new(2000, 10, 1, 2, 3, 4)
+      create_active_session_and_stream!(user: user, session_time: session_time)
+      dormant_session, dormant_stream = create_dormant_session_and_stream!(user: user, session_time: session_time)
+
+      get :index, q: {
+        time_from: session_time.to_datetime.strftime("%Q").to_i / 1000 - 1,
+        time_to: session_time.to_datetime.strftime("%Q").to_i / 1000 + 1,
+        tags: "",
+        usernames: "",
+        session_ids: [],
+        west: dormant_session.longitude - 1,
+        east: dormant_session.longitude + 1,
+        south: dormant_session.latitude - 1,
+        north: dormant_session.latitude + 1,
+        limit: 2,
+        offset: 0,
+        sensor_name: dormant_stream.sensor_name,
+        measurement_type: dormant_stream.measurement_type,
+        unit_symbol: dormant_stream.unit_symbol
+      }.to_json
+
+      expected = {
+        "fetchableSessionsCount" => 1,
+        "sessions" => [{
+          "id" => dormant_session.id,
+          "end_time_local" => "2000-10-01T02:03:04.000Z",
+          "start_time_local" => "2000-10-01T02:03:04.000Z",
+          "is_indoor" => dormant_session.is_indoor,
+          "latitude" => dormant_session.latitude,
+          "longitude" => dormant_session.longitude,
+          "title" => dormant_session.title,
+          "type" => "FixedSession",
+          "username" => user.username,
+          "streams" => {
+            dormant_stream.sensor_name => {
+              "average_value" => nil,
+              "id" => dormant_stream.id,
+              "max_latitude" => dormant_stream.max_latitude,
+              "max_longitude" => dormant_stream.max_longitude,
+              "measurement_short_type" => dormant_stream.measurement_short_type,
+              "measurement_type" => dormant_stream.measurement_type,
+              "measurements_count" => 1,
+              "min_latitude" => dormant_stream.min_latitude,
+              "min_longitude" => dormant_stream.min_longitude,
+              "sensor_name" => dormant_stream.sensor_name,
+              "sensor_package_name" => dormant_stream.sensor_package_name,
+              "session_id" => dormant_session.id,
+              "size" => 1,
+              "start_latitude" => dormant_stream.start_latitude,
+              "start_longitude" => dormant_stream.start_longitude,
+              "threshold_high" => dormant_stream.threshold_high,
+              "threshold_low" => dormant_stream.threshold_low,
+              "threshold_medium" => dormant_stream.threshold_medium,
+              "threshold_very_high" => dormant_stream.threshold_very_high,
+              "threshold_very_low" => dormant_stream.threshold_very_low,
+              "unit_name" => dormant_stream.unit_name,
+              "unit_symbol" => dormant_stream.unit_symbol
+            }
+          }
+        }]
+      }
+
+      expect(json_response).to eq(expected)
+    end
+  end
+
+  private
+
+  def create_active_session_and_stream!(user:, session_time:)
+    latitude = 123
+    longitude = 234
+    session = create_fixed_session!(
+      user: user,
+      contribute: true,
+      time: session_time,
+      latitude: latitude,
+      longitude: longitude,
+      last_measurement_at: DateTime.current
+    )
+    stream = create_stream!(session: session, latitude: latitude, longitude: longitude)
+    create_measurement!(stream: stream)
+
+    [session, stream]
+  end
+
+  def create_dormant_session_and_stream!(user:, session_time:)
+    latitude = 123
+    longitude = 234
+    session = create_fixed_session!(
+      user: user,
+      contribute: true,
+      time: session_time,
+      latitude: latitude,
+      longitude: longitude,
+      last_measurement_at: DateTime.current - 1.hour - 1.second
+    )
+    stream = create_stream!(session: session, latitude: latitude, longitude: longitude)
+    create_measurement!(stream: stream)
+
+    [session, stream]
+  end
+
+
+  def create_user!
+    User.create!(
+      username: "username",
+      email: "email@example.com",
+      password: "password"
+    )
+  end
+
+  def create_fixed_session!(user:, time:, contribute:, latitude:, longitude:, last_measurement_at:)
+    FixedSession.create!(
+      title: "title",
+      user: user,
+      uuid: SecureRandom.uuid,
+      calibration: 100,
+      offset_60_db: 0,
+      start_time: DateTime.current,
+      start_time_local: time,
+      end_time: DateTime.current,
+      end_time_local: time,
+      is_indoor: true,
+      latitude: latitude,
+      longitude: longitude,
+      contribute: contribute,
+      last_measurement_at: last_measurement_at
+    )
+  end
+
+  def create_stream!(session:, latitude:, longitude:)
+      Stream.create!(
+        session: session,
+        sensor_name: "AirBeam2-F",
+        measurement_short_type: "F",
+        measurement_type: "Temperature",
+        sensor_package_name: "Airbeam2-0018961071B4",
+        unit_name: "fahrenheit",
+        unit_symbol: "F",
+        threshold_very_low: 20,
+        threshold_low: 60,
+        threshold_medium: 70,
+        threshold_high: 80,
+        threshold_very_high: 100,
+        min_latitude: latitude,
+        max_latitude: latitude,
+        min_longitude: longitude,
+        max_longitude: longitude,
+        start_latitude: latitude,
+        start_longitude: longitude
+      )
+  end
+
+  def create_measurement!(stream:)
+    Measurement.create!(
+      time: DateTime.current,
+      latitude: 123,
+      longitude: 123,
+      value: 123,
+      milliseconds: 123,
+      stream: stream
+    )
+  end
+end


### PR DESCRIPTION
Before we were using `/api/realtime/sessions` which returns both active and dormant. This PR removes that endpoint cause it's not used anymore by both mobile and web app.
Also, it moves the endpoint to a more descriptive URL