### PR TITLE
Fix sessions fetch when reloading page (or when copy / pasting link)

### DIFF
--- a/app/javascript/angular/code/services/google/_map.js
+++ b/app/javascript/angular/code/services/google/_map.js
@@ -24,15 +24,18 @@ export const map = (
     init: function(element, options) {
       this.mapObj = googleMaps.init(element, options);
       this.markers = $window.__markers;
-      this.listen("idle", this.saveViewport);
-      this.listen(
+      this.addListener("idle", this.saveViewport);
+      this.addListener(
         "visible_changed",
         function() {
           $rootScope.$digest();
         },
         this.mapObj.getStreetView()
       );
-      this.listen("maptypeid_changed", _(this.onMapTypeIdChanged).bind(this));
+      this.addListener(
+        "maptypeid_changed",
+        _(this.onMapTypeIdChanged).bind(this)
+      );
       rectangles.init(this.mapObj);
     },
 
@@ -148,9 +151,9 @@ export const map = (
       digester();
     },
 
-    listen: function(name, callback, diffmap) {
+    addListener: function(name, callback, diffmap) {
       const cb = _(callback).bind(this);
-      return googleMaps.listen(diffmap || this.mapObj, name, cb);
+      return googleMaps.addListener(diffmap || this.mapObj, name, cb);
     },
 
     unregisterAll: function() {
@@ -169,7 +172,7 @@ export const map = (
       var self = this;
       rectangles.draw(data, thresholds);
       _(rectangles.get()).each(function(rectangle) {
-        self.listen(
+        self.addListener(
           "click",
           function() {
             clickCallback({
@@ -258,7 +261,7 @@ export const map = (
         options
       );
 
-      googleMaps.listen(markerClusterer, "clusterclick", onClick);
+      googleMaps.addListener(markerClusterer, "clusterclick", onClick);
       this.clusterer = markerClusterer;
     },
 

--- a/app/javascript/angular/code/services/google/_map.js
+++ b/app/javascript/angular/code/services/google/_map.js
@@ -25,6 +25,9 @@ export const map = (
       this.mapObj = googleMaps.init(element, options);
       this.markers = $window.__markers;
       this.addListener("idle", this.saveViewport);
+      googleMaps.addListenerOnce(this.mapObj, "idle", () =>
+        $rootScope.$broadcast("googleMapsReady")
+      );
       this.addListener(
         "visible_changed",
         function() {

--- a/app/javascript/angular/code/services/google/google_maps.js
+++ b/app/javascript/angular/code/services/google/google_maps.js
@@ -44,6 +44,9 @@ angular.module("google").factory("googleMaps", [
       addListener: (obj, name, callback) =>
         google.maps.event.addListener(obj, name, callback),
 
+      addListenerOnce: (obj, name, callback) =>
+        google.maps.event.addListenerOnce(obj, name, callback),
+
       latLng: (lat, lng) => new google.maps.LatLng(lat, lng),
 
       latLngBounds: (lat, lng) => new google.maps.LatLngBounds(lat, lng),

--- a/app/javascript/angular/code/services/google/google_maps.js
+++ b/app/javascript/angular/code/services/google/google_maps.js
@@ -41,7 +41,7 @@ angular.module("google").factory("googleMaps", [
         onPanOrZoomHandle = mapObj.addListener("bounds_changed", callback);
       },
 
-      listen: (obj, name, callback) =>
+      addListener: (obj, name, callback) =>
         google.maps.event.addListener(obj, name, callback),
 
       latLng: (lat, lng) => new google.maps.LatLng(lat, lng),

--- a/app/javascript/angular/code/services/google/info_window.js
+++ b/app/javascript/angular/code/services/google/info_window.js
@@ -10,7 +10,7 @@ angular.module("google").factory("infoWindow", [
   function(map, $http, $compile, $rootScope, versioner, $timeout) {
     var InfoWindow = function() {
       this.popup = new google.maps.InfoWindow();
-      map.listen("zoom_changed", _(this.hide).bind(this));
+      map.addListener("zoom_changed", _(this.hide).bind(this));
     };
 
     const FIXED_INFO_WINDOW_PATH = "/partials/fixed_info_window.html";

--- a/app/javascript/angular/code/services/google/note.js
+++ b/app/javascript/angular/code/services/google/note.js
@@ -8,7 +8,7 @@ angular.module("google").factory("note", [
   function($http, $compile, $rootScope, $timeout, versioner, map) {
     var Note = function() {
       this.popup = new google.maps.InfoWindow();
-      map.listen("zoom_changed", _(this.hide).bind(this));
+      map.addListener("zoom_changed", _(this.hide).bind(this));
     };
     Note.prototype = {
       get: function() {

--- a/app/javascript/angular/tests/_map.test.js
+++ b/app/javascript/angular/tests/_map.test.js
@@ -342,6 +342,7 @@ const mockGoogleMaps = ({ successfulGeocoding } = {}) => {
     addListener: event => {
       callbacks += 1;
     },
+    addListenerOnce: () => {},
     hasCallbacks: () => callbacks > 0,
     unlistenPanOrZoom: () => {
       callbacks -= 1;

--- a/app/javascript/angular/tests/_map.test.js
+++ b/app/javascript/angular/tests/_map.test.js
@@ -53,7 +53,7 @@ test("goToAddress with successful geocoding calls fitBounds", t => {
 test("goToAddress when calling fitBounds removes callbacks from the map", t => {
   const geocoder = mockGeocoder();
   const googleMaps = mockGoogleMaps({ successfulGeocoding: true });
-  googleMaps.listen("bounds_changed", () => {});
+  googleMaps.addListener("bounds_changed", () => {});
 
   t.true(googleMaps.hasCallbacks());
 
@@ -69,7 +69,7 @@ test("goToAddress when calling fitBounds removes callbacks from the map", t => {
 test("goToAddress re-adds callbacks from the map after calling fitBounds", t => {
   const geocoder = mockGeocoder();
   const googleMaps = mockGoogleMaps({ successfulGeocoding: true });
-  googleMaps.listen("bounds_changed", () => {});
+  googleMaps.addListener("bounds_changed", () => {});
 
   const service = _map({ geocoder, googleMaps });
 
@@ -139,7 +139,7 @@ test("fitBounds with coord 200 north and 200 east calls fitBounds with a specifi
 
 test("fitBounds when calling fitBounds removes callbacks from the map", t => {
   const googleMaps = mockGoogleMaps();
-  googleMaps.listen("bounds_changed", () => {});
+  googleMaps.addListener("bounds_changed", () => {});
 
   t.true(googleMaps.hasCallbacks());
 
@@ -159,7 +159,7 @@ test("fitBounds when calling fitBounds removes callbacks from the map", t => {
 
 test("fitBounds re-adds callbacks from the map after calling fitBounds", t => {
   const googleMaps = mockGoogleMaps();
-  googleMaps.listen("bounds_changed", () => {});
+  googleMaps.addListener("bounds_changed", () => {});
 
   t.true(googleMaps.hasCallbacks());
 
@@ -261,7 +261,7 @@ test("drawRectangles sets a listener with a callback with bounds excluding other
   };
   const rectangles = { get: () => [rectangle] };
   const googleMaps = {
-    listen: (x, y, mapCallback) => {
+    addListener: (x, y, mapCallback) => {
       mapCallback();
     }
   };
@@ -279,7 +279,7 @@ test("drawRectangles sets a listener on rectangle click", t => {
   const rectangle = { a: null };
   const rectangles = { get: () => [rectangle] };
   const mapListen = sinon.spy();
-  const googleMaps = { listen: mapListen };
+  const googleMaps = { addListener: mapListen };
   const service = _map({ rectangles, googleMaps });
 
   service.drawRectangles({}, {}, () => {});
@@ -339,7 +339,7 @@ const mockGoogleMaps = ({ successfulGeocoding } = {}) => {
     },
     wasCalled: () => count === 1,
     wasFitBoundsCalledWith: arg => deepEqual(arg, calls[calls.length - 1]),
-    listen: event => {
+    addListener: event => {
       callbacks += 1;
     },
     hasCallbacks: () => callbacks > 0,

--- a/app/javascript/angular/tests/_sessions_list_ctrl.test.js
+++ b/app/javascript/angular/tests/_sessions_list_ctrl.test.js
@@ -2,7 +2,7 @@ import test from "blue-tape";
 import { mock } from "./helpers";
 import { SessionsListCtrl } from "../code/controllers/_sessions_list_ctrl";
 
-test("with no sessions selected when params.map changes it calls sessions.fetch", t => {
+test("with no sessions selected and isSearchAsIMoveOn true when params.map changes it calls sessions.fetch", t => {
   const callbacks = [];
   const $scope = {
     $watch: (str, callback) =>
@@ -11,7 +11,10 @@ test("with no sessions selected when params.map changes it calls sessions.fetch"
   const sessions = {
     ...mock("fetch")
   };
-  _SessionsListCtrl({ $scope, sessions });
+  const params = {
+    get: () => ({ isSearchAsIMoveOn: true })
+  };
+  _SessionsListCtrl({ $scope, sessions, params });
 
   callbacks.forEach(callback =>
     callback({ hasChangedProgrammatically: false })
@@ -40,7 +43,13 @@ test("with session selected when params.map changes it does not call sessions.fe
   t.end();
 });
 
-const _SessionsListCtrl = ({ map, $scope, updateCrowdMapLayer, sessions }) => {
+const _SessionsListCtrl = ({
+  map,
+  $scope,
+  updateCrowdMapLayer,
+  sessions,
+  params
+}) => {
   const _sessions = { reSelectAllSessions: () => {}, ...sessions };
   const _$scope = {
     sessions: _sessions,
@@ -49,7 +58,12 @@ const _SessionsListCtrl = ({ map, $scope, updateCrowdMapLayer, sessions }) => {
     $on: () => {},
     ...$scope
   };
-  const params = { get: () => ({}), update: () => {}, paramsData: {} };
+  const _params = {
+    get: () => ({}),
+    update: () => {},
+    paramsData: {},
+    ...params
+  };
   const _map = {
     onPanOrZoom: () => {},
     ...map
@@ -62,7 +76,7 @@ const _SessionsListCtrl = ({ map, $scope, updateCrowdMapLayer, sessions }) => {
 
   return SessionsListCtrl(
     _$scope,
-    params,
+    _params,
     null,
     null,
     {},


### PR DESCRIPTION
Comments in the code explain why this fixes the problem. I've used `$broadcast` and `$on` that are Angular things. But I think that it's not adding more complexity in terms of removing Angular code later. In fact, if the logic for fetching sessions moves to Elm we would just call a port from the `addListenerOnce`.

Can review commit by commit. The first one is a refactor to use `addListener` in place of `listen`. The idea is to use the same vocabulary as GoogleMaps w/o introducing new words / verbs