### PR TITLE
ui(session card): truncate title and add ellipsis

### DIFF
--- a/app/assets/stylesheets/modules/sessions.css.scss
+++ b/app/assets/stylesheets/modules/sessions.css.scss
@@ -57,6 +57,9 @@
 .session-name {
   font-size: 16px;
   font-weight: $font-stack-regular;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .session-owner {


### PR DESCRIPTION
![Screen Shot 2019-05-16 at 11 42 51](https://user-images.githubusercontent.com/5238698/57844154-c6472e00-77cf-11e9-80c4-50cf860ba419.png)

@gitjul seems like the width is not needed. In case you think we should add it please feel free to add commits to this PR cause I'd be clueless on how much that should be