### PR TITLE
Import svgs using file-loader

### DIFF
--- a/app/javascript/angular/code/services/_draw_session.js
+++ b/app/javascript/angular/code/services/_draw_session.js
@@ -1,12 +1,13 @@
 import _ from "underscore";
-import { removeMarker } from "./google/_map.js.erb";
+import { removeMarker } from "./google/_map.js";
+import * as assets from "../../../assets";
 
-<% helpers = ActionController::Base.helpers %>
-
-const locationMarker1Path = "<%= helpers.image_path('location_marker1.svg') %>";
-const locationMarker2Path = "<%= helpers.image_path('location_marker2.svg') %>";
-const locationMarker3Path = "<%= helpers.image_path('location_marker3.svg') %>";
-const locationMarker4Path = "<%= helpers.image_path('location_marker4.svg') %>";
+const locationMarkersByLevel = {
+  1: assets.locationMarker1Path,
+  2: assets.locationMarker2Path,
+  3: assets.locationMarker3Path,
+  4: assets.locationMarker4Path
+};
 
 export const drawSession = (sensors, map, heat, note, empty) => {
   var DrawSession = function() {};
@@ -104,7 +105,7 @@ const createMeasurementMarker = (measurement, idx, heat, map, suffix) => {
     icon: {
       anchor: new google.maps.Point(6, 6),
       size: new google.maps.Size(12, 12),
-      url: eval(`locationMarker${level}Path`)
+      url: locationMarkersByLevel[level]
     }
   });
 

--- a/app/javascript/angular/code/services/draw_session.js
+++ b/app/javascript/angular/code/services/draw_session.js
@@ -1,4 +1,4 @@
-import { drawSession } from "./_draw_session.js.erb";
+import { drawSession } from "./_draw_session.js";
 
 angular
   .module("aircasting")

--- a/app/javascript/angular/code/services/google/_map.js
+++ b/app/javascript/angular/code/services/google/_map.js
@@ -1,14 +1,7 @@
 import _ from "underscore";
 import { buildCustomMarker } from "./custom_marker";
 import MarkerClusterer from "@google/markerclustererplus";
-
-<% helpers = ActionController::Base.helpers %>
-
-const locationMarkerPath = "<%= helpers.image_path('location_marker.svg') %>";
-const marker1Path = "<%= helpers.image_path('marker1.svg') %>";
-const marker2Path = "<%= helpers.image_path('marker2.svg') %>";
-const marker3Path = "<%= helpers.image_path('marker3.svg') %>";
-const marker4Path = "<%= helpers.image_path('marker4.svg') %>";
+import * as assets from "../../../../assets";
 
 export const map = (
   params,
@@ -228,9 +221,9 @@ export const map = (
           // anchor formula: margin + (scaledSize / 2) = 24
           // but we had to add +1 to the second anchor value based on visual feedback
           anchor: new google.maps.Point(24, 25),
-          size: new google.maps.Size(60,60),
-          scaledSize: new google.maps.Size(12,12),
-          url: locationMarkerPath
+          size: new google.maps.Size(60, 60),
+          scaledSize: new google.maps.Size(12, 12),
+          url: assets.locationMarkerPath
         }
       });
 
@@ -246,10 +239,10 @@ export const map = (
     clusterMarkers: function(onClick) {
       const options = {
         styles: [
-          { url: marker1Path, height: 30, width: 30 },
-          { url: marker2Path, height: 30, width: 30 },
-          { url: marker3Path, height: 30, width: 30 },
-          { url: marker4Path, height: 30, width: 30 }
+          { url: assets.marker1Path, height: 30, width: 30 },
+          { url: assets.marker2Path, height: 30, width: 30 },
+          { url: assets.marker3Path, height: 30, width: 30 },
+          { url: assets.marker4Path, height: 30, width: 30 }
         ],
         zoomOnClick: false,
         gridSize: 20,

--- a/app/javascript/angular/code/services/google/graph_highlight.js
+++ b/app/javascript/angular/code/services/google/graph_highlight.js
@@ -1,7 +1,5 @@
-import { removeMarker, drawMarker } from "./_map.js.erb";
-
-<% helpers = ActionController::Base.helpers %>
-const locationMarkerPath = "<%= helpers.image_path('location_marker.svg') %>"
+import { removeMarker, drawMarker } from "./_map.js";
+import * as assets from "../../../../assets";
 
 let items = [];
 
@@ -22,7 +20,7 @@ export const show = points => {
         icon: {
           anchor: new google.maps.Point(8, 8),
           size: new google.maps.Size(16, 16),
-          url: locationMarkerPath
+          url: assets.locationMarkerPath
         }
       }),
       point: point

--- a/app/javascript/angular/code/services/google/map.js
+++ b/app/javascript/angular/code/services/google/map.js
@@ -1,4 +1,4 @@
-import { map } from "./_map.js.erb";
+import { map } from "./_map.js";
 
 angular
   .module("google")

--- a/app/javascript/angular/code/services/graph.js
+++ b/app/javascript/angular/code/services/graph.js
@@ -1,6 +1,6 @@
 import Highcharts from "highcharts/highstock";
 import { buildOptions } from "./buildGraphOptions";
-import * as graphHighlight from "./google/graph_highlight.js.erb";
+import * as graphHighlight from "./google/graph_highlight";
 import * as http from "./http";
 import {
   measurementsToTime,

--- a/app/javascript/angular/tests/_draw_session.test.js
+++ b/app/javascript/angular/tests/_draw_session.test.js
@@ -1,17 +1,6 @@
 import test from "blue-tape";
 import { mock } from "./helpers";
-import { drawSession } from "../code/services/_draw_session.js.erb";
-
-test("drawMobileSession draws a session when session is loaded and sensor is selected", t => {
-  const map = mock("drawMarker");
-  const drawSessionStub = _drawSession({ map, sensors: selectedSensor });
-
-  drawSessionStub.drawMobileSession(loadedSession, () => {});
-
-  t.true(map.wasCalled());
-
-  t.end();
-});
+import { drawSession } from "../code/services/_draw_session.js";
 
 test("undoDraw removes all session elements from the map", t => {
   const marker = mock("setMap");

--- a/app/javascript/angular/tests/_map.test.js
+++ b/app/javascript/angular/tests/_map.test.js
@@ -1,7 +1,7 @@
 import test from "blue-tape";
 import deepEqual from "fast-deep-equal";
 import { mock } from "./helpers";
-import { map } from "../code/services/google/_map.js.erb";
+import { map } from "../code/services/google/_map.js";
 import sinon from "sinon";
 
 test("goToAddress with no address it does not decode", t => {

--- a/app/javascript/assets.js
+++ b/app/javascript/assets.js
@@ -1,0 +1,44 @@
+export const locationMarker1Path =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/location_marker1.svg");
+
+export const locationMarker2Path =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/location_marker2.svg");
+
+export const locationMarker3Path =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/location_marker3.svg");
+
+export const locationMarker4Path =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/location_marker4.svg");
+
+export const locationMarkerPath =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/location_marker.svg");
+
+export const marker1Path =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/marker1.svg");
+
+export const marker2Path =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/marker2.svg");
+
+export const marker3Path =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/marker3.svg");
+
+export const marker4Path =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/marker4.svg");

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,6 +1,5 @@
 const { environment } = require("@rails/webpacker");
 const elm = require("./loaders/elm");
-const erb = require("./loaders/erb");
 const webpack = require("webpack");
 
 // https://github.com/rails/webpacker/blob/master/docs/v4-upgrade.md#excluding-node_modules-from-being-transpiled-by-babel-loader
@@ -13,6 +12,5 @@ environment.plugins.append(
   })
 );
 
-environment.loaders.append("erb", erb);
 environment.loaders.prepend("elm", elm);
 module.exports = environment;

--- a/config/webpack/loaders/erb.js
+++ b/config/webpack/loaders/erb.js
@@ -1,5 +1,0 @@
-module.exports = {
-  test: /\.erb$/,
-  enforce: "pre",
-  loader: "rails-erb-loader"
-};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "jquery-migrate": "1.4.1",
     "moment": "~2.15.2",
     "nouislider": "^13.1.4",
-    "rails-erb-loader": "^5.5.2",
     "tippy.js": "^4.2.0",
     "underscore": "~1.8.3",
     "underscore.string": "~2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,7 +27,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.4.0":
+"@babel/generator@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.0.tgz#c230e79589ae7a729fd4631b9ded4dc220418196"
   dependencies:
@@ -179,12 +179,6 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-split-export-declaration@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz#571bfd52701f492920d63b7f735030e9a3e10b55"
-  dependencies:
-    "@babel/types" "^7.4.0"
-
 "@babel/helper-split-export-declaration@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
@@ -216,11 +210,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.4.0", "@babel/parser@^7.4.3":
+"@babel/parser@^7.4.0":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.3.tgz#eb3ac80f64aa101c907d4ce5406360fe75b7895b"
 
-"@babel/parser@^7.4.4":
+"@babel/parser@^7.4.3", "@babel/parser@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
 
@@ -596,7 +590,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/template@^7.0.0", "@babel/template@^7.1.0":
+"@babel/template@^7.1.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
   dependencies:
@@ -604,7 +598,7 @@
     "@babel/parser" "^7.4.0"
     "@babel/types" "^7.4.0"
 
-"@babel/template@^7.4.4":
+"@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
   dependencies:
@@ -612,21 +606,7 @@
     "@babel/parser" "^7.4.4"
     "@babel/types" "^7.4.4"
 
-"@babel/traverse@^7.0.0":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.3.tgz#1a01f078fc575d589ff30c0f71bf3c3d9ccbad84"
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.4.0"
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.4.0"
-    "@babel/parser" "^7.4.3"
-    "@babel/types" "^7.4.0"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.11"
-
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.4.tgz#0776f038f6d78361860b6823887d4f3937133fe8"
   dependencies:
@@ -3213,9 +3193,9 @@ handle-thing@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
 
-handlebars@^4.0.1, handlebars@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
+handlebars@^4.0.1, handlebars@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -3823,51 +3803,51 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-lib-coverage@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#0b891e5ad42312c2b9488554f603795f9a2211ba"
+istanbul-lib-coverage@^2.0.3, istanbul-lib-coverage@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
 
 istanbul-lib-hook@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz#e0e581e461c611be5d0e5ef31c5f0109759916fb"
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz#c95695f383d4f8f60df1f04252a9550e15b5b133"
   dependencies:
     append-transform "^1.0.0"
 
 istanbul-lib-instrument@^3.0.0, istanbul-lib-instrument@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz#a2b5484a7d445f1f311e93190813fa56dfb62971"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
   dependencies:
-    "@babel/generator" "^7.0.0"
-    "@babel/parser" "^7.0.0"
-    "@babel/template" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@babel/types" "^7.0.0"
-    istanbul-lib-coverage "^2.0.3"
-    semver "^5.5.0"
+    "@babel/generator" "^7.4.0"
+    "@babel/parser" "^7.4.3"
+    "@babel/template" "^7.4.0"
+    "@babel/traverse" "^7.4.3"
+    "@babel/types" "^7.4.0"
+    istanbul-lib-coverage "^2.0.5"
+    semver "^6.0.0"
 
 istanbul-lib-report@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz#bfd324ee0c04f59119cb4f07dab157d09f24d7e4"
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
   dependencies:
-    istanbul-lib-coverage "^2.0.3"
-    make-dir "^1.3.0"
-    supports-color "^6.0.0"
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    supports-color "^6.1.0"
 
 istanbul-lib-source-maps@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz#f1e817229a9146e8424a28e5d69ba220fda34156"
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
   dependencies:
     debug "^4.1.1"
-    istanbul-lib-coverage "^2.0.3"
-    make-dir "^1.3.0"
-    rimraf "^2.6.2"
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    rimraf "^2.6.3"
     source-map "^0.6.1"
 
 istanbul-reports@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.1.1.tgz#72ef16b4ecb9a4a7bd0e2001e00f95d1eec8afa9"
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.6.tgz#7b4f2660d82b29303a8fe6091f8ca4bf058da1af"
   dependencies:
-    handlebars "^4.1.0"
+    handlebars "^4.1.2"
 
 istanbul@^0.4.5:
   version "0.4.5"
@@ -4108,10 +4088,6 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
-lodash.defaults@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
-
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -4205,7 +4181,7 @@ make-dir@^1.3.0:
   dependencies:
     pify "^3.0.0"
 
-make-dir@^2.0.0:
+make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
   dependencies:
@@ -5903,13 +5879,6 @@ querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
 
-rails-erb-loader@^5.5.2:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/rails-erb-loader/-/rails-erb-loader-5.5.2.tgz#db3fa8ac89600f09d179a1a70a2ca18c592576ea"
-  dependencies:
-    loader-utils "^1.1.0"
-    lodash.defaults "^4.2.0"
-
 randomatic@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.1.tgz#b776efc59375984e36c537b2f51a1f0aff0da1ed"
@@ -6856,7 +6825,7 @@ supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^6.0.0, supports-color@^6.1.0:
+supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
   dependencies:


### PR DESCRIPTION
Since `yarn test` does not go through webpack, we need to `require`
conditionally the svgs. In tests it will return "", in
non-tests it will run the require that webpack would have transpiled
with the help of file-loader.
It's not possible to conditionally `import` that's why `require` is
used.