### PR TITLE
Tooltips

### DIFF
--- a/app/javascript/elm/src/LabelsInput.elm
+++ b/app/javascript/elm/src/LabelsInput.elm
@@ -5,6 +5,7 @@ import Html.Attributes exposing (class, disabled, for, id, name, placeholder, ty
 import Html.Events as Events
 import Html.Events.Extra as ExtraEvents
 import Set exposing (Set)
+import Tooltip exposing (TooltipText)
 
 
 type Model
@@ -68,10 +69,11 @@ update msg model toCmd =
 -- VIEW
 
 
-view : Model -> String -> String -> String -> Bool -> Html Msg
-view model text_ inputId placeholderText isDisabled =
+view : Model -> String -> String -> String -> Bool -> TooltipText -> Html Msg
+view model text_ inputId placeholderText isDisabled tooltipText =
     div []
         [ label [ for inputId ] [ text text_ ]
+        , Tooltip.view tooltipText
         , div [ class "tag-container" ]
             [ input
                 [ id inputId

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -24,6 +24,7 @@ import Sensor exposing (Sensor)
 import String exposing (fromInt)
 import Time exposing (Posix)
 import TimeRange exposing (TimeRange)
+import Tooltip
 import Url exposing (Url)
 
 
@@ -687,8 +688,10 @@ viewSessionTypes model =
     div [ class "sessions-type" ]
         [ a [ href "/mobile_map", classList [ ( "session-type-mobile", True ), ( "selected", model.page == Mobile ) ] ]
             [ text "mobile" ]
+        , Tooltip.view Tooltip.mobileTab
         , a [ href "/fixed_map", classList [ ( "session-type-fixed", True ), ( "selected", model.page == Fixed ) ] ]
             [ text "fixed" ]
+        , Tooltip.view Tooltip.fixedTab
         ]
 
 
@@ -772,10 +775,10 @@ viewMobileFilters model =
     form [ class "filters-form" ]
         [ viewParameterFilter model.sensors model.selectedSensorId
         , viewSensorFilter model.sensors model.selectedSensorId
-        , viewLocation model.location model.isIndoor
+        , viewLocationFilter model.location model.isIndoor
         , TimeRange.view RefreshTimeRange False
-        , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" False
-        , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False
+        , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" False Tooltip.profilesFilter
+        , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False Tooltip.tagsFilter
         , div [ class "filter-separator" ] []
         , viewCrowdMapCheckBox model.isCrowdMapOn
         , if model.isCrowdMapOn then
@@ -791,16 +794,18 @@ viewFixedFilters model =
     form [ class "filters-form" ]
         [ viewParameterFilter model.sensors model.selectedSensorId
         , viewSensorFilter model.sensors model.selectedSensorId
-        , viewLocation model.location model.isIndoor
+        , viewLocationFilter model.location model.isIndoor
         , TimeRange.view RefreshTimeRange model.isStreaming
-        , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" model.isIndoor
-        , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False
+        , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" model.isIndoor Tooltip.profilesFilter
+        , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False Tooltip.tagsFilter
         , label [] [ text "type" ]
+        , Tooltip.view Tooltip.typeToggleFilter
         , div []
             [ viewToggleButton "outdoor" (not model.isIndoor) ToggleIndoor
             , viewToggleButton "indoor" model.isIndoor ToggleIndoor
             ]
         , label [] [ text "streaming" ]
+        , Tooltip.view Tooltip.streamingToggleFilter
         , div []
             [ viewToggleButton "active" model.isStreaming ToggleStreaming
             , viewToggleButton "dormant" (not model.isStreaming) ToggleStreaming
@@ -828,6 +833,7 @@ viewParameterFilter : List Sensor -> String -> Html Msg
 viewParameterFilter sensors selectedSensorId =
     div []
         [ label [ for "parameter" ] [ text "parameter:" ]
+        , Tooltip.view Tooltip.parameterFilter
         , input
             [ id "parameter"
             , class "input-dark"
@@ -847,6 +853,7 @@ viewSensorFilter : List Sensor -> String -> Html Msg
 viewSensorFilter sensors selectedSensorId =
     div []
         [ label [ for "sensor" ] [ text "sensor:" ]
+        , Tooltip.view Tooltip.sensorFilter
         , input
             [ id "sensor"
             , class "input-dark"
@@ -874,6 +881,7 @@ viewCrowdMapCheckBox isCrowdMapOn =
                 ]
                 []
             , label [ for "checkbox-crowd-map" ] [ text "Crowd Map" ]
+            , Tooltip.view Tooltip.crowdMap
             ]
         ]
 
@@ -899,10 +907,11 @@ viewCrowdMapSlider resolution =
         ]
 
 
-viewLocation : String -> Bool -> Html Msg
-viewLocation location isIndoor =
+viewLocationFilter : String -> Bool -> Html Msg
+viewLocationFilter location isIndoor =
     div []
         [ label [ for "location" ] [ text "location:" ]
+        , Tooltip.view Tooltip.locationFilter
         , input
             [ id "location"
             , value location

--- a/app/javascript/elm/src/TimeRange.elm
+++ b/app/javascript/elm/src/TimeRange.elm
@@ -5,6 +5,7 @@ import Html.Attributes exposing (attribute, class, disabled, for, id, name, plac
 import Html.Events as Events
 import Json.Decode as Decode
 import Json.Encode as Encode
+import Tooltip
 
 
 type TimeRange
@@ -53,6 +54,7 @@ view : msg -> Bool -> Html msg
 view refreshTimeRange isDisabled =
     div []
         [ label [ for "time-range" ] [ text "time frame:" ]
+        , Tooltip.view Tooltip.timeRangeFilter
         , input
             [ id "time-range"
             , attribute "autocomplete" "off"

--- a/app/javascript/elm/src/Tooltip.elm
+++ b/app/javascript/elm/src/Tooltip.elm
@@ -1,0 +1,71 @@
+module Tooltip exposing
+    ( TooltipText
+    , crowdMap
+    , fixedTab
+    , locationFilter
+    , mobileTab
+    , parameterFilter
+    , profilesFilter
+    , sensorFilter
+    , streamingToggleFilter
+    , tagsFilter
+    , timeRangeFilter
+    , typeToggleFilter
+    , view
+    )
+
+import Html exposing (Html, span, text)
+import Html.Attributes exposing (attribute)
+
+
+type TooltipText
+    = TooltipText String
+
+
+view : TooltipText -> Html msg
+view (TooltipText tooltipText) =
+    span [ attribute "data-tippy-content" tooltipText ] [ text "?" ]
+
+
+mobileTab =
+    TooltipText "The mobile tab displays measurements from mobile sessions. When recording mobile sessions, measurements are created, timestamped, and geolocated once per second. Average values for the duration of the session are displayed inside the session map markers."
+
+
+fixedTab =
+    TooltipText "The fixed tab displays measurements from fixed sessions. When recording fixed sessions, measurements are created and timestamped once per minute and geocoordinates are fixed to a set location. Hourly average values are displayed inside the session map markers. These measurements are updated on the hour."
+
+
+parameterFilter =
+    TooltipText "The parameter field describes the broad category of environmental or physiological measurements being recorded. The AirCasting platform is device agnostic i.e. it will ingest and display data from any instrument that formats and communicates data according to our formatting and communications protocol."
+
+
+sensorFilter =
+    TooltipText "The sensor field describes the specific make and model of the sensor that is creating measurements."
+
+
+locationFilter =
+    TooltipText "Enter an address, intersection, or postal code to pan and zoom the map to that location."
+
+
+timeRangeFilter =
+    TooltipText "Enter a time frame to view sessions that include measurements with corresponding timestamps."
+
+
+profilesFilter =
+    TooltipText "Enter a profile name or names to filter the sessions by profile name."
+
+
+tagsFilter =
+    TooltipText "Enter a tag or tags to filter the sessions by tags. Tags are keywords assigned to sessions."
+
+
+crowdMap =
+    TooltipText "The CrowdMap averages together all the measurements from all the sessions listed on the sessions list and displays these averages as colored grid cells. The color of each grid cell corresponds to the average intensity of all the measurements recorded in that area. Click on a grid cell to view the underlying data. Increase the CrowdMap resolution to reduce the size of the CrowdMap grid cells. Reduce the CrowdMap resolution to increase the size of the CrowdMap grid cells."
+
+
+typeToggleFilter =
+    TooltipText "Outdoor sessions are recorded by instruments located outdoors. Indoor measurements are recorded by instruments located indoors. Indoor sessions do not include geocoordinates and are therefore not geolocated on the map."
+
+
+streamingToggleFilter =
+    TooltipText "Fixed sessions that have submitted a measurement in the past hour are considered active. Fixed sessions that have not submitted measurements in the past hour are considered dormant."

--- a/app/javascript/elm/tests/LabelsInputTests.elm
+++ b/app/javascript/elm/tests/LabelsInputTests.elm
@@ -7,6 +7,7 @@ import Test exposing (..)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Slc
+import Tooltip
 
 
 all : Test
@@ -14,18 +15,18 @@ all =
     describe "view"
         [ fuzz string "label area has a description" <|
             \description ->
-                LabelsInput.view LabelsInput.empty description "input-id" "placeholder" False
+                LabelsInput.view LabelsInput.empty description "input-id" "placeholder" False Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.has [ Slc.text description ]
         , fuzz bool "label input can be disabled" <|
             \isDisabled ->
-                LabelsInput.view LabelsInput.empty "description" "input-id" "placeholder" isDisabled
+                LabelsInput.view LabelsInput.empty "description" "input-id" "placeholder" isDisabled Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute (type_ "text") ]
                     |> Query.has [ Slc.attribute (disabled isDisabled) ]
         , fuzz string "when user types, updateLabelsSearch is triggered with the input" <|
             \input ->
-                LabelsInput.view LabelsInput.empty "description" "input-id" "placeholder" False
+                LabelsInput.view LabelsInput.empty "description" "input-id" "placeholder" False Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.find [ Slc.tag "input" ]
                     |> Event.simulate (Event.input input)
@@ -36,7 +37,7 @@ all =
                     labels =
                         LabelsInput.withCandidate candidate LabelsInput.empty
                 in
-                LabelsInput.view labels "description" "input-id" "placeholder" False
+                LabelsInput.view labels "description" "input-id" "placeholder" False Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.find [ Slc.tag "input" ]
                     |> Query.has [ Slc.attribute <| value candidate ]
@@ -46,7 +47,7 @@ all =
                     labels =
                         LabelsInput.fromList [ label ]
                 in
-                LabelsInput.view labels "description" "input-id" "placeholder" False
+                LabelsInput.view labels "description" "input-id" "placeholder" False Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.find [ Slc.tag "button" ]
                     |> Event.simulate Event.click

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -4,6 +4,7 @@ import linkIcon from "../../assets/images/link-icon.svg";
 import resetIcon from "../../assets/images/reset-icon.svg";
 import "nouislider";
 import * as graph from "../angular/code/services/graph";
+import tippy from "tippy.js";
 
 document.addEventListener("DOMContentLoaded", () => {
   fetch("/api/sensors.json")
@@ -76,8 +77,22 @@ document.addEventListener("DOMContentLoaded", () => {
       window.__elmApp = Elm.Main.init({ flags });
 
       setupHeatMap();
+
+      setupTooltips();
     });
 });
+
+const setupTooltips = () => {
+  const nodes = document.querySelectorAll("[data-tippy-content]");
+  if (nodes.length === 0) {
+    setTimeout(setupTooltips, 100);
+  } else {
+    tippy(nodes, {
+      placement: "right",
+      arrow: true
+    });
+  }
+};
 
 const setupHeatMap = () => {
   const node = document.getElementById("heatmap");


### PR DESCRIPTION
I've noticed that `filtersUtils.js` adds as options
```
      animateFill: false,
      interactive: true,
      trigger: "manual"
```
could @AkkarinForest or @gitjul double check if any is needed in this case?

Notice that `TooltipText` is an [opaque data type](https://medium.com/@ckoster22/advanced-types-in-elm-opaque-types-ec5ec3b84ed2). That means the type system won't confuse `String`s with `TooltipText`

Stuff is unstyled, there's a ticket for that (https://llp.kanbanery.com/projects/8040/board/tasks/2407513). @gitjul let me know if I can simplify your style task in this PR.