### PR TITLE
Timerange yy instead of yyyy

### DIFF
--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -138,22 +138,9 @@ export const FixedSessionsMapCtrl = (
 
       const setupStreamingTimeRangeFilter = (timeFrom, timeTo) => {
         if (document.getElementById("time-range")) {
-          $("#time-range").daterangepicker({
-            linkedCalendars: false,
-            timePicker: true,
-            timePicker24Hour: true,
-            startDate: moment
-              .unix(timeFrom)
-              .utc()
-              .format("MM/DD/YYYY HH:mm"),
-            endDate: moment
-              .unix(timeTo)
-              .utc()
-              .format("MM/DD/YYYY HH:mm"),
-            locale: {
-              format: "MM/DD/YYYY HH:mm"
-            }
-          });
+          $("#time-range").daterangepicker(
+            FiltersUtils.daterangepickerConfig(timeFrom, timeTo)
+          );
         } else {
           window.setTimeout(
             setupStreamingTimeRangeFilter(timeFrom, timeTo),

--- a/app/javascript/angular/code/filtersUtils.js
+++ b/app/javascript/angular/code/filtersUtils.js
@@ -26,25 +26,27 @@ export const oneHourAgo = () =>
     .subtract(1, "hour")
     .format("X");
 
+export const daterangepickerConfig = (timeFrom, timeTo) => ({
+  linkedCalendars: false,
+  timePicker: true,
+  timePicker24Hour: true,
+  startDate: moment
+    .unix(timeFrom)
+    .utc()
+    .format("MM/DD/YY HH:mm"),
+  endDate: moment
+    .unix(timeTo)
+    .utc()
+    .format("MM/DD/YY HH:mm"),
+  locale: {
+    format: "MM/DD/YY HH:mm"
+  }
+});
+
 export const setupTimeRangeFilter = (callback, timeFrom, timeTo) => {
   if (document.getElementById("time-range")) {
     $("#time-range").daterangepicker(
-      {
-        linkedCalendars: false,
-        timePicker: true,
-        timePicker24Hour: true,
-        startDate: moment
-          .unix(timeFrom)
-          .utc()
-          .format("MM/DD/YYYY HH:mm"),
-        endDate: moment
-          .unix(timeTo)
-          .utc()
-          .format("MM/DD/YYYY HH:mm"),
-        locale: {
-          format: "MM/DD/YYYY HH:mm"
-        }
-      },
+      daterangepickerConfig(timeFrom, timeTo),
       function(timeFrom, timeTo) {
         timeFrom = timeFrom.utcOffset(0, true).unix();
         timeTo = timeTo.utcOffset(0, true).unix();


### PR DESCRIPTION
Just two digits for the timerange input

![Screen Shot 2019-05-16 at 12 02 09 1](https://user-images.githubusercontent.com/5238698/57845523-7453d780-77d2-11e9-9076-0594b1aa7755.png)
