### PR TITLE
Graph measurement dot on top

### DIFF
--- a/app/assets/stylesheets/modules/markers.css.scss
+++ b/app/assets/stylesheets/modules/markers.css.scss
@@ -9,6 +9,10 @@
   color: transparent;
   cursor: pointer;
 
+  &.measurement {
+    background-color: pink;
+  }
+
   &.default {
     background-color: $grey;
   }

--- a/app/javascript/angular/code/services/google/_map.js
+++ b/app/javascript/angular/code/services/google/_map.js
@@ -311,11 +311,15 @@ export const removeMarker = function(marker) {
   marker.setMap(null);
 };
 
-export const drawMarker = function({ position, title, zIndex, icon }) {
-  var newMarker = new google.maps.Marker({ position, title, zIndex, icon });
+export const drawCustomMarker = ({ position }) => {
+  const customMarker = buildCustomMarker({
+    object: { latLng: new google.maps.LatLng(position) },
+    colorClass: "measurement",
+    type: "marker"
+  });
 
-  newMarker.setMap(window.__map);
-  window.__markers.push(newMarker);
+  customMarker.setMap(window.__map);
+  window.__markers.push(customMarker);
 
-  return newMarker;
+  return customMarker;
 };

--- a/app/javascript/angular/code/services/google/_map.js
+++ b/app/javascript/angular/code/services/google/_map.js
@@ -200,13 +200,13 @@ export const map = (
       callback,
       type
     }) {
-      const customMarker = buildCustomMarker(
+      const customMarker = buildCustomMarker({
         object,
         content,
         colorClass,
         callback,
         type
-      );
+      });
 
       customMarker.setMap(this.get());
       this.markers.push(customMarker);

--- a/app/javascript/angular/code/services/google/custom_marker.js
+++ b/app/javascript/angular/code/services/google/custom_marker.js
@@ -1,5 +1,17 @@
-export function buildCustomMarker(object, content, colorClass, callback, type) {
-  const CustomMarker = function(object, content, colorClass, callback, type) {
+export function buildCustomMarker({
+  object,
+  content,
+  colorClass,
+  callback,
+  type
+}) {
+  const CustomMarker = function({
+    object,
+    content,
+    colorClass,
+    callback,
+    type
+  }) {
     this.position = object.latLng;
 
     const marker = document.createElement("div");
@@ -76,5 +88,5 @@ export function buildCustomMarker(object, content, colorClass, callback, type) {
 
   CustomMarker.prototype.value = () => object.value;
 
-  return new CustomMarker(object, content, colorClass, callback, type);
+  return new CustomMarker({ object, content, colorClass, callback, type });
 }

--- a/app/javascript/angular/code/services/google/graph_highlight.js
+++ b/app/javascript/angular/code/services/google/graph_highlight.js
@@ -1,4 +1,4 @@
-import { removeMarker, drawMarker } from "./_map.js";
+import { removeMarker, drawCustomMarker } from "./_map.js";
 import * as assets from "../../../../assets";
 
 let items = [];
@@ -14,14 +14,8 @@ export const show = points => {
   hide();
   points.forEach(point => {
     items.push({
-      marker: drawMarker({
-        position: { lat: point.latitude, lng: point.longitude },
-        zIndex: 300000,
-        icon: {
-          anchor: new google.maps.Point(8, 8),
-          size: new google.maps.Size(16, 16),
-          url: assets.locationMarkerPath
-        }
+      marker: drawCustomMarker({
+        position: { lat: point.latitude, lng: point.longitude }
       }),
       point: point
     });


### PR DESCRIPTION
By being in the same pane of starting markers but created later, it is on top.

![Screen Shot 2019-05-29 at 13 52 57](https://user-images.githubusercontent.com/5238698/58555188-23ec6900-8219-11e9-8c10-45a37a1a15e2.png)

One refactor we should consider is to have custom functions when building custom markers. Instead of
```js
        const customMarker = map.drawCustomMarker({
          object: { latLng },
          colorClass: "default",
          callback: callback(Session.id(session)),
          type: "marker"
        });

// or

        const marker = map.drawCustomMarker({
          object: { latLng },
          content: content,
          colorClass: heatLevel,
          callback: callback(Session.id(session)),
          type: "data-marker"
        });
```

Something like `buildStartingMarker` or `buildMeasurementMarker` that only accepts vars as input and internally already knows `type`, `colorClass` where it's not dynamic (eg for a data marker `type` is always `"data-marker"`