### PR TITLE
Style "search as I move" and "search again" button

### DIFF
--- a/app/assets/stylesheets/global/forms.css.scss
+++ b/app/assets/stylesheets/global/forms.css.scss
@@ -17,8 +17,11 @@ input {
 }
 
 input[type="checkbox"] {
-  margin-top: 24px;
-  width: auto;
+  width: inherit;
+
+  & + label {
+    margin-left: 10px;
+  }
 }
 
 .input-dark {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -16,6 +16,7 @@
 @import "./modules/filters-popups";
 @import "./modules/heatmap";
 @import "./modules/map";
+@import "./modules/map-search-control";
 @import "./modules/markers";
 @import "./modules/overlay";
 @import "./modules/reset-button";

--- a/app/assets/stylesheets/modules/buttons.css.scss
+++ b/app/assets/stylesheets/modules/buttons.css.scss
@@ -14,6 +14,11 @@
   color: white;
 }
 
+.button--dark {
+  background-color: $dark-blue;
+  color: white;
+}
+
 .time-frame-button {
   font-size: $tiny-font;
   font-weight: $font-stack-bold;

--- a/app/assets/stylesheets/modules/map-search-control.css.scss
+++ b/app/assets/stylesheets/modules/map-search-control.css.scss
@@ -1,0 +1,26 @@
+.search-control {
+  position: absolute;
+  right: 175px;
+  top: 6px;
+  z-index: 999;
+}
+
+.search-control__switch {
+  background: white;
+  border-radius: 2px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 1px;
+  padding: 4px 25px 3px 10px;
+}
+
+.search-control__button {
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: bold;
+  padding: 6px 20px 5px;
+}
+
+label[for="search-control-checkbox"] {
+  font-family: sans-serif;
+  font-size: 13px;
+  font-weight: $font-stack-regular;
+}

--- a/app/assets/stylesheets/modules/map-search-control.css.scss
+++ b/app/assets/stylesheets/modules/map-search-control.css.scss
@@ -16,7 +16,7 @@
   border-radius: 4px;
   font-size: 13px;
   font-weight: bold;
-  padding: 6px 20px 5px;
+  padding: 6px 20px;
 }
 
 label[for="search-control-checkbox"] {

--- a/app/assets/stylesheets/modules/map-search-control.css.scss
+++ b/app/assets/stylesheets/modules/map-search-control.css.scss
@@ -19,7 +19,7 @@
   padding: 6px 20px;
 }
 
-label[for="search-control-checkbox"] {
+label[for="checkbox-search-as-i-move"] {
   font-family: sans-serif;
   font-size: 13px;
   font-weight: $font-stack-regular;

--- a/app/assets/stylesheets/modules/map-search-control.css.scss
+++ b/app/assets/stylesheets/modules/map-search-control.css.scss
@@ -9,14 +9,17 @@
   background: white;
   border-radius: 2px;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 1px;
+  height: 25px;
   padding: 4px 25px 3px 10px;
 }
 
 .search-control__button {
   border-radius: 4px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 1px;
   font-size: 13px;
   font-weight: bold;
-  padding: 6px 20px;
+  height: 25px;
+  padding: 6px 20px 5px;
 }
 
 label[for="checkbox-search-as-i-move"] {

--- a/app/javascript/angular/code/directives/googlemap.js
+++ b/app/javascript/angular/code/directives/googlemap.js
@@ -20,7 +20,7 @@ angular.module("aircasting").directive("googlemap", function() {
       const minZoom = 3;
       let options = {
         center: latlng,
-        controlSize: 24,
+        controlSize: 25,
         fullscreenControl: false,
         minZoom,
         mapTypeId: mapType,

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -613,23 +613,24 @@ view model =
 
 viewSearchAsIMove : Bool -> Bool -> Html Msg
 viewSearchAsIMove wasMapMoved isSearchAsIMoveOn =
-    div [ Html.Attributes.style "position" "absolute", Html.Attributes.style "z-index" "99999" ]
+    div [ class "search-control" ]
         [ if wasMapMoved then
             button
-                [ Events.onClick FetchSessions
+                [ class "button button--dark search-control__button"
+                , Events.onClick FetchSessions
                 ]
                 [ text "Search again" ]
 
           else
-            div []
+            div [ class "search-control__switch" ]
                 [ input
-                    [ id "checkbox-search"
+                    [ id "checkbox-search-as-i-move"
                     , type_ "checkbox"
                     , checked isSearchAsIMoveOn
                     , Events.onClick ToggleIsSearchOn
                     ]
                     []
-                , label [ for "checkbox-search" ] [ text "Search as I move the map" ]
+                , label [ for "search-control-checkbox" ] [ text "Search as I move the map" ]
                 ]
         ]
 

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -630,7 +630,7 @@ viewSearchAsIMove wasMapMoved isSearchAsIMoveOn =
                     , Events.onClick ToggleIsSearchOn
                     ]
                     []
-                , label [ for "search-control-checkbox" ] [ text "Search as I move the map" ]
+                , label [ for "checkbox-search-as-i-move" ] [ text "Search as I move the map" ]
                 ]
         ]
 

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -718,7 +718,7 @@ viewTests =
                 { defaultModel | isSearchAsIMoveOn = isSearchAsIMoveOn }
                     |> view
                     |> Query.fromHtml
-                    |> Query.find [ Slc.id "checkbox-search" ]
+                    |> Query.find [ Slc.id "checkbox-search-as-i-move" ]
                     |> Query.has
                         [ Slc.attribute <| checked isSearchAsIMoveOn ]
         ]


### PR DESCRIPTION
We're not replacing the default map controls now so I made the search as I move look similar to the controls and made the "Search again" button stand out by applying a dark blue. This is loosely based on the designs.

Looks like this right now:

![Screenshot 2019-05-14 at 15 44 50](https://user-images.githubusercontent.com/457999/57702936-50bc5000-765f-11e9-9cda-b42455d148aa.png)

![Screenshot 2019-05-14 at 15 44 42](https://user-images.githubusercontent.com/457999/57702951-59148b00-765f-11e9-9454-a48e35727865.png)

