### PR TITLE
Use one tooltip instance

### DIFF
--- a/app/javascript/angular/code/filtersUtils.js
+++ b/app/javascript/angular/code/filtersUtils.js
@@ -79,15 +79,17 @@ export const setupClipboard = () => {
   new Clipboard("#copy-link-button");
 };
 
-export const tooltipInstance = tooltipId =>
+export const tooltipInstance = (tooltipId, oldTooltip) =>
   tippy(`#${tooltipId}`, {
     animateFill: false,
     interactive: true,
     trigger: "manual"
-  })[0];
+  })[0] || oldTooltip;
+
+let tooltip;
 
 export const fetchShortUrl = (tooltipId, currentUrl) => {
-  const tooltip = tooltipInstance(tooltipId);
+  tooltip = tooltipInstance(tooltipId, tooltip);
 
   tooltip.setContent("Fetching...");
   tooltip.show();


### PR DESCRIPTION
There was a bug when a user opened a tooltip window and clicked again on the button to open a tooltip window. That second click would try to create a second tooltip instance using the same id as the first instance. That would return a null instead of creating an instance and the SetContent would throw an error when executed on null.