### PR TITLE
Filter out sessions with at least one empty stream

### DIFF
--- a/app/javascript/angular/code/services/sessions_downloader.js
+++ b/app/javascript/angular/code/services/sessions_downloader.js
@@ -32,24 +32,8 @@ angular.module("aircasting").factory("sessionsDownloader", [
         .error(error);
     };
 
-    var completeSessions = function(data) {
-      var sessions = _.reject(data, function(session) {
-        return _.isEmpty(session.streams);
-      });
-
-      sessions = _.reject(sessions, function(session) {
-        return _.some(_.values(session.streams), function(stream) {
-          return stream.size === 0;
-        });
-      });
-
-      return sessions;
-    };
-
     var preprocessData = function(data, sessions, params) {
       var times;
-
-      data = completeSessions(data);
 
       _(data).each(function(session) {
         if (session.start_time_local && session.end_time_local) {

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -134,16 +134,6 @@ class Session < ActiveRecord::Base
       .local_minutes_range(Utils.minutes_of_day(time_from), Utils.minutes_of_day(time_to))
   end
 
-  def self.filtered_json(data, limit, offset)
-    offset(offset)
-    .limit(limit)
-    .with_user_and_streams
-    .filter(data).as_json(
-      only: filtered_json_fields,
-      methods: session_methods
-    )
-  end
-
   def self.selected_sessions_json(data)
     where("id IN (?)", data[:session_ids])
     .with_user_and_streams

--- a/spec/models/mobile_session_spec.rb
+++ b/spec/models/mobile_session_spec.rb
@@ -154,20 +154,6 @@ describe MobileSession do
     end
   end
 
-  describe '.filtered_json' do
-    let(:data) { double('data') }
-    let(:records) { double('records') }
-    let(:json) { double('json') }
-
-    it 'should return filter() as json' do
-      expect(MobileSession).to receive(:filter).with(data).and_return(records)
-      expect(records).to receive(:as_json).with(hash_including({:only => [:id, :title, :start_time_local, :end_time_local],
-        :methods => [:username, :streams]})).and_return(json)
-
-      expect(MobileSession.filtered_json(data, 0, 50)).to eq(json)
-    end
-  end
-
   describe '#set_url_token' do
     let(:token) { "abc123" }
     let(:gen) { double(:generate_unique => token) }


### PR DESCRIPTION
Turns out the changes in the backend related to mobile sessions endpoint already filter everything correctly. All that I had to do was to delete the filtering from the frontend.