### PR TITLE
Sessions: remove debounce

### DIFF
--- a/app/javascript/angular/code/aircasting.js
+++ b/app/javascript/angular/code/aircasting.js
@@ -1,5 +1,3 @@
-import constants from "./constants";
-
 angular.module("google", []);
 angular.module("aircasting", ["ngCookies", "google"]);
 

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -1,5 +1,4 @@
 import _ from "underscore";
-import { debounce } from "debounce";
 import constants from "../constants";
 import * as Session from "../values/session";
 import { calculateBounds } from "../calculateBounds";
@@ -61,8 +60,6 @@ export const fixedSessions = (
     },
 
     onSessionsFetch: function(fetchableSessionsCount) {
-      if ($window.location.pathname !== constants.fixedMapRoute) return;
-
       this.drawSessionsInLocation();
       if (fetchableSessionsCount) {
         this.fetchableSessionsCount = fetchableSessionsCount;
@@ -205,9 +202,7 @@ export const fixedSessions = (
       session.markers.push(customMarker);
     },
 
-    _fetch: function(values = {}) {
-      // if _fetch is called after the route has changed (eg debounced)
-      if ($window.location.pathname !== constants.fixedMapRoute) return;
+    fetch: function(values = {}) {
       const limit = values.amount || 50;
       const offset = values.fetchedSessionsCount || 0;
 
@@ -260,11 +255,7 @@ export const fixedSessions = (
           this.downloadSessions("/api/fixed/dormant/sessions.json", reqData);
         }
       }
-    },
-
-    fetch: debounce(function(values) {
-      this._fetch(values);
-    }, 750)
+    }
   };
   return new FixedSessions();
 };

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -1,6 +1,4 @@
 import _ from "underscore";
-import { debounce } from "debounce";
-import constants from "../constants";
 import * as Session from "../values/session";
 import { clusterer } from "../clusterer";
 import { calculateBounds } from "../calculateBounds";
@@ -67,8 +65,6 @@ export const mobileSessions = (
     },
 
     onSessionsFetch: function(fetchableSessionsCount) {
-      if ($window.location.pathname !== constants.mobileMapRoute) return;
-
       if (!params.isCrowdMapOn()) {
         this.drawSessionsInLocation();
       }
@@ -222,9 +218,7 @@ export const mobileSessions = (
         .success(callback(session, sessionsUtils.selectedSession(this)));
     },
 
-    _fetch: function(values = {}) {
-      // if _fetch is called after the route has changed (eg debounced)
-      if ($window.location.pathname !== constants.mobileMapRoute) return;
+    fetch: function(values = {}) {
       const limit = values.amount || 50;
       const offset = values.fetchedSessionsCount || 0;
 
@@ -279,11 +273,7 @@ export const mobileSessions = (
           _(this.onSessionsFetchError).bind(this)
         );
       }
-    },
-
-    fetch: debounce(function(values) {
-      this._fetch(values);
-    }, 750)
+    }
   };
   return new MobileSessions();
 };

--- a/app/javascript/angular/tests/_fixed_sessions.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions.test.js
@@ -16,7 +16,7 @@ test("fetch with no sessions ids in params passes empty array to sessionsDownloa
     sessionIds
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].session_ids, sessionIds);
 
@@ -33,7 +33,7 @@ test("fetch with sessions ids in params passes them to sessionsDownloader", t =>
     sessionIds
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].session_ids, sessionIds);
 
@@ -48,7 +48,7 @@ test("fetch with time params passes them to sessionsDownloader", t => {
     data
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].time_from, 1);
   t.deepEqual(sessionsDownloaderCalls[0].time_to, 2);
@@ -64,7 +64,7 @@ test("fetch with tags and usernames params passes them to sessionsDownloader", t
     data
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].tags, "tag1, tag2");
   t.deepEqual(sessionsDownloaderCalls[0].usernames, "will123, agata");
@@ -80,7 +80,7 @@ test("fetch with isIndoor set to true passes is_indoor true to sessionsDownloade
     data
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].is_indoor, true);
 
@@ -104,7 +104,7 @@ test("fetch with isIndoor set to true does not pass map corner coordinates to se
     map
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].west, undefined);
   t.deepEqual(sessionsDownloaderCalls[0].east, undefined);
@@ -122,7 +122,7 @@ test("fetch with isIndoor set to false does not pass is_indoor to sessionsDownlo
     data
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].is_indoor, undefined);
 
@@ -137,7 +137,7 @@ test("fetch with missing timeFrom value in params does not call downloadSessions
     data
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.true(sessionsDownloaderCalls.length === 0);
 
@@ -152,7 +152,7 @@ test("fetch with missing timeTo value in params does not call downloadSessions",
     data
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.true(sessionsDownloaderCalls.length === 0);
 
@@ -164,7 +164,7 @@ test("fetch with time calls drawSession.clear", t => {
   const data = buildData({ time: {} });
   const fixedSessionsService = _fixedSessions({ data, drawSession });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.true(drawSession.wasCalled());
 
@@ -179,26 +179,9 @@ test("fetch with time calls downloadSessions", t => {
     data
   });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.true(sessionsDownloaderCalls.length > 0);
-
-  t.end();
-});
-
-test("fetch when on a different route than fixed map does not call downloadSessions", t => {
-  const sessionsDownloaderCalls = [];
-  const data = buildData({ time: {} });
-  const $window = { location: { pathname: "/other_route" } };
-  const fixedSessionsService = _fixedSessions({
-    sessionsDownloaderCalls,
-    data,
-    $window
-  });
-
-  fixedSessionsService._fetch();
-
-  t.true(sessionsDownloaderCalls.length === 0);
 
   t.end();
 });
@@ -215,7 +198,7 @@ test("fetch passes map corner coordinates to sessionsDownloader", t => {
   };
   const fixedSessionsService = _fixedSessions({ sessionsDownloaderCalls, map });
 
-  fixedSessionsService._fetch();
+  fixedSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].west, 1);
   t.deepEqual(sessionsDownloaderCalls[0].east, 2);
@@ -473,7 +456,6 @@ const _fixedSessions = ({
   data,
   drawSession,
   sessionIds = [],
-  $window,
   map,
   sessionsUtils,
   sensors
@@ -511,7 +493,6 @@ const _fixedSessions = ({
   const sessionsDownloader = (_, arg) => {
     sessionsDownloaderCalls.push(arg);
   };
-  const _$window = $window || { location: { pathname: "/fixed_map" } };
   const _sessionsUtils = {
     find: () => ({}),
     onSingleSessionFetch: (x, y, callback) => callback(),
@@ -533,7 +514,7 @@ const _fixedSessions = ({
     sessionsDownloader,
     _drawSession,
     _sessionsUtils,
-    _$window,
+    null,
     _heat
   );
 };

--- a/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
@@ -51,7 +51,7 @@ const _FixedSessionsMapCtrl = ({ callback, params, sensors }) => {
     clearRectangles: () => {},
     removeAllMarkers: () => {}
   };
-  const _$window = {};
+  const $window = {};
 
   return FixedSessionsMapCtrl(
     _$scope,
@@ -62,7 +62,7 @@ const _FixedSessionsMapCtrl = ({ callback, params, sensors }) => {
     null,
     null,
     functionBlocker,
-    _$window,
+    $window,
     infoWindow
   );
 };

--- a/app/javascript/angular/tests/_mobile_sessions.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions.test.js
@@ -14,7 +14,7 @@ test("fetch with no sessions ids in params passes empty array to sessionsDownloa
     sessionIds
   });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].session_ids, sessionIds);
 
@@ -31,7 +31,7 @@ test("fetch with sessions ids in params passes them to sessionsDownloader", t =>
     sessionIds
   });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].session_ids, sessionIds);
 
@@ -46,7 +46,7 @@ test("fetch with time params passes them to sessionsDownloader", t => {
     data
   });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].time_from, 1);
   t.deepEqual(sessionsDownloaderCalls[0].time_to, 2);
@@ -62,7 +62,7 @@ test("fetch with tags and usernames params passes them to sessionsDownloader", t
     data
   });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].tags, "tag1, tag2");
   t.deepEqual(sessionsDownloaderCalls[0].usernames, "will123, agata");
@@ -78,7 +78,7 @@ test("fetch with missing timeFrom value in params does not call downloadSessions
     data
   });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.true(sessionsDownloaderCalls.length === 0);
 
@@ -93,7 +93,7 @@ test("fetch with missing timeTo value in params does not call downloadSessions",
     data
   });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.true(sessionsDownloaderCalls.length === 0);
 
@@ -105,7 +105,7 @@ test("fetch with time calls drawSession.clear", t => {
   const data = buildData({ time: {} });
   const mobileSessionsService = _mobileSessions({ data, drawSession });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.true(drawSession.wasCalled());
 
@@ -120,26 +120,9 @@ test("fetch with time calls downloadSessions", t => {
     data
   });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.true(sessionsDownloaderCalls.length > 0);
-
-  t.end();
-});
-
-test("fetch when on a different route than mobile map does not call downloadSessions", t => {
-  const sessionsDownloaderCalls = [];
-  const data = buildData({ time: {} });
-  const $window = { location: { pathname: "/other_route" } };
-  const mobileSessionsService = _mobileSessions({
-    sessionsDownloaderCalls,
-    data,
-    $window
-  });
-
-  mobileSessionsService._fetch();
-
-  t.true(sessionsDownloaderCalls.length === 0);
 
   t.end();
 });
@@ -159,7 +142,7 @@ test("fetch passes map corner coordinates to sessionsDownloader", t => {
     map
   });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].west, 1);
   t.deepEqual(sessionsDownloaderCalls[0].east, 2);
@@ -175,7 +158,7 @@ test("fetch called without arguments assigns default values", t => {
     sessionsDownloaderCalls
   });
 
-  mobileSessionsService._fetch();
+  mobileSessionsService.fetch();
 
   t.deepEqual(sessionsDownloaderCalls[0].limit, 50);
   t.deepEqual(sessionsDownloaderCalls[0].offset, 0);
@@ -189,7 +172,7 @@ test("fetch called with values passes them to session downloader", t => {
     sessionsDownloaderCalls
   });
 
-  mobileSessionsService._fetch({
+  mobileSessionsService.fetch({
     amount: 100,
     fetchedSessionsCount: 50
   });
@@ -203,7 +186,7 @@ test("fetch called with values passes them to session downloader", t => {
 test("fetch resets sessions list if offset equal 0", t => {
   const mobileSessionsService = _mobileSessions({});
 
-  mobileSessionsService._fetch({
+  mobileSessionsService.fetch({
     fetchedSessionsCount: 0
   });
 
@@ -217,7 +200,7 @@ test("fetch keeps the previous sessions list if offset does not equal 0", t => {
 
   mobileSessionsService.sessions = ["someSession"];
 
-  mobileSessionsService._fetch({
+  mobileSessionsService.fetch({
     fetchedSessionsCount: 50
   });
 
@@ -522,7 +505,6 @@ const _mobileSessions = ({
   data,
   drawSession,
   sessionIds = [],
-  $window,
   map,
   sessionsUtils,
   sensors
@@ -571,7 +553,6 @@ const _mobileSessions = ({
     ...sessionsUtils
   };
   const $http = { get: () => ({ success: callback => callback() }) };
-  const _$window = $window || { location: { pathname: "/mobile_map" } };
   const _heat = { levelName: () => "mid", outsideOfScope: () => false };
 
   return mobileSessions(
@@ -583,7 +564,6 @@ const _mobileSessions = ({
     sessionsDownloader,
     _drawSession,
     _sessionsUtils,
-    _heat,
-    _$window
+    _heat
   );
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "angular": "1.2.29",
     "angular-cookies": "1.2.29",
     "clipboard": "^2.0.4",
-    "debounce": "^1.2.0",
     "elm": "^0.19.0-no-deps",
     "elm-webpack-loader": "^5.0.0",
     "highcharts": "~7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,10 +2194,6 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debounce@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
-
 debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Since the query for the sessions list got faster and the user can also
disable searches when moving the map, debouncing the search just slow
the UX down.