### PR TITLE
Tweak mobile sessions perf

### DIFF
--- a/app/javascript/angular/code/values/session.js
+++ b/app/javascript/angular/code/values/session.js
@@ -5,14 +5,14 @@ export const formatSessionForList = session => ({
   startTime: session.startTime,
   endTime: session.endTime,
   shortTypes: session.shortTypes,
-  // `average` for mobile sessions, `last_hour_average` for streaming fixed sessions
+  // `stream.average_value` for mobile sessions
+  // `session.last_hour_average` for streaming fixed sessions
   // non-streaming fixed sessions do not have average
   // The `hasOwnProperty` check is needed because 0 is falsy in JS
-  average: session.hasOwnProperty("average")
-    ? session.average
-    : session.hasOwnProperty("last_hour_average")
-    ? session.last_hour_average
-    : null,
+  average:
+    session.type === "MobileSession"
+      ? session.selectedStream.average_value
+      : session.last_hour_average,
   // marker location for mobile sessions is based on the location of first measurement for a given stream
   // for fixed sessions location is constant so and stored on the session directly
   location: {

--- a/app/models/mobile_session.rb
+++ b/app/models/mobile_session.rb
@@ -25,13 +25,6 @@ class MobileSession < Session
     [:id, :title, :start_time_local, :end_time_local]
   end
 
-  def measurements_average
-    stream = self.streams.length >= 1 ? self.streams.first : nil
-    if stream
-      self.streams.first.measurements.average(:value)
-    end
-  end
-
   def fixed?
     false
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -208,10 +208,6 @@ class Session < ActiveRecord::Base
       end
     end
 
-    if type == "MobileSession"
-      res.merge!("average" => measurements_average)
-    end
-
     res.merge!("streams" => map_of_streams)
 
     res

--- a/spec/controllers/api/mobile/sessions_controller_spec.rb
+++ b/spec/controllers/api/mobile/sessions_controller_spec.rb
@@ -37,7 +37,6 @@ describe Api::Mobile::SessionsController do
       expected = {
         "fetchableSessionsCount" => 1,
         "sessions" => [
-          "average" => measurement.value,
           "end_time_local" => "2000-10-01T02:03:04.000Z",
           "start_time_local" => "2000-10-01T02:03:04.000Z",
           "id" => session.id,


### PR DESCRIPTION
By avoiding access to the measurements in database the query should run faster. Unfortunately, it seems like the cache on production already does a lot and this change does not change much in perf.