### PR TITLE
Don't refetch sessions when toggling CrowdMap

### DIFF
--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -102,9 +102,7 @@ export const MobileSessionsMapCtrl = (
 
       elmApp.ports.toggleCrowdMap.subscribe(crowdMap => {
         params.updateData({ crowdMap });
-        $scope.sessions.fetch({
-          amount: params.paramsData["fetchedSessionsCount"]
-        });
+        sessions.toggleCrowdMapView();
       });
 
       elmApp.ports.updateResolution.subscribe(gridResolution => {

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -81,6 +81,16 @@ export const mobileSessions = (
       sessionsUtils.updateCrowdMapLayer(this.sessionIds());
     },
 
+    toggleCrowdMapView: function() {
+      if (params.isCrowdMapOn()) {
+        drawSession.clear(this.sessions);
+        sessionsUtils.updateCrowdMapLayer(this.sessionIds());
+      } else {
+        map.clearRectangles();
+        this.drawSessionsInLocation();
+      }
+    },
+
     deselectSession: function(id) {
       const session = this.find(id);
       if (!session) return;


### PR DESCRIPTION
This solves the problem with preserving the session list length and also makes the switch faster. Anyone sees any edge cases when removing this fetch could cause an issue?