### PR TITLE
Disabled state for inputs

### DIFF
--- a/app/assets/stylesheets/global/forms.css.scss
+++ b/app/assets/stylesheets/global/forms.css.scss
@@ -14,6 +14,14 @@ input {
   &:focus {
     outline: none;
   }
+
+  &[disabled] {
+    opacity: 0.6;
+
+    & + label {
+      opacity: 0.6;
+    }
+  }
 }
 
 input[type="checkbox"] {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -26,6 +26,7 @@
 @import "./modules/single-session";
 @import "./modules/spinner";
 @import "./modules/static";
+@import "./modules/tag";
 @import "./modules/time-filter-calendar";
 @import "./modules/toggle-button";
 

--- a/app/assets/stylesheets/modules/filters.css.scss
+++ b/app/assets/stylesheets/modules/filters.css.scss
@@ -20,41 +20,24 @@
   position: absolute;
 }
 
+.filters__input-group {
+  display: flex;
+  flex-flow: column-reverse;
+  position: relative;
+}
+
 .filter-separator {
   border-bottom: white solid 0.6px;
   opacity: 0.4;
   width: 100%;
 }
 
-.filters-tag {
-  background-color: white;
-  border-radius: 15px;
-  color: $brand-secondary;
-  display: inline-block;
-  font-size: $tiny-font;
-  font-weight: $font-stack-regular;
-  margin-right: 10px;
-  margin-top: 10px;
-  padding: 3px 8px;
-}
-
-.filters-tag-close {
-  background: image-url("close-icon.svg") no-repeat right center;
-  border: none;
-  padding: 0 0 0 16px;
-  width: 8px;
-  height: 8px;
-  vertical-align: middle;
-}
-
-.input-filters.input-filters-tag {
-  margin-bottom: 0px;
-}
-
-.tag-container {
-  margin-bottom: 24px;
-}
-
 .input-time {
   letter-spacing: -0.4px;
+}
+
+[data-tippy-content] {
+  position: absolute;
+  right: 0;
+  top: 0;
 }

--- a/app/assets/stylesheets/modules/session-type-nav.css.scss
+++ b/app/assets/stylesheets/modules/session-type-nav.css.scss
@@ -11,6 +11,7 @@
   font-weight: $font-stack-bold;
   font-size: $small-font;
   padding: $margin-default;
+  position: relative;
   text-align: left;
   width: 50%;
   z-index: 1;
@@ -23,5 +24,10 @@
 
   &:focus {
     outline: none;
+  }
+
+  [data-tippy-content] {
+    right: 20px;
+    top: initial;
   }
 }

--- a/app/assets/stylesheets/modules/tag.css.scss
+++ b/app/assets/stylesheets/modules/tag.css.scss
@@ -1,0 +1,29 @@
+.tag-container {
+  margin-bottom: 24px;
+  order: -1;
+
+  & + input {
+    margin-bottom: 0;
+  }
+}
+
+.tag {
+  background-color: white;
+  border-radius: 15px;
+  color: $brand-secondary;
+  display: inline-block;
+  font-size: $tiny-font;
+  font-weight: $font-stack-regular;
+  margin-right: 10px;
+  margin-top: 10px;
+  padding: 3px 8px;
+}
+
+.tag-close {
+  background: image-url("close-icon.svg") no-repeat right center;
+  border: none;
+  padding: 0 0 0 16px;
+  width: 8px;
+  height: 8px;
+  vertical-align: middle;
+}

--- a/app/javascript/elm/src/LabelsInput.elm
+++ b/app/javascript/elm/src/LabelsInput.elm
@@ -76,36 +76,33 @@ update msg model toCmd =
 
 view : Model -> String -> String -> String -> Bool -> TooltipText -> Html Msg
 view model text_ inputId placeholderText isDisabled tooltipText =
-    div []
-        [ label [ for inputId ] [ text text_ ]
-        , Tooltip.view tooltipText
-        , div [ class "tag-container" ]
-            [ input
-                [ id inputId
-                , class "input-dark"
-                , class "input-filters"
-                , class "input-filters-tag"
-                , placeholder placeholderText
-                , type_ "text"
-                , name inputId
-                , ExtraEvents.onEnter (Add <| getCandidate model)
-                , Events.onInput UpdateCandidate
-                , value <| getCandidate model
-                , disabled isDisabled
-                ]
-                []
-            , div [] (List.map viewLabel <| asList model)
+    div [ class "filters__input-group" ]
+        [ div [ class "tag-container" ] (List.map viewLabel <| asList model)
+        , input
+            [ id inputId
+            , class "input-dark"
+            , class "input-filters"
+            , placeholder placeholderText
+            , type_ "text"
+            , name inputId
+            , ExtraEvents.onEnter (Add <| getCandidate model)
+            , Events.onInput UpdateCandidate
+            , value <| getCandidate model
+            , disabled isDisabled
             ]
+            []
+        , label [ for inputId ] [ text text_ ]
+        , Tooltip.view tooltipText
         ]
 
 
 viewLabel : String -> Html Msg
 viewLabel label =
-    div [ class "filters-tag" ]
+    div [ class "tag" ]
         [ text label
         , button
             [ id label
-            , class "filters-tag-close"
+            , class "tag-close"
             , Events.onClick <| Remove label
             ]
             []

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -867,10 +867,8 @@ viewToggleButton label isPressed callback =
 
 viewParameterFilter : List Sensor -> String -> Html Msg
 viewParameterFilter sensors selectedSensorId =
-    div []
-        [ label [ for "parameter" ] [ text "parameter:" ]
-        , Tooltip.view Tooltip.parameterFilter
-        , input
+    div [ class "filters__input-group" ]
+        [ input
             [ id "parameter"
             , class "input-dark"
             , class "input-filters"
@@ -882,15 +880,15 @@ viewParameterFilter sensors selectedSensorId =
             , autocomplete False
             ]
             []
+        , label [ for "parameter" ] [ text "parameter:" ]
+        , Tooltip.view Tooltip.parameterFilter
         ]
 
 
 viewSensorFilter : List Sensor -> String -> Html Msg
 viewSensorFilter sensors selectedSensorId =
-    div []
-        [ label [ for "sensor" ] [ text "sensor:" ]
-        , Tooltip.view Tooltip.sensorFilter
-        , input
+    div [ class "filters__input-group" ]
+        [ input
             [ id "sensor"
             , class "input-dark"
             , class "input-filters"
@@ -902,6 +900,8 @@ viewSensorFilter sensors selectedSensorId =
             , autocomplete False
             ]
             []
+        , label [ for "sensor" ] [ text "sensor:" ]
+        , Tooltip.view Tooltip.sensorFilter
         ]
 
 
@@ -945,10 +945,8 @@ viewCrowdMapSlider resolution =
 
 viewLocationFilter : String -> Bool -> Html Msg
 viewLocationFilter location isIndoor =
-    div []
-        [ label [ for "location" ] [ text "location:" ]
-        , Tooltip.view Tooltip.locationFilter
-        , input
+    div [ class "filters__input-group" ]
+        [ input
             [ id "location"
             , value location
             , class "input-dark"
@@ -961,6 +959,8 @@ viewLocationFilter location isIndoor =
             , onEnter SubmitLocation
             ]
             []
+        , label [ for "location" ] [ text "location:" ]
+        , Tooltip.view Tooltip.locationFilter
         ]
 
 

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -723,11 +723,9 @@ viewSessionTypeNav : Model -> Html Msg
 viewSessionTypeNav model =
     div [ class "session-type-nav" ]
         [ a [ href "/mobile_map", classList [ ( "session-type-nav__item", True ), ( "selected", model.page == Mobile ) ] ]
-            [ text "mobile" ]
-        , Tooltip.view Tooltip.mobileTab
+            [ text "mobile", Tooltip.view Tooltip.mobileTab ]
         , a [ href "/fixed_map", classList [ ( "session-type-nav__item", True ), ( "selected", model.page == Fixed ) ] ]
-            [ text "fixed" ]
-        , Tooltip.view Tooltip.fixedTab
+            [ text "fixed", Tooltip.view Tooltip.fixedTab ]
         ]
 
 

--- a/app/javascript/elm/src/TimeRange.elm
+++ b/app/javascript/elm/src/TimeRange.elm
@@ -52,10 +52,8 @@ timeRangeDecoder =
 
 view : msg -> Bool -> Html msg
 view refreshTimeRange isDisabled =
-    div []
-        [ label [ for "time-range" ] [ text "time frame:" ]
-        , Tooltip.view Tooltip.timeRangeFilter
-        , input
+    div [ class "filters__input-group" ]
+        [ input
             [ id "time-range"
             , attribute "autocomplete" "off"
             , class "input-dark"
@@ -67,5 +65,7 @@ view refreshTimeRange isDisabled =
             , disabled isDisabled
             ]
             []
+        , label [ for "time-range" ] [ text "time frame:" ]
+        , Tooltip.view Tooltip.timeRangeFilter
         , button [ Events.onClick refreshTimeRange ] [ text "refresh" ]
         ]


### PR DESCRIPTION
In order to target labels and set them to 40% opacity like the inputs as imagined by Pina the structure was changed so that labels are after inputs I used flexbox + changed order of elements + `column-reverse`. It's not the default way of doing things, usually labels are above inputs in html, but I don't think it should cause accessibility issues (labels are connected to inputs with `for`). And it's a neat trick if I may say so :P 

I also refactored some styles, mainly extracted tag styles and changed class names.

I'm not sure if the difference is clearly visible, but we'll test.

![Screenshot 2019-05-15 at 13 54 14](https://user-images.githubusercontent.com/457999/57774022-b705a900-7719-11e9-86dd-e2d81c856f29.png)
