### PR TITLE
fix(pulsing marker)

### DIFF
--- a/app/assets/images/pulsing_location_marker.svg
+++ b/app/assets/images/pulsing_location_marker.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="8" cy="8" r="8" fill="#09a8f0"/>
+</svg>

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -3,6 +3,8 @@
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *= require_self
- *= require main
- *= require_tree ./vendor
 */
+
+body {
+  background: pink;
+}

--- a/app/assets/stylesheets/config/jquery-ui-assets.css.scss
+++ b/app/assets/stylesheets/config/jquery-ui-assets.css.scss
@@ -1,33 +1,34 @@
 .ui-icon {
   width: 16px;
   height: 16px;
-  background-image: image-url("ui-icons_222222_256x240.png");
+  background-image: url("../../images/ui-icons_222222_256x240.png");
 }
 .ui-widget-content .ui-icon {
-  background-image: image-url("ui-icons_222222_256x240.png");
+  background-image: url("../../images/ui-icons_222222_256x240.png");
 }
 .ui-widget-header .ui-icon {
-  background-image: image-url("ui-icons_222222_256x240.png");
+  background-image: url("../../images/ui-icons_222222_256x240.png");
 }
 .ui-state-default .ui-icon {
-  background-image: image-url("ui-icons_888888_256x240.png");
+  background-image: url("../../images/ui-icons_888888_256x240.png");
 }
 .ui-state-hover .ui-icon,
 .ui-state-focus .ui-icon {
-  background-image: image-url("ui-icons_454545_256x240.png");
+  background-image: url("../../images/ui-icons_454545_256x240.png");
 }
 .ui-state-active .ui-icon {
-  background-image: image-url("ui-icons_454545_256x240.png");
+  background-image: url("../../images/ui-icons_454545_256x240.png");
 }
 .ui-state-highlight .ui-icon {
-  background-image: image-url("ui-icons_2e83ff_256x240.png");
+  background-image: url("../../images/ui-icons_2e83ff_256x240.png");
 }
 .ui-state-error .ui-icon,
 .ui-state-error-text .ui-icon {
-  background-image: image-url("ui-icons_cd0a0a_256x240.png");
+  background-image: url("../../images/ui-icons_cd0a0a_256x240.png");
 }
 .ui-autocomplete-loading {
-  background: white url("ui-anim_basic_16x16.gif") right center no-repeat;
+  background: white url("../../images/ui-anim_basic_16x16.gif") right center
+    no-repeat;
 }
 .ui-widget-header,
 .ui-widget button {

--- a/app/assets/stylesheets/modules/markers.css.scss
+++ b/app/assets/stylesheets/modules/markers.css.scss
@@ -145,7 +145,7 @@
   width: 100px;
 }
 
-#highlightMarkerLayer img {
+img[src*="pulsing_location_marker"] {
   margin: 18px !important;
   animation: pulse 0.7s infinite alternate;
   -webkit-animation: pulse 0.7s infinite alternate;

--- a/app/assets/stylesheets/modules/static.css.scss
+++ b/app/assets/stylesheets/modules/static.css.scss
@@ -80,7 +80,7 @@ p.download {
   }
 
   .habitatmap {
-    background: image-url("HM_LogoForAC.jpg") no-repeat;
+    background: url("../../images/HM_LogoForAC.jpg") no-repeat;
     height: 81px;
     width: 57px;
     display: block;
@@ -93,11 +93,11 @@ p.download {
     height: 30px;
   }
   .twitter-link {
-    background: image-url("AC_TwitterLogo.jpg") no-repeat;
+    background: url("../../images/AC_TwitterLogo.jpg") no-repeat;
     margin-right: 15px;
   }
   .facebook-link {
-    background: image-url("AC_FacebookLogo.jpg") no-repeat;
+    background: url("../../images/AC_FacebookLogo.jpg") no-repeat;
   }
   .label {
     display: block;

--- a/app/assets/stylesheets/modules/tag.css.scss
+++ b/app/assets/stylesheets/modules/tag.css.scss
@@ -20,7 +20,7 @@
 }
 
 .tag-close {
-  background: image-url("close-icon.svg") no-repeat right center;
+  background: url("../../images/close-icon.svg") no-repeat right center;
   border: none;
   padding: 0 0 0 16px;
   width: 8px;

--- a/app/assets/stylesheets/modules/time-filter-calendar.css.scss
+++ b/app/assets/stylesheets/modules/time-filter-calendar.css.scss
@@ -60,12 +60,12 @@
 }
 
 .daterangepicker .calendar-table .next span {
-  background-image: image-url("calendar-arrow-right.svg");
+  background-image: url("../../images/calendar-arrow-right.svg");
   background-position: center;
 }
 
 .daterangepicker .calendar-table .prev span {
-  background-image: image-url("calendar-arrow-left.svg");
+  background-image: url("../../images/calendar-arrow-left.svg");
   background-position: center right;
 }
 

--- a/app/javascript/angular/code/services/google/_map.js
+++ b/app/javascript/angular/code/services/google/_map.js
@@ -223,15 +223,10 @@ export const map = (
           anchor: new google.maps.Point(24, 25),
           size: new google.maps.Size(60, 60),
           scaledSize: new google.maps.Size(12, 12),
-          url: assets.locationMarkerPath
+          url: assets.pulsingLocationMarkerPath
         }
       });
-
-      let overlay = new google.maps.OverlayView();
-      overlay.draw = function() {
-        this.getPanes().markerLayer.id = "highlightMarkerLayer";
-      };
-      overlay.setMap(this.mapObj);
+      highlightMarker.setAnimation(true);
 
       return highlightMarker;
     },

--- a/app/javascript/assets.js
+++ b/app/javascript/assets.js
@@ -23,6 +23,11 @@ export const locationMarkerPath =
     ? ""
     : require("../assets/images/location_marker.svg");
 
+export const pulsingLocationMarkerPath =
+  process.env.NODE_ENV === "test"
+    ? ""
+    : require("../assets/images/pulsing_location_marker.svg");
+
 export const marker1Path =
   process.env.NODE_ENV === "test"
     ? ""

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -7,6 +7,7 @@ import tooltipIcon from "../../assets/images/tooltip-icon.svg";
 import "nouislider";
 import * as graph from "../angular/code/services/graph";
 import tippy from "tippy.js";
+import "../../assets/stylesheets/main.scss";
 
 document.addEventListener("DOMContentLoaded", () => {
   fetch("/api/sensors.json")

--- a/app/views/layouts/map.html.haml
+++ b/app/views/layouts/map.html.haml
@@ -6,7 +6,6 @@
     %title AirCasting
     = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{A9n.google_maps_api_key}"
     = javascript_pack_tag "elm"
-    = stylesheet_link_tag "application"
     = javascript_pack_tag "application"
     = favicon_link_tag "favicon.png"
     = render :partial => 'shared/analytics'

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -12,5 +12,9 @@ environment.plugins.append(
   })
 );
 
+environment.loaders.get("sass").use.splice(-1, 0, {
+  loader: "resolve-url-loader"
+});
+
 environment.loaders.prepend("elm", elm);
 module.exports = environment;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "istanbul": "^0.4.5",
     "nyc": "^13.3.0",
     "prettier": "1.17.0",
+    "resolve-url-loader": "^3.1.0",
     "sinon": "^7.2.3",
     "webpack-dev-server": "^3.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,16 @@ acorn@^6.0.5:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
 
+adjust-sourcemap-loader@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz#6471143af75ec02334b219f54bc7970c52fb29a4"
+  dependencies:
+    assert "1.4.1"
+    camelcase "5.0.0"
+    loader-utils "1.2.3"
+    object-path "0.11.4"
+    regex-parser "2.2.10"
+
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -1002,6 +1012,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arity-n@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -1076,7 +1090,7 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
-assert@^1.1.1:
+assert@1.4.1, assert@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
@@ -1484,6 +1498,10 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
@@ -1751,6 +1769,12 @@ component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
+compose-function@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/compose-function/-/compose-function-3.0.3.tgz#9ed675f13cc54501d30950a486ff6a7ba3ab185f"
+  dependencies:
+    arity-n "^1.0.4"
+
 compressible@~2.0.16:
   version "2.0.17"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.17.tgz#6e8c108a16ad58384a977f3a482ca20bff2f38c1"
@@ -1819,11 +1843,15 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-convert-source-map@^1.1.0, convert-source-map@^1.6.0:
+convert-source-map@1.6.0, convert-source-map@^1.1.0, convert-source-map@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   dependencies:
     safe-buffer "~5.1.1"
+
+convert-source-map@^0.3.3:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -2051,6 +2079,15 @@ css-what@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
 
+css@^2.0.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssdb@^4.3.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0"
@@ -2140,6 +2177,12 @@ currently-unhandled@^0.4.1:
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
+
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2539,9 +2582,32 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.50"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.50.tgz#6d0e23a0abdb27018e5ac4fd09b412bc5517a778"
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.1"
+    next-tick "^1.0.0"
+
 es6-error@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+
+es6-iterator@2.0.3, es6-iterator@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -4048,6 +4114,14 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
+loader-utils@1.2.3, loader-utils@^1.0.1, loader-utils@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^2.0.0"
+    json5 "^1.0.1"
+
 loader-utils@^0.2.12:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
@@ -4056,14 +4130,6 @@ loader-utils@^0.2.12:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
-
-loader-utils@^1.0.1, loader-utils@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^2.0.0"
-    json5 "^1.0.1"
 
 loader-utils@^1.0.2, loader-utils@^1.1.0:
   version "1.1.0"
@@ -4533,6 +4599,10 @@ neo-async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
 
+next-tick@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -4816,6 +4886,10 @@ object-keys@^1.0.11, object-keys@^1.0.12:
 object-keys@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
+object-path@0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -5743,17 +5817,17 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.16"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.16.tgz#48f64f1b4b558cb8b52c88987724359acb010da2"
+postcss@7.0.14, postcss@^7.0.2:
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^7.0.2:
-  version "7.0.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.5, postcss@^7.0.6:
+  version "7.0.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.16.tgz#48f64f1b4b558cb8b52c88987724359acb010da2"
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -6048,6 +6122,10 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regex-parser@2.2.10:
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.10.tgz#9e66a8f73d89a107616e63b39d4deddfee912b37"
+
 regexp-tree@^0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.6.tgz#84900fa12fdf428a2ac25f04300382a7c0148479"
@@ -6174,6 +6252,21 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
+resolve-url-loader@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-3.1.0.tgz#54d8181d33cd1b66a59544d05cadf8e4aa7d37cc"
+  dependencies:
+    adjust-sourcemap-loader "2.0.0"
+    camelcase "5.0.0"
+    compose-function "3.0.3"
+    convert-source-map "1.6.0"
+    es6-iterator "2.0.3"
+    loader-utils "1.2.3"
+    postcss "7.0.14"
+    rework "1.0.1"
+    rework-visit "1.0.0"
+    source-map "0.6.1"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -6209,6 +6302,17 @@ resumer@~0.0.0:
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+
+rework-visit@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rework-visit/-/rework-visit-1.0.0.tgz#9945b2803f219e2f7aca00adb8bc9f640f842c9a"
+
+rework@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/rework/-/rework-1.0.1.tgz#30806a841342b54510aa4110850cd48534144aa7"
+  dependencies:
+    convert-source-map "^0.3.3"
+    css "^2.0.0"
 
 rgb-regex@^1.0.1:
   version "1.0.1"
@@ -6513,7 +6617,7 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:
@@ -6534,6 +6638,10 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -6543,10 +6651,6 @@ source-map@^0.4.2:
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 source-map@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
* First commit moves scss for map to webpack
* Second commit fixes the pulsing marker problem

We can share scss between JS and Rails. In fact, `app/assets/stylesheets/application.css` is used by Rails (see `app/views/layouts/application.html.haml`) and `app/assets/stylesheets/main.scss` is used by JS (see `app/javascript/packs/elm.js`). Prolly we should move files around and rename them. But this should prove that we don't lose flexibility but allow us to keep responsibility separated (ie Rails handling Rails stuff via asset pipeline, JS handling JS stuff via Webpack).

Some stuff that is now in main.scss (JS) should be moved to `application.css` because it's needed in Rails pages