### PR TITLE
Sessions list perf

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -77,7 +77,7 @@ class Session < ActiveRecord::Base
     sessions = sessions.where(is_indoor: data[:is_indoor]) unless data[:is_indoor].nil?
 
     if data[:east] && data[:west] && data[:north] && data[:south]
-      sessions = sessions.from_location(data)
+      joins(:streams).merge(Stream.in_rectangle(data))
     end
 
     sensor_name = data[:sensor_name]
@@ -111,16 +111,6 @@ class Session < ActiveRecord::Base
     end
 
     sessions
-  end
-
-  def self.from_location(data)
-    streams_ids = Stream.select('streams.id').
-      joins(:session).
-      where('sessions.contribute' => true).
-      in_rectangle(data).
-      map(&:id)
-
-    where(:streams => {:id => streams_ids.uniq})
   end
 
   def self.filter_by_time_range(sessions, time_from, time_to)


### PR DESCRIPTION
This makes the query go much faster. Manual testing on clone showed an improvement of ~83% (from 6 to 1 seconds). The awesome thing is that whoever uses `Session.filter` is now getting that improvement for free.

I've just noticed today that `Session.from_location` was calling `map`. Thus, it was firing an additional query. By using ActiveRecord syntax the additional query is gone and the filtering on `in_rectangle` becomes part of the unique big query generated by `Session.filter`.

I've manually checked that the two query returns the same things.