### PR TITLE
Export selected session

### DIFF
--- a/app/javascript/elm/src/Api.elm
+++ b/app/javascript/elm/src/Api.elm
@@ -1,0 +1,15 @@
+module Api exposing (exportLink, exportPath)
+
+
+exportPath : String
+exportPath =
+    "/api/sessions/export.json"
+
+
+exportLink : List { session | id : Int } -> String
+exportLink sessions =
+    let
+        query =
+            String.join "&" << List.map ((++) "session_ids[]=" << String.fromInt << .id)
+    in
+    exportPath ++ "?" ++ query sessions

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -8,12 +8,13 @@ module Data.SelectedSession exposing
     , view
     )
 
+import Api
 import Data.HeatMapThresholds as HeatMapThresholds exposing (HeatMapThresholds)
 import Data.Page exposing (Page(..))
 import Data.Session
 import Data.Times as Times
-import Html exposing (Html, div, p, span, text)
-import Html.Attributes exposing (class)
+import Html exposing (Html, a, div, p, span, text)
+import Html.Attributes exposing (class, href, target)
 import Http
 import Json.Decode as Decode exposing (Decoder(..))
 import Json.Decode.Pipeline exposing (custom, required)
@@ -134,4 +135,5 @@ view session heatMapThresholds =
                 ]
             ]
         , span [ class "single-session-date" ] [ text <| Times.format session.startTime session.endTime ]
+        , a [ target "_blank", href <| Api.exportLink [ session ] ] [ text "export sessions" ]
         ]

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -1,5 +1,6 @@
-module Main exposing (Msg(..), defaultModel, exportPath, update, view)
+module Main exposing (Msg(..), defaultModel, update, view)
 
+import Api
 import Browser exposing (..)
 import Browser.Events
 import Browser.Navigation
@@ -26,11 +27,6 @@ import Time exposing (Posix)
 import TimeRange exposing (TimeRange)
 import Tooltip
 import Url exposing (Url)
-
-
-exportPath : String
-exportPath =
-    "/api/sessions/export.json"
 
 
 
@@ -665,22 +661,13 @@ viewFiltersButtons selectedSession sessions linkIcon =
     case selectedSession of
         NotAsked ->
             div [ class "filters-buttons" ]
-                [ a [ class "filters-button export-button", target "_blank", href <| exportLink sessions ] [ text "export sessions" ]
+                [ a [ class "filters-button export-button", target "_blank", href <| Api.exportLink sessions ] [ text "export sessions" ]
                 , button [ class "filters-button link-button", Events.onClick ShowCopyLinkTooltip, id "copy-link-tooltip" ]
                     [ img [ src linkIcon, alt "Link icon" ] [] ]
                 ]
 
         _ ->
             text ""
-
-
-exportLink : List Session -> String
-exportLink sessions =
-    let
-        query =
-            String.join "&" << List.map ((++) "session_ids[]=" << String.fromInt << .id)
-    in
-    exportPath ++ "?" ++ query sessions
 
 
 viewSessionTypes : Model -> Html Msg

--- a/app/javascript/elm/tests/ApiTests.elm
+++ b/app/javascript/elm/tests/ApiTests.elm
@@ -1,0 +1,31 @@
+module ApiTests exposing (suite)
+
+import Api
+import Expect
+import Fuzz exposing (int)
+import Test exposing (..)
+import TestUtils exposing (defaultSession)
+
+
+suite : Test
+suite =
+    describe "Api: "
+        [ fuzz int "with 1 session exportLink generates the correct link" <|
+            \id ->
+                let
+                    expected =
+                        Api.exportPath ++ "?session_ids[]=" ++ String.fromInt id
+                in
+                [ { defaultSession | id = id } ]
+                    |> Api.exportLink
+                    |> Expect.equal expected
+        , fuzz int "with 2 sessions exportLink generates the correct link" <|
+            \id ->
+                let
+                    expected =
+                        Api.exportPath ++ "?session_ids[]=" ++ String.fromInt id ++ "&session_ids[]=" ++ String.fromInt (id + 1)
+                in
+                [ { defaultSession | id = id }, { defaultSession | id = id + 1 } ]
+                    |> Api.exportLink
+                    |> Expect.equal expected
+        ]

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -1,5 +1,6 @@
 module MainTests exposing (crowdMapArea, locationFilter, parameterSensorFilter, popups, profilesArea, session, sessionWithId, sessionWithTitle, shortTypes, tagsArea, timeFilter, toggleIndoorFilter, toggleStreamingFilter, updateTests, viewTests)
 
+import Api
 import Data.HeatMapThresholds exposing (HeatMapThresholds)
 import Data.Page exposing (Page(..))
 import Data.SelectedSession exposing (SelectedSession)
@@ -670,7 +671,7 @@ viewTests =
             \id ->
                 let
                     expected =
-                        exportPath ++ "?session_ids[]=" ++ String.fromInt id
+                        Api.exportPath ++ "?session_ids[]=" ++ String.fromInt id
                 in
                 { defaultModel | sessions = [ sessionWithId id ], selectedSession = NotAsked }
                     |> view
@@ -681,7 +682,7 @@ viewTests =
             \id ->
                 let
                     expected =
-                        exportPath ++ "?session_ids[]=" ++ String.fromInt id ++ "&session_ids[]=" ++ String.fromInt (id + 1)
+                        Api.exportPath ++ "?session_ids[]=" ++ String.fromInt id ++ "&session_ids[]=" ++ String.fromInt (id + 1)
                 in
                 { defaultModel | sessions = [ sessionWithId id, sessionWithId (id + 1) ], selectedSession = NotAsked }
                     |> view

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -1,10 +1,6 @@
-module MainTests exposing (crowdMapArea, locationFilter, parameterSensorFilter, popups, profilesArea, session, sessionWithId, sessionWithTitle, shortTypes, tagsArea, timeFilter, toggleIndoorFilter, toggleStreamingFilter, updateTests, viewTests)
+module MainTests exposing (crowdMapArea, locationFilter, parameterSensorFilter, popups, profilesArea, tagsArea, timeFilter, toggleIndoorFilter, toggleStreamingFilter, updateTests, viewTests)
 
-import Api
-import Data.HeatMapThresholds exposing (HeatMapThresholds)
 import Data.Page exposing (Page(..))
-import Data.SelectedSession exposing (SelectedSession)
-import Data.Session exposing (..)
 import Expect
 import Fuzz exposing (bool, float, int, intRange, list, string)
 import Html exposing (text)
@@ -22,28 +18,9 @@ import Test exposing (..)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Slc
+import TestUtils exposing (defaultSelectedSession, defaultSensors, defaultSession, heatMapThresholdsWithMaximum, heatMapThresholdsWithMinimum, simulatedEventObject)
 import Time
 import TimeRange
-
-
-heatMapThresholdsWithMinimum : Int -> HeatMapThresholds
-heatMapThresholdsWithMinimum value =
-    { threshold1 = { value = value, default = 1 }
-    , threshold2 = { value = 2, default = 2 }
-    , threshold3 = { value = 3, default = 3 }
-    , threshold4 = { value = 4, default = 4 }
-    , threshold5 = { value = 5, default = 5 }
-    }
-
-
-heatMapThresholdsWithMaximum : Int -> HeatMapThresholds
-heatMapThresholdsWithMaximum value =
-    { threshold1 = { value = 1, default = 1 }
-    , threshold2 = { value = 2, default = 2 }
-    , threshold3 = { value = 3, default = 3 }
-    , threshold4 = { value = 4, default = 4 }
-    , threshold5 = { value = value, default = 5 }
-    }
 
 
 popups : Test
@@ -67,16 +44,6 @@ popups =
         ]
 
 
-sensors : List Sensor.Sensor
-sensors =
-    [ { parameter = "parameter"
-      , name = "Sensor"
-      , unit = "unit"
-      , session_count = 1
-      }
-    ]
-
-
 parameterSensorFilter : Test
 parameterSensorFilter =
     describe "Parameter filter tests: "
@@ -84,7 +51,7 @@ parameterSensorFilter =
             \_ ->
                 { defaultModel
                     | selectedSensorId = "parameter-sensor (unit)"
-                    , sensors = sensors
+                    , sensors = defaultSensors
                 }
                     |> view
                     |> Query.fromHtml
@@ -94,7 +61,7 @@ parameterSensorFilter =
             \_ ->
                 { defaultModel
                     | selectedSensorId = "parameter-sensor (unit)"
-                    , sensors = sensors
+                    , sensors = defaultSensors
                 }
                     |> view
                     |> Query.fromHtml
@@ -380,14 +347,6 @@ profilesArea =
         ]
 
 
-simulatedEventObject value =
-    let
-        target =
-            Encode.object [ ( "value", Encode.string value ) ]
-    in
-    Encode.object [ ( "target", target ) ]
-
-
 crowdMapArea : Test
 crowdMapArea =
     describe "Crowd Map filter test: "
@@ -580,59 +539,12 @@ toggleStreamingFilter =
         ]
 
 
-shortTypes : List ShortType
-shortTypes =
-    [ { name = "name", type_ = "type_" } ]
-
-
-session : Session
-session =
-    { title = "title"
-    , id = 1
-    , startTime = Time.millisToPosix 0
-    , endTime = Time.millisToPosix 0
-    , username = "username"
-    , shortTypes = shortTypes
-    , average = Nothing
-    }
-
-
-sessionWithId : Int -> Session
-sessionWithId id =
-    { session | id = id }
-
-
-sessionWithTitle : String -> Session
-sessionWithTitle title =
-    { session | title = title }
-
-
-selectedSession =
-    { title = "title"
-    , username = "username"
-    , sensorName = "sensor-name"
-    , average = 2.0
-    , min = 1.0
-    , max = 3.0
-    , startTime = Time.millisToPosix 0
-    , endTime = Time.millisToPosix 0
-    , measurements = [ 1.0, 2.0, 3.0 ]
-    , id = 123
-    , streamId = 123
-    }
-
-
-selectedSessionWithId : Int -> SelectedSession
-selectedSessionWithId id =
-    { selectedSession | id = id }
-
-
 viewTests : Test
 viewTests =
     describe "view"
         [ fuzz2 string string "with no selection session titles are displayed in the list" <|
             \title1 title2 ->
-                { defaultModel | sessions = [ sessionWithTitle title1, sessionWithTitle title2 ], selectedSession = NotAsked }
+                { defaultModel | sessions = [ { defaultSession | title = title1 }, { defaultSession | title = title2 } ], selectedSession = NotAsked }
                     |> view
                     |> Query.fromHtml
                     |> Query.contains
@@ -642,7 +554,7 @@ viewTests =
         , fuzz (intRange 1 100) "with no selection and fetchableSessionsCount bigger than current session list length load more button is shown" <|
             \times ->
                 { defaultModel
-                    | sessions = List.repeat times session
+                    | sessions = List.repeat times defaultSession
                     , fetchableSessionsCount = times + 1
                     , selectedSession = NotAsked
                 }
@@ -652,7 +564,7 @@ viewTests =
         , fuzz (intRange 1 100) "with no selection and fetchableSessionsCount equal to current session list length load more button is not shown" <|
             \times ->
                 { defaultModel
-                    | sessions = List.repeat times session
+                    | sessions = List.repeat times defaultSession
                     , fetchableSessionsCount = times
                     , selectedSession = NotAsked
                 }
@@ -667,38 +579,16 @@ viewTests =
                     |> Query.fromHtml
                     |> Query.findAll [ Slc.text "Load More..." ]
                     |> Query.count (Expect.equal 0)
-        , fuzz int "with no selection and 1 sessions in the model the export link is correctly generated" <|
-            \id ->
-                let
-                    expected =
-                        Api.exportPath ++ "?session_ids[]=" ++ String.fromInt id
-                in
-                { defaultModel | sessions = [ sessionWithId id ], selectedSession = NotAsked }
-                    |> view
-                    |> Query.fromHtml
-                    |> Query.find [ Slc.containing [ Slc.text "export sessions" ] ]
-                    |> Query.has [ Slc.attribute <| href expected ]
-        , fuzz int "with no selection and 2 sessions in the model the export link is correctly generated" <|
-            \id ->
-                let
-                    expected =
-                        Api.exportPath ++ "?session_ids[]=" ++ String.fromInt id ++ "&session_ids[]=" ++ String.fromInt (id + 1)
-                in
-                { defaultModel | sessions = [ sessionWithId id, sessionWithId (id + 1) ], selectedSession = NotAsked }
-                    |> view
-                    |> Query.fromHtml
-                    |> Query.find [ Slc.containing [ Slc.text "export sessions" ] ]
-                    |> Query.has [ Slc.attribute <| href expected ]
         , test "with selection graph is shown" <|
             \_ ->
-                { defaultModel | selectedSession = Success selectedSession }
+                { defaultModel | selectedSession = Success defaultSelectedSession }
                     |> view
                     |> Query.fromHtml
                     |> Query.findAll [ Slc.id "graph" ]
                     |> Query.count (Expect.equal 1)
         , test "with selection a button to deselect session is shown" <|
             \_ ->
-                { defaultModel | selectedSession = Success selectedSession }
+                { defaultModel | selectedSession = Success defaultSelectedSession }
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.tag "button", Slc.containing [ Slc.text "X" ] ]
@@ -708,7 +598,7 @@ viewTests =
             \title username sensorName ->
                 let
                     selectedSession_ =
-                        { selectedSession
+                        { defaultSelectedSession
                             | title = title
                             , username = username
                             , sensorName = sensorName
@@ -725,7 +615,7 @@ viewTests =
             \average min max ->
                 let
                     selectedSession_ =
-                        { selectedSession
+                        { defaultSelectedSession
                             | average = average
                             , min = min
                             , max = max
@@ -750,7 +640,7 @@ viewTests =
                             |> Result.withDefault (Time.millisToPosix 0)
 
                     selectedSession_ =
-                        { selectedSession | startTime = start, endTime = end }
+                        { defaultSelectedSession | startTime = start, endTime = end }
                 in
                 { defaultModel | selectedSession = Success selectedSession_ }
                     |> view
@@ -813,7 +703,7 @@ updateTests =
             \id ->
                 let
                     model =
-                        { defaultModel | selectedSession = Success <| selectedSessionWithId id }
+                        { defaultModel | selectedSession = Success <| { defaultSelectedSession | id = id } }
 
                     expected =
                         { model | selectedSession = NotAsked }
@@ -826,7 +716,7 @@ updateTests =
             \id ->
                 let
                     model =
-                        { defaultModel | selectedSession = Success <| selectedSessionWithId id }
+                        { defaultModel | selectedSession = Success <| { defaultSelectedSession | id = id } }
 
                     expected =
                         { model | selectedSession = NotAsked }
@@ -839,7 +729,7 @@ updateTests =
             \id ->
                 let
                     model =
-                        { defaultModel | selectedSession = Success <| selectedSessionWithId id }
+                        { defaultModel | selectedSession = Success <| { defaultSelectedSession | id = id } }
 
                     expected =
                         Ports.toggleSession { selected = Nothing, deselected = Just id }
@@ -852,7 +742,7 @@ updateTests =
             \id ->
                 let
                     model =
-                        { defaultModel | sessions = [ sessionWithId id ] }
+                        { defaultModel | sessions = [ { defaultSession | id = id } ] }
 
                     newSession =
                         { id = id + 1
@@ -918,7 +808,7 @@ updateTests =
             \id ->
                 let
                     model =
-                        { defaultModel | selectedSession = Success <| selectedSessionWithId id }
+                        { defaultModel | selectedSession = Success <| { defaultSelectedSession | id = id } }
 
                     expected =
                         { model | selectedSession = NotAsked }
@@ -931,7 +821,7 @@ updateTests =
             \id ->
                 let
                     model =
-                        { defaultModel | selectedSession = Success <| selectedSessionWithId id }
+                        { defaultModel | selectedSession = Success <| { defaultSelectedSession | id = id } }
 
                     expected =
                         Ports.toggleSession { deselected = Just id, selected = Nothing }
@@ -944,7 +834,7 @@ updateTests =
             \id ->
                 let
                     model =
-                        { defaultModel | selectedSession = Success <| selectedSessionWithId id }
+                        { defaultModel | selectedSession = Success <| { defaultSelectedSession | id = id } }
 
                     expected =
                         { model | selectedSession = NotAsked }

--- a/app/javascript/elm/tests/TestUtils.elm
+++ b/app/javascript/elm/tests/TestUtils.elm
@@ -1,0 +1,87 @@
+module TestUtils exposing
+    ( defaultSelectedSession
+    , defaultSensors
+    , defaultSession
+    , heatMapThresholdsWithMaximum
+    , heatMapThresholdsWithMinimum
+    , simulatedEventObject
+    )
+
+import Data.HeatMapThresholds exposing (HeatMapThresholds)
+import Data.SelectedSession exposing (SelectedSession)
+import Data.Session exposing (Session, ShortType)
+import Json.Encode as Encode
+import Sensor exposing (Sensor)
+import Time
+
+
+simulatedEventObject : String -> Encode.Value
+simulatedEventObject value =
+    let
+        target =
+            Encode.object [ ( "value", Encode.string value ) ]
+    in
+    Encode.object [ ( "target", target ) ]
+
+
+defaultShortTypes : List ShortType
+defaultShortTypes =
+    [ { name = "name", type_ = "type_" } ]
+
+
+defaultSession : Session
+defaultSession =
+    { title = "title"
+    , id = 1
+    , startTime = Time.millisToPosix 0
+    , endTime = Time.millisToPosix 0
+    , username = "username"
+    , shortTypes = defaultShortTypes
+    , average = Nothing
+    }
+
+
+heatMapThresholdsWithMinimum : Int -> HeatMapThresholds
+heatMapThresholdsWithMinimum value =
+    { threshold1 = { value = value, default = 1 }
+    , threshold2 = { value = 2, default = 2 }
+    , threshold3 = { value = 3, default = 3 }
+    , threshold4 = { value = 4, default = 4 }
+    , threshold5 = { value = 5, default = 5 }
+    }
+
+
+heatMapThresholdsWithMaximum : Int -> HeatMapThresholds
+heatMapThresholdsWithMaximum value =
+    { threshold1 = { value = 1, default = 1 }
+    , threshold2 = { value = 2, default = 2 }
+    , threshold3 = { value = 3, default = 3 }
+    , threshold4 = { value = 4, default = 4 }
+    , threshold5 = { value = value, default = 5 }
+    }
+
+
+defaultSensors : List Sensor
+defaultSensors =
+    [ { parameter = "parameter"
+      , name = "Sensor"
+      , unit = "unit"
+      , session_count = 1
+      }
+    ]
+
+
+defaultSelectedSession : SelectedSession
+defaultSelectedSession =
+    { title = "title"
+    , username = "username"
+    , sensorName = "sensor-name"
+    , average = 2.0
+    , min = 1.0
+    , max = 3.0
+    , startTime = Time.millisToPosix 0
+    , endTime = Time.millisToPosix 0
+    , measurements = [ 1.0, 2.0, 3.0 ]
+    , id = 123
+    , streamId = 123
+    }


### PR DESCRIPTION
You can review commit by commit.

Add button in the graph area to export the single session. Notice that I use an [extensible record type](https://medium.com/@ckoster22/advanced-types-in-elm-extensible-records-67e9d804030d) cause I could pass both a `Session` or a `SelectedSession` to `exportPath`.

Also, in the second commit I've removed the two view tests related to the export link and moved them to app/javascript/elm/tests/ApiTests.elm. 
I believe the important stuff to be tested is the link generation which is still covered. We lose the coverage on the fact that
- the button is not there when a session is selected; even if this was broken I don't see this as a big problem
- the button is there when there are no selections; this was validated when creating the feature and removing it takes a lot of distractions (by the author of the change, by the reviewers, by the manual testing)