### PR TITLE
Fix: no session list for dormant sessions

### DIFF
--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -191,5 +191,6 @@ const selectedStream = sensorName => session => ({
 
 const formatSessionForElm = s => ({
   ...s,
-  shortTypes: s.shortTypes.map(({ name, type }) => ({ name, type_: type }))
+  shortTypes: s.shortTypes.map(({ name, type }) => ({ name, type_: type })),
+  average: s.average || null
 });


### PR DESCRIPTION
For dormant sessions, the field was undefined and elm couldn't decode the date. 
I set it to null. We have `(Decode.field "average" <| Decode.nullable Decode.float)` on the elm side so this should be handled correctly now.