### PR TITLE
Don't fetch unnecessary measurements

### DIFF
--- a/app/javascript/angular/code/services/graph.js
+++ b/app/javascript/angular/code/services/graph.js
@@ -108,6 +108,7 @@ const afterSetExtremes = ({ streamId, times, showStatsCallback }) => e => {
         measurements,
         times
       });
+      measurementsByTime = dataByTime;
       showStatsCallback(getValues(measurements));
       chart.series[0].setData(Object.values(dataByTime), false);
       chart.redraw();

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -32,7 +32,6 @@ type alias SelectedSession =
     , sensorName : String
     , startTime : Posix
     , endTime : Posix
-    , measurements : List Float
     , id : Int
     , streamId : Int
     , selectedMeasurements : List Float
@@ -68,20 +67,18 @@ decoder =
         |> required "sensorName" Decode.string
         |> required "startTime" millisToPosixDecoder
         |> required "endTime" millisToPosixDecoder
-        |> required "measurements" (Decode.list Decode.float)
         |> required "id" Decode.int
         |> required "streamId" Decode.int
         |> hardcoded []
 
 
-toSelectedSession : String -> String -> String -> Posix -> Posix -> List Float -> Int -> Int -> List Float -> SelectedSession
-toSelectedSession title username sensorName startTime endTime measurements sessionId streamId selectedMeasurements =
+toSelectedSession : String -> String -> String -> Posix -> Posix -> Int -> Int -> List Float -> SelectedSession
+toSelectedSession title username sensorName startTime endTime sessionId streamId selectedMeasurements =
     { title = title
     , username = username
     , sensorName = sensorName
     , startTime = startTime
     , endTime = endTime
-    , measurements = measurements
     , id = sessionId
     , streamId = streamId
     , selectedMeasurements = selectedMeasurements

--- a/app/javascript/elm/tests/TestUtils.elm
+++ b/app/javascript/elm/tests/TestUtils.elm
@@ -74,7 +74,6 @@ defaultSelectedSession =
     , sensorName = "sensor-name"
     , startTime = Time.millisToPosix 0
     , endTime = Time.millisToPosix 0
-    , measurements = [ 1.0, 2.0, 3.0 ]
     , id = 123
     , streamId = 123
     , selectedMeasurements = []

--- a/app/services/api/to_session_hash.rb
+++ b/app/services/api/to_session_hash.rb
@@ -7,7 +7,7 @@ class Api::ToSessionHash
     return Failure.new(form.errors) if form.invalid?
 
     session = @model
-      .includes(streams: [:measurements])
+      .includes(:streams)
       .where(id: form.to_h[:id], streams: { sensor_name: form.to_h[:sensor_name]})
       .first!
 
@@ -15,7 +15,6 @@ class Api::ToSessionHash
       title: session.title,
       username: session.user.username,
       sensorName: session.streams.first.sensor_name,
-      measurements: measurements(session),
       startTime: format_time(session.start_time_local),
       endTime: format_time(session.end_time_local),
       id: session.id,
@@ -27,9 +26,5 @@ class Api::ToSessionHash
 
   def format_time(time)
     time.to_datetime.strftime("%Q").to_i
-  end
-
-  def measurements(session)
-    @measurements ||= session.streams.first.measurements.map(&:value)
   end
 end

--- a/spec/controllers/api/fixed/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/sessions_controller_spec.rb
@@ -13,10 +13,6 @@ describe Api::Fixed::SessionsController do
       create_stream!(session: session, sensor_name: "another-sensor-name")
       stream = create_stream!(session: session, sensor_name: sensor_name)
       create_stream!(session: session, sensor_name: "yet another-sensor-name")
-      value1 = 1.0
-      create_measurement!(stream: stream, value: value1)
-      value2 = 2.0
-      create_measurement!(stream: stream, value: value2)
 
       get :show, id: session.id, sensor_name: sensor_name
 
@@ -24,7 +20,6 @@ describe Api::Fixed::SessionsController do
         "title" => title,
         "username" => username,
         "sensorName" => sensor_name,
-        "measurements" => [value1, value2],
         "startTime" => 970365780000,
         "endTime" => 1004850360000,
         "id" => session.id,
@@ -75,17 +70,6 @@ describe Api::Fixed::SessionsController do
       threshold_medium: 70,
       threshold_high: 80,
       threshold_very_high: 100
-    )
-  end
-
-  def create_measurement!(stream:, value:)
-    Measurement.create!(
-      time: DateTime.current,
-      latitude: 123,
-      longitude: 123,
-      value: value,
-      milliseconds: 123,
-      stream: stream
     )
   end
 end

--- a/spec/controllers/api/mobile/sessions_controller_spec.rb
+++ b/spec/controllers/api/mobile/sessions_controller_spec.rb
@@ -86,8 +86,6 @@ describe Api::Mobile::SessionsController do
       create_stream!(session: session, sensor_name: "another-sensor-name")
       stream = create_stream!(session: session, sensor_name: sensor_name)
       create_stream!(session: session, sensor_name: "yet another-sensor-name")
-      measurement1 = create_measurement!(stream: stream)
-      measurement2 = create_measurement!(stream: stream)
 
       get :show, id: session.id, sensor_name: sensor_name
 
@@ -95,7 +93,6 @@ describe Api::Mobile::SessionsController do
         "title" => session.title,
         "username" => user.username,
         "sensorName" => sensor_name,
-        "measurements" => [measurement1.value, measurement2.value],
         "startTime" => 970365780000,
         "endTime" => 1004850360000,
         "id" => session.id,


### PR DESCRIPTION
For long fixed sessions that was causing very long loading times. And these measurements are not used for anything. 
We are doing a separate fetch on the angular side to fetch measurements for mobile session necessary to draw a session on the map.