### PR TITLE
Put filters into a div instead of a form.

### DIFF
--- a/app/assets/stylesheets/modules/filters.css.scss
+++ b/app/assets/stylesheets/modules/filters.css.scss
@@ -9,7 +9,7 @@
   width: $filters-width;
 }
 
-.filters__form {
+.filters__div {
   padding: 12px 12px $action-container-height 12px;
 }
 

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -896,7 +896,7 @@ viewFilters model =
 
 viewMobileFilters : Model -> Html Msg
 viewMobileFilters model =
-    form [ class "filters__form" ]
+    div [ class "filters__div" ]
         [ viewParameterFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewSensorFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewLocationFilter model.location model.isIndoor model.tooltipIcon
@@ -909,7 +909,7 @@ viewMobileFilters model =
 
 viewFixedFilters : Model -> Html Msg
 viewFixedFilters model =
-    form [ class "filters__form" ]
+    div [ class "filters__div" ]
         [ viewParameterFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewSensorFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewLocationFilter model.location model.isIndoor model.tooltipIcon


### PR DESCRIPTION
It solves a fascinating bug: submitting location was changing the state of "Redo search when map is
moved". This is because pressing enter on a form acts as pressing the
neares button of type submit (which is the default type). So pressing
enter while using filters was 'clicking' the refresh time range button,
which in turn was executing fetch sessions. And receiving new sessions
list changes "Redo Search in Map" back into "Redo search when map is
moved".

It's worth noting that the fetched sessions where incorrect. The command
to fetch session was triggered before the map had time to move to the
new location, so the sessions were for the old location.