### PR TITLE
Search as I move the map

### DIFF
--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -51,19 +51,18 @@ export const SessionsListCtrl = (
       if (hasChangedProgrammatically === undefined) return;
 
       if (firstLoad) {
-        sessions.fetch({ amount: params.get("fetchedSessionsCount") });
+        sessions.fetch({ amount: params.paramsData["fetchedSessionsCount"] });
         firstLoad = false;
         return;
       }
 
       if (!params.get("data").isSearchOn) {
-        console.warn("map was moved");
         elmApp.ports.mapMoved.send(null);
         return;
       }
 
       if (hasChangedProgrammatically) {
-        sessions.fetch({ amount: params.get("fetchedSessionsCount") });
+        sessions.fetch({ amount: params.paramsData["fetchedSessionsCount"] });
         return;
       }
       sessions.fetch();

--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -48,12 +48,19 @@ export const SessionsListCtrl = (
     ({ hasChangedProgrammatically }) => {
       console.log("watch - params.get('map')");
       if (sessions.hasSelectedSessions()) return;
-      if ($scope.firstLoad || hasChangedProgrammatically) {
+
+      if ($scope.firstLoad) {
+        sessions.fetch({ amount: params.get("fetchedSessionsCount") });
+        $scope.firstLoad = false;
+      }
+
+      if (!params.get("data").isSearchOn) return;
+
+      if (hasChangedProgrammatically) {
         sessions.fetch({ amount: params.get("fetchedSessionsCount") });
       } else {
         sessions.fetch();
       }
-      $scope.firstLoad = false;
     },
     true
   );
@@ -147,6 +154,11 @@ export const SessionsListCtrl = (
           $scope.$apply();
         }
       );
+
+      elmApp.ports.toggleIsSearchOn.subscribe(isSearchOn => {
+        params.update({ data: { isSearchOn: isSearchOn } });
+        $scope.$apply();
+      });
     });
   }
 };

--- a/app/javascript/angular/tests/_sessions_list_ctrl.test.js
+++ b/app/javascript/angular/tests/_sessions_list_ctrl.test.js
@@ -14,7 +14,9 @@ test("with no sessions selected when params.map changes it calls sessions.fetch"
   };
   _SessionsListCtrl({ $scope, sessions });
 
-  callbacks.forEach(callback => callback({}));
+  callbacks.forEach(callback =>
+    callback({ hasChangedProgrammatically: false })
+  );
 
   t.true(sessions.wasCalled());
 
@@ -49,7 +51,7 @@ const _SessionsListCtrl = ({ map, $scope, updateCrowdMapLayer, sessions }) => {
     $on: () => {},
     ...$scope
   };
-  const params = { get: () => ({}), update: () => {} };
+  const params = { get: () => ({}), update: () => {}, paramsData: {} };
   const functionBlocker = { block: () => {} };
   const _map = {
     onPanOrZoom: () => {},

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -59,6 +59,7 @@ type alias Model =
     , resetIcon : String
     , heatMapThresholds : WebData HeatMapThresholds
     , isStreaming : Bool
+    , isSearchOn : Bool
     }
 
 
@@ -86,6 +87,7 @@ defaultModel =
     , linkIcon = ""
     , resetIcon = ""
     , heatMapThresholds = NotAsked
+    , isSearchOn = False
     }
 
 
@@ -105,6 +107,7 @@ type alias Flags =
     , linkIcon : String
     , resetIcon : String
     , heatMapThresholdValues : Maybe HeatMapThresholdValues
+    , isSearchOn : Bool
     }
 
 
@@ -143,6 +146,7 @@ init flags url key =
         , heatMapThresholds =
             Maybe.map (Success << HeatMapThresholds.fromValues) flags.heatMapThresholdValues
                 |> Maybe.withDefault defaultModel.heatMapThresholds
+        , isSearchOn = flags.isSearchOn
       }
     , Cmd.batch
         [ fetchSelectedSession sensors flags.selectedSessionId flags.selectedSensorId page
@@ -206,6 +210,7 @@ type Msg
     | UpdateHeatMapMaximum String
     | ResetHeatMapToDefaults
     | UpdateHeatMapThresholdsFromAngular HeatMapThresholdValues
+    | ToggleIsSearchOn
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -437,6 +442,9 @@ update msg model =
                 _ ->
                     ( model, Cmd.none )
 
+        ToggleIsSearchOn ->
+            ( { model | isSearchOn = not model.isSearchOn }, Ports.toggleIsSearchOn (not model.isSearchOn) )
+
 
 updateHeatMapExtreme : Model -> String -> (Int -> HeatMapThresholds -> HeatMapThresholds) -> ( Model, Cmd Msg )
 updateHeatMapExtreme model str updateExtreme =
@@ -569,6 +577,16 @@ view model =
 
                           else
                             text ""
+                        , div []
+                            [ input
+                                [ id "checkbox-search"
+                                , type_ "checkbox"
+                                , checked model.isSearchOn
+                                , Events.onClick ToggleIsSearchOn
+                                ]
+                                []
+                            , label [ for "checkbox-search" ] [ text "Search as I move the map" ]
+                            ]
                         , div [ class "map", id "map11", attribute "ng-controller" "MapCtrl", attribute "googlemap" "" ]
                             []
                         , div

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -12,6 +12,7 @@ port module Ports exposing
     , timeRangeSelected
     , toggleCrowdMap
     , toggleIndoor
+    , toggleIsSearchOn
     , toggleSession
     , toggleSessionSelection
     , toggleStreaming
@@ -97,3 +98,6 @@ port drawMobile : GraphData -> Cmd a
 
 
 port drawFixed : GraphData -> Cmd a
+
+
+port toggleIsSearchOn : Bool -> Cmd a

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -1,9 +1,11 @@
 port module Ports exposing
     ( drawFixed
     , drawMobile
+    , fetchSessions
     , findLocation
     , loadMoreSessions
     , locationCleared
+    , mapMoved
     , profileSelected
     , refreshTimeRange
     , selectSensorId
@@ -101,3 +103,9 @@ port drawFixed : GraphData -> Cmd a
 
 
 port toggleIsSearchOn : Bool -> Cmd a
+
+
+port mapMoved : (() -> msg) -> Sub msg
+
+
+port fetchSessions : () -> Cmd a

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -802,6 +802,14 @@ viewTests =
                     |> view
                     |> Query.fromHtml
                     |> Query.has [ Slc.id "heatmap-unit-min", Slc.containing [ Slc.text unit ] ]
+        , fuzz bool "search checkbox state depends on model.isSearchOn" <|
+            \isSearchOn ->
+                { defaultModel | isSearchOn = isSearchOn }
+                    |> view
+                    |> Query.fromHtml
+                    |> Query.find [ Slc.id "checkbox-search" ]
+                    |> Query.has
+                        [ Slc.attribute <| checked isSearchOn ]
         ]
 
 
@@ -984,4 +992,11 @@ updateTests =
                     |> update (UpdateHeatMapMaximum int)
                     |> Tuple.first
                     |> Expect.equal expected
+        , fuzz bool "ToggleIsSearchOn changes the state of model.isSearchOn" <|
+            \onOrOff ->
+                { defaultModel | isSearchOn = onOrOff }
+                    |> update ToggleIsSearchOn
+                    |> Tuple.first
+                    |> .isSearchOn
+                    |> Expect.equal (not onOrOff)
         ]

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -28,7 +28,8 @@ document.addEventListener("DOMContentLoaded", () => {
         gridResolution: 25,
         isIndoor: false,
         isStreaming: true,
-        sensorId: "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
+        sensorId: "Particulate Matter-airbeam2-pm2.5 (µg/m³)",
+        isSearchOn: false
       };
 
       const data = { ...defaultData, ...params.data };
@@ -68,7 +69,8 @@ document.addEventListener("DOMContentLoaded", () => {
         linkIcon,
         resetIcon,
         heatMapThresholdValues,
-        isStreaming: data.isStreaming
+        isStreaming: data.isStreaming,
+        isSearchOn: data.isSearchOn
       };
 
       console.warn(flags);


### PR DESCRIPTION
Search as I move checkbox, it's turned off by default. When the map is moved on zoomed it changes into "search again" button. When the sessions list is refreshed it changes back to the checkbox.
Needs styling: https://llp.kanbanery.com/projects/8040/board/tasks/2407695