### PR TITLE
Crowd map plus minus buttons

### DIFF
--- a/app/assets/stylesheets/modules/crowd-map-slider.css.scss
+++ b/app/assets/stylesheets/modules/crowd-map-slider.css.scss
@@ -121,10 +121,12 @@ input[type="range"]:focus::-ms-fill-upper {
 
     &.minus {
       margin-top: -1px;
+      cursor: pointer;
     }
 
     &.plus {
       margin-top: 2px;
+      cursor: pointer;
     }
   }
 }

--- a/app/assets/stylesheets/modules/crowd-map-slider.css.scss
+++ b/app/assets/stylesheets/modules/crowd-map-slider.css.scss
@@ -128,7 +128,3 @@ input[type="range"]:focus::-ms-fill-upper {
     }
   }
 }
-
-.crowd-map-slider {
-  direction: rtl;
-}

--- a/app/javascript/elm/src/Data/BoundedInteger.elm
+++ b/app/javascript/elm/src/Data/BoundedInteger.elm
@@ -1,0 +1,76 @@
+module Data.BoundedInteger exposing (BoundedInteger, LowerBound(..), UpperBound(..), Value(..), addOne, build, getLowerBound, getUpperBound, getValue, setValue, subOne)
+
+
+type BoundedInteger
+    = BoundedInteger
+        { lowerBound : Int
+        , upperBound : Int
+        , value : Int
+        }
+
+
+type LowerBound
+    = LowerBound Int
+
+
+type UpperBound
+    = UpperBound Int
+
+
+type Value
+    = Value Int
+
+
+build : LowerBound -> UpperBound -> Value -> BoundedInteger
+build (LowerBound lowerBound) (UpperBound upperBound) (Value value) =
+    BoundedInteger
+        { lowerBound = lowerBound
+        , upperBound = upperBound
+        , value = value
+        }
+
+
+setValue : Int -> BoundedInteger -> BoundedInteger
+setValue value existingValue =
+    updateValue (\_ -> value) existingValue
+
+
+getValue : BoundedInteger -> Int
+getValue (BoundedInteger existingValue) =
+    existingValue.value
+
+
+getUpperBound : BoundedInteger -> Int
+getUpperBound (BoundedInteger existingValue) =
+    existingValue.upperBound
+
+
+getLowerBound : BoundedInteger -> Int
+getLowerBound (BoundedInteger existingValue) =
+    existingValue.lowerBound
+
+
+updateValue : (Int -> Int) -> BoundedInteger -> BoundedInteger
+updateValue update (BoundedInteger existingValue) =
+    let
+        updatedValue =
+            update existingValue.value
+    in
+    if updatedValue > existingValue.upperBound then
+        BoundedInteger existingValue
+
+    else if updatedValue < existingValue.lowerBound then
+        BoundedInteger existingValue
+
+    else
+        BoundedInteger { existingValue | value = updatedValue }
+
+
+addOne : BoundedInteger -> BoundedInteger
+addOne existingValue =
+    updateValue (\x -> x + 1) existingValue
+
+
+subOne : BoundedInteger -> BoundedInteger
+subOne existingValue =
+    updateValue (\x -> x - 1) existingValue

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -358,7 +358,7 @@ crowdMapArea =
                     |> Tuple.first
                     |> .crowdMapResolution
                     |> Expect.equal (BoundedInteger.build (LowerBound 1) (UpperBound 40) (Value 40))
-         , test "'off' is selected by default" <|
+        , test "'off' is selected by default" <|
             \_ ->
                 defaultModel
                     |> view
@@ -375,8 +375,13 @@ crowdMapArea =
                     |> Event.expect ToggleCrowdMap
         , test "slider has a description with current crowd map grid cell size" <|
             \_ ->
-                { defaultModel | isCrowdMapOn = True, crowdMapResolution = BoundedInteger.build (LowerBound 1)
-                (UpperBound 40) (Value 40) }
+                { defaultModel
+                    | isCrowdMapOn = True
+                    , crowdMapResolution =
+                        BoundedInteger.build (LowerBound 1)
+                            (UpperBound 40)
+                            (Value 40)
+                }
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute <| id "crowd-map-slider" ]
@@ -396,8 +401,13 @@ crowdMapArea =
             \resolution ->
                 let
                     model =
-                        { defaultModel | isCrowdMapOn = True, crowdMapResolution = BoundedInteger.build (LowerBound 1)
-                        (UpperBound 40) (Value resolution)}
+                        { defaultModel
+                            | isCrowdMapOn = True
+                            , crowdMapResolution =
+                                BoundedInteger.build (LowerBound 1)
+                                    (UpperBound 40)
+                                    (Value resolution)
+                        }
                 in
                 model
                     |> view

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -1,5 +1,6 @@
 module MainTests exposing (crowdMapArea, locationFilter, parameterSensorFilter, popups, profilesArea, tagsArea, timeFilter, toggleIndoorFilter, toggleStreamingFilter, updateTests, viewTests)
 
+import Data.BoundedInteger as BoundedInteger exposing (BoundedInteger, LowerBound(..), UpperBound(..), Value(..))
 import Data.Page exposing (Page(..))
 import Expect
 import Fuzz exposing (bool, float, int, intRange, list, string)
@@ -343,14 +344,21 @@ crowdMapArea =
                     |> Tuple.first
                     |> .isCrowdMapOn
                     |> Expect.equal (not onOffValue)
-        , fuzz int "UpdateCrowdMapResolution changes the value of model.crowdMapResolution" <|
+        , fuzz (intRange 1 39) "UpdateCrowdMapResolution changes the value of model.crowdMapResolution" <|
             \resolution ->
-                { defaultModel | crowdMapResolution = resolution }
-                    |> update (UpdateCrowdMapResolution resolution)
+                { defaultModel | crowdMapResolution = BoundedInteger.build (LowerBound 1) (UpperBound 40) (Value resolution) }
+                    |> update (UpdateCrowdMapResolution (resolution + 1))
                     |> Tuple.first
                     |> .crowdMapResolution
-                    |> Expect.equal resolution
-        , test "'off' is selected by default" <|
+                    |> Expect.equal (BoundedInteger.build (LowerBound 1) (UpperBound 40) (Value (resolution + 1)))
+        , test "UpdateCrowdMapResolution doesn't change the value if it's higher than upper bound" <|
+            \_ ->
+                { defaultModel | crowdMapResolution = BoundedInteger.build (LowerBound 1) (UpperBound 40) (Value 40) }
+                    |> update (UpdateCrowdMapResolution 41)
+                    |> Tuple.first
+                    |> .crowdMapResolution
+                    |> Expect.equal (BoundedInteger.build (LowerBound 1) (UpperBound 40) (Value 40))
+         , test "'off' is selected by default" <|
             \_ ->
                 defaultModel
                     |> view
@@ -367,7 +375,8 @@ crowdMapArea =
                     |> Event.expect ToggleCrowdMap
         , test "slider has a description with current crowd map grid cell size" <|
             \_ ->
-                { defaultModel | isCrowdMapOn = True, crowdMapResolution = 11 }
+                { defaultModel | isCrowdMapOn = True, crowdMapResolution = BoundedInteger.build (LowerBound 1)
+                (UpperBound 40) (Value 40) }
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute <| id "crowd-map-slider" ]
@@ -375,19 +384,20 @@ crowdMapArea =
                         [ text "grid cell size: 40" ]
 
         -- resolution 11 maps to size 40
-        , test "slider default value is 25" <|
+        , test "slider default value is 20" <|
             \_ ->
                 { defaultModel | isCrowdMapOn = True }
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute <| class "crowd-map-slider" ]
                     |> Query.has
-                        [ Slc.attribute <| value "25" ]
+                        [ Slc.attribute <| value "20" ]
         , fuzz int "slider value depends on model.crowdMapResolution" <|
             \resolution ->
                 let
                     model =
-                        { defaultModel | isCrowdMapOn = True, crowdMapResolution = resolution }
+                        { defaultModel | isCrowdMapOn = True, crowdMapResolution = BoundedInteger.build (LowerBound 1)
+                        (UpperBound 40) (Value resolution)}
                 in
                 model
                     |> view


### PR DESCRIPTION
Making the crowdmap resolution +/- buttons functional. There needs to be a transformation between 50-11 range in JS and 1-40 range in elm, so we are subtracting the resolution value from 51.

TODO:
- comment why 51 -
- boundary check (ie should not be possible to go below 1 and above 40)- DONE
- fix compile errors - introduce bound types, expose functions instead of a constructor - DONE
- extract function in update to update resolution in the model and call the port - DONE
- debounce buttons - DONE
- fix failing tests - DONE