### PR TITLE
Display statistics for the selected graph range

### DIFF
--- a/app/assets/stylesheets/modules/single-session.css.scss
+++ b/app/assets/stylesheets/modules/single-session.css.scss
@@ -83,3 +83,7 @@
   margin-top: 11px;
   float: left;
 }
+
+.single-session-placeholder {
+  height: 57px;
+}

--- a/app/javascript/angular/code/services/graph.js
+++ b/app/javascript/angular/code/services/graph.js
@@ -11,7 +11,12 @@ let measurementsByTime = {};
 let chart = null;
 const RENDER_TO_ID = "graph";
 
-export const fetchAndDrawFixed = ({ sensor, heat, times, streamId }) => {
+export const fetchAndDrawFixed = showStatsCallback => ({
+  sensor,
+  heat,
+  times,
+  streamId
+}) => {
   // render empty graph with loading message
   drawFixed({
     measurements: [],
@@ -28,29 +33,49 @@ export const fetchAndDrawFixed = ({ sensor, heat, times, streamId }) => {
       start_time: pageStartTime,
       end_time: times.end
     })
-    .then(xs => {
+    .then(measurements => {
+      showStatsCallback(getValues(measurements));
+
       drawFixed({
         measurements: measurementsToTimeWithExtremes({
-          measurements: xs,
+          measurements,
           times
         }),
         sensor,
         heat,
-        afterSetExtremes: afterSetExtremes({ streamId, times })
+        afterSetExtremes: afterSetExtremes({
+          streamId,
+          times,
+          showStatsCallback
+        })
       });
     });
 };
 
-export const fetchAndDrawMobile = ({ sensor, heat, times, streamId }) => {
+export const fetchAndDrawMobile = showStatsCallback => ({
+  sensor,
+  heat,
+  times,
+  streamId
+}) => {
   // render empty graph with loading message
-  drawMobile({ measurements: [], sensor, heat });
+  drawMobile({ measurements: [], sensor, heat, showStatsCallback });
 
   http
     .get("/api/measurements.json", {
       stream_id: streamId
     })
-    .then(xs => {
-      drawMobile({ measurements: measurementsToTime(xs), sensor, heat });
+    .then(measurements => {
+      measurements = measurementsToTime(measurements);
+
+      showStatsCallback(filterMeasurements(measurements));
+
+      drawMobile({
+        measurements,
+        sensor,
+        heat,
+        showStatsCallback
+      });
     });
 };
 
@@ -69,7 +94,7 @@ const onMouseOverMultiple = (start, end) => {
   graphHighlight.show([points[pointNum]]);
 };
 
-const afterSetExtremes = ({ streamId, times }) => e => {
+const afterSetExtremes = ({ streamId, times, showStatsCallback }) => e => {
   chart.showLoading("Loading data from server...");
 
   http
@@ -83,7 +108,7 @@ const afterSetExtremes = ({ streamId, times }) => e => {
         measurements,
         times
       });
-      measurementsByTime = dataByTime;
+      showStatsCallback(getValues(measurements));
       chart.series[0].setData(Object.values(dataByTime), false);
       chart.redraw();
       chart.hideLoading();
@@ -104,10 +129,23 @@ const fixedButtons = [[hr1, hrs12, hrs24, wk1, mth1, all], 2];
 
 const mobileButtons = [[min1, min5, min30, hr1, hrs12, all], 4];
 
-export const drawMobile = ({ measurements, sensor, heat }) => {
+export const drawMobile = ({
+  measurements,
+  sensor,
+  heat,
+  showStatsCallback
+}) => {
   const [buttons, selectedButton] = mobileButtons;
   const scrollbar = {};
-  const xAxis = {};
+  const xAxis = {
+    events: {
+      afterSetExtremes: event => {
+        showStatsCallback(
+          getValuesInRange(Object.values(measurements), event.min, event.max)
+        );
+      }
+    }
+  };
   draw({
     buttons,
     selectedButton,
@@ -200,3 +238,26 @@ const draw = ({
     .getElementById(RENDER_TO_ID)
     .addEventListener("mouseleave", graphHighlight.hide);
 };
+
+const getValues = data => data.map(m => m.value);
+
+const filterMeasurements = measurements => {
+  measurements = Object.values(measurements);
+  const diff = mobileButtons[0][mobileButtons[1]];
+
+  if (diff.type === "all") {
+    return measurements.map(measurement => measurement.y);
+  } else {
+    const max = Math.max(...measurements.map(measurement => measurement.x));
+    const min = moment(max)
+      .subtract(diff.count, diff.type)
+      .valueOf();
+
+    return getValuesInRange(measurements, min, max);
+  }
+};
+
+const getValuesInRange = (data, min, max) =>
+  data
+    .filter(dataPoint => dataPoint.x >= min && dataPoint.x <= max)
+    .map(dataPoint => dataPoint.y);

--- a/app/javascript/angular/code/services/graph.js
+++ b/app/javascript/angular/code/services/graph.js
@@ -241,16 +241,16 @@ const draw = ({
 
 const getValues = data => data.map(m => m.value);
 
-const filterMeasurements = measurements => {
-  measurements = Object.values(measurements);
-  const diff = mobileButtons[0][mobileButtons[1]];
+const filterMeasurements = measurementsByTime => {
+  const measurements = Object.values(measurementsByTime);
+  const selectedTimeRange = mobileButtons[0][mobileButtons[1]];
 
-  if (diff.type === "all") {
+  if (selectedTimeRange.type === "all") {
     return measurements.map(measurement => measurement.y);
   } else {
     const max = Math.max(...measurements.map(measurement => measurement.x));
     const min = moment(max)
-      .subtract(diff.count, diff.type)
+      .subtract(selectedTimeRange.count, selectedTimeRange.type)
       .valueOf();
 
     return getValuesInRange(measurements, min, max);

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -131,7 +131,7 @@ view session heatMapThresholds linkIcon toMsg =
         , p [ class "single-session-sensor" ] [ text session.sensorName ]
         , case session.selectedMeasurements of
             [] ->
-                div [] []
+                div [ class "single-session-placeholder" ] []
 
             measurements ->
                 let

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -5,6 +5,7 @@ module Data.SelectedSession exposing
     , times
     , toId
     , toStreamId
+    , updateRange
     , view
     )
 
@@ -19,7 +20,7 @@ import Html.Events as Events
 import Http
 import Json.Decode as Decode exposing (Decoder(..))
 import Json.Decode.Pipeline exposing (custom, hardcoded, required)
-import RemoteData exposing (WebData)
+import RemoteData exposing (RemoteData(..), WebData)
 import Sensor exposing (Sensor)
 import Time exposing (Posix)
 
@@ -33,7 +34,7 @@ type alias SelectedSession =
     , measurements : List Float
     , id : Int
     , streamId : Int
-    , selectedRangeMeasurements : List Float
+    , selectedMeasurements : List Float
     }
 
 
@@ -73,7 +74,7 @@ decoder =
 
 
 toSelectedSession : String -> String -> String -> Posix -> Posix -> List Float -> Int -> Int -> List Float -> SelectedSession
-toSelectedSession title username sensorName startTime endTime measurements sessionId streamId selectedRangeMeasurements =
+toSelectedSession title username sensorName startTime endTime measurements sessionId streamId selectedMeasurements =
     { title = title
     , username = username
     , sensorName = sensorName
@@ -82,7 +83,7 @@ toSelectedSession title username sensorName startTime endTime measurements sessi
     , measurements = measurements
     , id = sessionId
     , streamId = streamId
-    , selectedRangeMeasurements = selectedRangeMeasurements
+    , selectedMeasurements = selectedMeasurements
     }
 
 
@@ -108,6 +109,16 @@ fetch sensors sensorId page id toCmd =
             Cmd.none
 
 
+updateRange : WebData SelectedSession -> List Float -> WebData SelectedSession
+updateRange result measurements =
+    case result of
+        Success session ->
+            Success { session | selectedMeasurements = measurements }
+
+        _ ->
+            result
+
+
 view : SelectedSession -> WebData HeatMapThresholds -> String -> (String -> msg) -> Html msg
 view session heatMapThresholds linkIcon toMsg =
     let
@@ -118,7 +129,7 @@ view session heatMapThresholds linkIcon toMsg =
         [ p [ class "single-session-name" ] [ text session.title ]
         , p [ class "single-session-username" ] [ text session.username ]
         , p [ class "single-session-sensor" ] [ text session.sensorName ]
-        , case session.selectedRangeMeasurements of
+        , case session.selectedMeasurements of
             [] ->
                 div [] []
 

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -213,6 +213,7 @@ type Msg
     | MapMoved
     | FetchSessions
     | HighlightSessionMarker (Maybe Location)
+    | GraphRangeSelected (List Float)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -459,6 +460,14 @@ update msg model =
 
         HighlightSessionMarker location ->
             ( model, Ports.highlightSessionMarker location )
+
+        GraphRangeSelected measurements ->
+            case model.selectedSession of
+                Success selectedSession ->
+                    ( { model | selectedSession = Success { selectedSession | selectedRangeMeasurements = measurements } }, Cmd.none )
+
+                _ ->
+                    ( model, Cmd.none )
 
 
 updateHeatMapExtreme : Model -> String -> (Int -> HeatMapThresholds -> HeatMapThresholds) -> ( Model, Cmd Msg )
@@ -1017,4 +1026,5 @@ subscriptions _ =
         , Ports.toggleSessionSelection ToggleSessionSelectionFromAngular
         , Ports.updateHeatMapThresholdsFromAngular UpdateHeatMapThresholdsFromAngular
         , Ports.mapMoved (always MapMoved)
+        , Ports.graphRangeSelected GraphRangeSelected
         ]

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -462,12 +462,7 @@ update msg model =
             ( model, Ports.highlightSessionMarker location )
 
         GraphRangeSelected measurements ->
-            case model.selectedSession of
-                Success selectedSession ->
-                    ( { model | selectedSession = Success { selectedSession | selectedRangeMeasurements = measurements } }, Cmd.none )
-
-                _ ->
-                    ( model, Cmd.none )
+            ( { model | selectedSession = SelectedSession.updateRange model.selectedSession measurements }, Cmd.none )
 
 
 updateHeatMapExtreme : Model -> String -> (Int -> HeatMapThresholds -> HeatMapThresholds) -> ( Model, Cmd Msg )

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -3,6 +3,7 @@ port module Ports exposing
     , drawMobile
     , fetchSessions
     , findLocation
+    , graphRangeSelected
     , highlightSessionMarker
     , loadMoreSessions
     , locationCleared
@@ -113,3 +114,6 @@ port fetchSessions : () -> Cmd a
 
 
 port highlightSessionMarker : Maybe Location -> Cmd a
+
+
+port graphRangeSelected : (List Float -> msg) -> Sub msg

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -636,7 +636,7 @@ viewTests =
                 let
                     selectedSession =
                         { defaultSelectedSession
-                            | selectedRangeMeasurements = [ 1, 4 ]
+                            | selectedMeasurements = [ 1, 4 ]
                         }
 
                     expected =

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -631,18 +631,16 @@ viewTests =
                     |> view
                     |> Query.fromHtml
                     |> Query.has [ Slc.all expected ]
-        , fuzz3 float float float "with selection the session rounded average min and max are shown" <|
-            \average min max ->
+        , test "with selection the session rounded average min and max are shown" <|
+            \_ ->
                 let
                     selectedSession =
                         { defaultSelectedSession
-                            | average = average
-                            , min = min
-                            , max = max
+                            | selectedRangeMeasurements = [ 1, 4 ]
                         }
 
                     expected =
-                        List.map (\x -> Slc.containing [ Slc.text x ]) [ String.fromInt <| round average, String.fromFloat min, String.fromFloat max ]
+                        List.map (\x -> Slc.containing [ Slc.text x ]) [ String.fromInt <| 3, String.fromFloat 1, String.fromFloat 4 ]
                 in
                 { defaultModel | selectedSession = Success selectedSession }
                     |> view

--- a/app/javascript/elm/tests/TestUtils.elm
+++ b/app/javascript/elm/tests/TestUtils.elm
@@ -77,5 +77,5 @@ defaultSelectedSession =
     , measurements = [ 1.0, 2.0, 3.0 ]
     , id = 123
     , streamId = 123
-    , selectedRangeMeasurements = []
+    , selectedMeasurements = []
     }

--- a/app/javascript/elm/tests/TestUtils.elm
+++ b/app/javascript/elm/tests/TestUtils.elm
@@ -72,12 +72,10 @@ defaultSelectedSession =
     { title = "title"
     , username = "username"
     , sensorName = "sensor-name"
-    , average = 2.0
-    , min = 1.0
-    , max = 3.0
     , startTime = Time.millisToPosix 0
     , endTime = Time.millisToPosix 0
     , measurements = [ 1.0, 2.0, 3.0 ]
     , id = 123
     , streamId = 123
+    , selectedRangeMeasurements = []
     }

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -148,9 +148,15 @@ const setupHeatMap = () => {
       );
     });
 
-    window.__elmApp.ports.drawFixed.subscribe(draw(graph.fetchAndDrawFixed));
+    const callback = window.__elmApp.ports.graphRangeSelected.send;
 
-    window.__elmApp.ports.drawMobile.subscribe(draw(graph.fetchAndDrawMobile));
+    window.__elmApp.ports.drawFixed.subscribe(
+      draw(graph.fetchAndDrawFixed(callback))
+    );
+
+    window.__elmApp.ports.drawMobile.subscribe(
+      draw(graph.fetchAndDrawMobile(callback))
+    );
   }
 };
 

--- a/app/services/api/to_session_hash.rb
+++ b/app/services/api/to_session_hash.rb
@@ -15,7 +15,6 @@ class Api::ToSessionHash
       title: session.title,
       username: session.user.username,
       sensorName: session.streams.first.sensor_name,
-      average: average(measurements(session)),
       measurements: measurements(session),
       startTime: format_time(session.start_time_local),
       endTime: format_time(session.end_time_local),
@@ -30,12 +29,7 @@ class Api::ToSessionHash
     time.to_datetime.strftime("%Q").to_i
   end
 
-  def average(xs)
-    xs.inject(:+).to_f / xs.length
-  end
-
   def measurements(session)
     @measurements ||= session.streams.first.measurements.map(&:value)
   end
 end
-

--- a/spec/controllers/api/fixed/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/sessions_controller_spec.rb
@@ -24,7 +24,6 @@ describe Api::Fixed::SessionsController do
         "title" => title,
         "username" => username,
         "sensorName" => sensor_name,
-        "average" => 1.5,
         "measurements" => [value1, value2],
         "startTime" => 970365780000,
         "endTime" => 1004850360000,

--- a/spec/controllers/api/mobile/sessions_controller_spec.rb
+++ b/spec/controllers/api/mobile/sessions_controller_spec.rb
@@ -95,7 +95,6 @@ describe Api::Mobile::SessionsController do
         "title" => session.title,
         "username" => user.username,
         "sensorName" => sensor_name,
-        "average" => (measurement1.value + measurement2.value) / 2,
         "measurements" => [measurement1.value, measurement2.value],
         "startTime" => 970365780000,
         "endTime" => 1004850360000,


### PR DESCRIPTION
Getting the values for fixed is easier, cause we only download the measurements that are displayed on the graph.
For mobile I had to do some fancy filtering.

Also, it has to be done into places:
- everytime someone selects a range button, scrolls the graph, selects a graph region - the afterSetExtremes is triggered and there new stats are calculated
- unfortunately, this is not triggered when first loading the graph, so there I had to figure out a different way to filter the measurements, and for mobile it's a bit longer, but it's the best I could figure out.
