### PR TITLE
Fix dot changing color

### DIFF
--- a/app/controllers/api/measurement_sessions_controller.rb
+++ b/app/controllers/api/measurement_sessions_controller.rb
@@ -52,12 +52,6 @@ module Api
       end
     end
 
-    def show
-      session = MobileSession.find(params[:id])
-
-      respond_with session, :sensor_id => params[:sensor_id], :methods => [:notes], :stream_measurements => true
-    end
-
     def export
       service = Csv::ExportSessionsToCsv.new
 

--- a/app/controllers/api/mobile/sessions_controller.rb
+++ b/app/controllers/api/mobile/sessions_controller.rb
@@ -27,5 +27,16 @@ module Api
         render json: result.errors, status: :bad_request
       end
     end
+
+    def show2
+      form = Api::ParamsForm.new(params: params, schema: Api::Session::Schema, struct: Api::Session::Struct)
+      result = Api::ToSessionHash2.new(form: form).call
+
+      if result.success?
+        render json: result.value, status: :ok
+      else
+        render json: result.errors, status: :bad_request
+      end
+    end
   end
 end

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -242,9 +242,9 @@ export const mobileSessions = (
       if (!sensorName) return;
       session.alreadySelected = true;
       $http
-        .get("/api/sessions/" + id, {
+        .get("/api/mobile/sessions2/" + id, {
           cache: true,
-          params: { sensor_id: sensorName }
+          params: { sensor_name: sensorName }
         })
         .success(callback(session, allSelected));
     },

--- a/app/services/api/to_session_hash2.rb
+++ b/app/services/api/to_session_hash2.rb
@@ -1,0 +1,84 @@
+class Api::ToSessionHash2
+  def initialize(form:)
+    @form = form
+  end
+
+  def call
+    return Failure.new(form.errors) if form.invalid?
+
+    session = MobileSession.includes({ streams: :measurements }, :notes, :user).find(id)
+    stream = session.streams.where(sensor_name: sensor_name).first!
+    average = stream.measurements.average(:value)
+    user = session.user
+    measurements = stream.measurements.map { |m| m.as_json(only: [:time, :value, :latitude, :longitude]) }
+    notes = session.notes.map(&:as_json)
+
+    Success.new(
+      title: session.title,
+      average: average,
+      id: session.id,
+      contribute: session.contribute,
+      created_at: format_time(session.created_at),
+      data_type: session.data_type,
+      end_time: format_time(session.end_time),
+      end_time_local: format_time(session.end_time_local),
+      instrument: session.instrument,
+      is_indoor: session.is_indoor,
+      last_measurement_at: session.last_measurement_at,
+      latitude: session.latitude,
+      longitude: session.longitude,
+      measurements_count: session.measurements_count,
+      start_time: format_time(session.start_time),
+      start_time_local: format_time(session.start_time_local),
+      type: session.type,
+      updated_at: format_time(session.updated_at),
+      url_token: session.url_token,
+      user_id: user.id,
+      uuid: session.uuid,
+      notes: notes,
+      streams: {
+        stream.sensor_name => {
+          average_value: stream.average_value,
+          id: stream.id,
+          max_latitude: stream.max_latitude,
+          max_longitude: stream.max_longitude,
+          measurement_short_type: stream.measurement_short_type,
+          measurement_type: stream.measurement_type,
+          measurements_count: stream.measurements_count,
+          min_latitude: stream.min_latitude,
+          min_longitude: stream.min_longitude,
+          sensor_name: stream.sensor_name,
+          sensor_package_name: stream.sensor_package_name,
+          session_id: session.id,
+          size: stream.size,
+          start_latitude: stream.start_latitude,
+          start_longitude: stream.start_longitude,
+          threshold_high: stream.threshold_high,
+          threshold_low: stream.threshold_low,
+          threshold_medium: stream.threshold_medium,
+          threshold_very_high: stream.threshold_very_high,
+          threshold_very_low: stream.threshold_very_low,
+          unit_name: stream.unit_name,
+          unit_symbol: stream.unit_symbol,
+          measurements: measurements
+        }
+      }
+    )
+  end
+
+  private
+
+  attr_reader :form
+
+  def format_time(time)
+    time.strftime("%FT%T.000Z")
+  end
+
+  def id
+    form.to_h.id
+  end
+
+  def sensor_name
+    form.to_h.sensor_name
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :measurement_sessions, path: 'sessions', only: [:show, :create] do
+    resources :measurement_sessions, path: 'sessions', only: [:create] do
       collection do
         get :export
       end
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
     namespace :mobile do
       get "sessions" => "sessions#index"
       get "sessions/:id" => "sessions#show"
+      get "sessions2/:id" => "sessions#show2"
     end
 
     get "measurements" => "measurements#index"

--- a/doc/api.md
+++ b/doc/api.md
@@ -79,14 +79,14 @@ curl http://aircasting.org/api/mobile/sessions.json?limit=50&offset=0&q[measurem
 }
 ```
 
-## Session
+## Mobile Session
 
-GET `/api/sessions/:id`
+GET `/api/mobile/sessions2/:id`
 
 ### Example request
 
 ```
-curl http://aircasting.org/api/sessions/9586.json
+curl http://aircasting.org/api/mobile/sessions2/9586.json
 ```
 
 ### Example response

--- a/spec/controllers/api/measurement_sessions_controller_spec.rb
+++ b/spec/controllers/api/measurement_sessions_controller_spec.rb
@@ -52,19 +52,6 @@ describe Api::MeasurementSessionsController do
 
   before { sign_in user }
 
-  describe "GET 'show'" do
-    let(:session) { FactoryGirl.create(:mobile_session) }
-
-    before do
-      get :show, :id => session.id, :format => :json
-    end
-
-    it { is_expected.to respond_with(:ok) }
-    it "should contain notes" do
-      expect(json_response['notes']).to eq(jsonized(session.notes))
-    end
-  end
-
   describe "GET 'show_multiple'" do
     let(:session1) { FactoryGirl.create(:mobile_session) }
     let(:session2) { FactoryGirl.create(:mobile_session) }


### PR DESCRIPTION
Take out the old mobile show end point of the mess. Proposals are open for a better naming than `2`. 
This makes stuff more explicit instead of getting into the woods of `Session.as_json` with its ifs and nested `as_json`. Also, it places the route in a more meaningful name (except the `2`).

At the moment we have two show mobile endpoints (ie `show` and `show2`) cause one is used in Elm and the other in Angular. Most of the fields in `show2` are prolly not even used in Angular. My hope is that by making things more explicit, down the line we would be able to merge or simplify endpoints. Especially, cause we will be shrinking Angular code more and more.

Besides that this fixes a bug. In fact, the old endpoint returned the wrong avarage at the root level of the json. That happened because `MobileSession.measurements_average` took `streams.first` out of all the streams instead of the stream that the show endpoint was focusing on. That created the bug where the color of the dot changed to a wrong one.