### PR TITLE
refactor: remove watch on selectedSessionIds

### DIFF
--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -79,7 +79,7 @@ export const FixedSessionsMapCtrl = (
       const elmApp = window.__elmApp;
 
       elmApp.ports.selectSensorId.subscribe(sensorId => {
-        params.update({ selectedSessionIds: [] });
+        $scope.sessions.deselectSession();
         params.update({ data: { sensorId } });
         $scope.sessions.fetch();
       });

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -95,7 +95,7 @@ export const MobileSessionsMapCtrl = (
       const elmApp = window.__elmApp;
 
       elmApp.ports.selectSensorId.subscribe(sensorId => {
-        params.update({ selectedSessionIds: [] });
+        $scope.sessions.deselectSession();
         params.update({ data: { sensorId } });
         $scope.sessions.fetch();
       });

--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -116,23 +116,14 @@ export const SessionsListCtrl = (
     }
     var session = sessions.find(sessionId);
     if (sessions.isSelected(session)) {
-      params.update({ selectedSessionIds: [] });
+      sessions.deselectSession();
       callback(null);
     } else if ($scope.canSelectSession(sessionId)) {
-      params.update({ selectedSessionIds: [sessionId] });
+      sessions.selectSession(sessionId);
       $scope.markerSelected.set(true);
       callback(sessionId);
     }
   };
-
-  $scope.$watch(
-    "params.get('selectedSessionIds')",
-    function(newIds, oldIds) {
-      console.log("watch - params.get('selectedSessionIds')");
-      sessions.sessionsChanged(newIds, oldIds);
-    },
-    true
-  );
 
   $scope.setDefaults();
 

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -55,10 +55,6 @@ export const fixedSessions = (
       sessionsUtils.onSessionsFetchError(data);
     },
 
-    sessionsChanged: function(newIds, oldIds) {
-      sessionsUtils.sessionsChanged(this, newIds, oldIds);
-    },
-
     onSessionsFetch: function(fetchableSessionsCount) {
       this.drawSessionsInLocation();
       if (fetchableSessionsCount) {
@@ -69,12 +65,13 @@ export const fixedSessions = (
       }
     },
 
-    deselectSession: function(id) {
-      var session = this.find(id);
+    deselectSession: function() {
+      var session = this.find(sessionsUtils.selectedSessionId());
       if (!session) return;
       session.loaded = false;
       session.alreadySelected = false;
       params.update({ prevMapPosition: {} });
+      params.update({ selectedSessionIds: [] });
       map.fitBounds(prevMapPosition.bounds, prevMapPosition.zoom);
     },
 
@@ -96,6 +93,7 @@ export const fixedSessions = (
           );
         }
       };
+      params.update({ selectedSessionIds: [id] });
       this._selectSession(id, fitBounds);
     },
 

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -66,18 +66,16 @@ export const fixedSessions = (
     },
 
     deselectSession: function() {
-      var session = this.find(sessionsUtils.selectedSessionId());
+      var session = sessionsUtils.selectedSession(this);
       if (!session) return;
       session.loaded = false;
-      session.alreadySelected = false;
       params.update({ prevMapPosition: {} });
       params.update({ selectedSessionIds: [] });
       map.fitBounds(prevMapPosition.bounds, prevMapPosition.zoom);
     },
 
     selectSession: function(id) {
-      const session = this.find(id);
-      const fitBounds = () => {
+      const fitBounds = session => {
         if (!session.is_indoor) {
           prevMapPosition = {
             bounds: map.getBounds(),
@@ -98,18 +96,17 @@ export const fixedSessions = (
     },
 
     reSelectSession: function(id) {
-      const noop = () => {};
+      const noop = _ => {};
       this._selectSession(id, noop);
     },
 
     _selectSession: function(id, callback) {
-      var session = this.find(id);
-      if (!session || session.alreadySelected) return;
+      const session = sessionsUtils.selectedSession(this);
+      if (!session) return;
       var sensorId = sensors.selectedId();
       var sensor = sensors.sensors[sensorId] || {};
       var sensorName = sensor.sensor_name;
       if (!sensorName) return;
-      session.alreadySelected = true;
       $http
         .get("/api/realtime/sessions/" + id, {
           cache: true,

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -88,17 +88,16 @@ export const mobileSessions = (
     },
 
     deselectSession: function() {
-      const session = this.find(sessionsUtils.selectedSessionId());
+      const session = sessionsUtils.selectedSession(this);
       if (!session) return;
       session.loaded = false;
-      session.alreadySelected = false;
       params.update({ prevMapPosition: {} });
       params.update({ selectedSessionIds: [] });
       drawSession.undoDraw(session, prevMapPosition);
     },
 
     selectSession: function(id) {
-      const callback = (session, selectedSession) => data => {
+      const callback = session => data => {
         drawSession.clear(this.sessions);
         prevMapPosition = {
           bounds: map.getBounds(),
@@ -111,7 +110,7 @@ export const mobileSessions = (
         const draw = () =>
           drawSession.drawMobileSession(session, drawSessionStartingMarker);
         map.fitBoundsWithBottomPadding(
-          calculateBounds(sensors, selectedSession, map.getZoom())
+          calculateBounds(sensors, session, map.getZoom())
         );
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       };
@@ -211,19 +210,18 @@ export const mobileSessions = (
     },
 
     _selectSession: function(id, callback) {
-      var session = this.find(id);
-      if (!session || session.alreadySelected) return;
+      const session = sessionsUtils.selectedSession(this);
+      if (!session) return;
       var sensorId = sensors.selectedId();
       var sensor = sensors.sensors[sensorId] || {};
       var sensorName = sensor.sensor_name;
       if (!sensorName) return;
-      session.alreadySelected = true;
       $http
         .get("/api/mobile/sessions2/" + id, {
           cache: true,
           params: { sensor_name: sensorName }
         })
-        .success(callback(session, sessionsUtils.selectedSession(this)));
+        .success(callback(session));
     },
 
     fetch: function(values = {}) {

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -60,10 +60,6 @@ export const mobileSessions = (
       sessionsUtils.onSessionsFetchError(data);
     },
 
-    sessionsChanged: function(newIds, oldIds) {
-      sessionsUtils.sessionsChanged(this, newIds, oldIds);
-    },
-
     onSessionsFetch: function(fetchableSessionsCount) {
       if (!params.isCrowdMapOn()) {
         this.drawSessionsInLocation();
@@ -91,12 +87,13 @@ export const mobileSessions = (
       }
     },
 
-    deselectSession: function(id) {
-      const session = this.find(id);
+    deselectSession: function() {
+      const session = this.find(sessionsUtils.selectedSessionId());
       if (!session) return;
       session.loaded = false;
       session.alreadySelected = false;
       params.update({ prevMapPosition: {} });
+      params.update({ selectedSessionIds: [] });
       drawSession.undoDraw(session, prevMapPosition);
     },
 
@@ -118,6 +115,7 @@ export const mobileSessions = (
         );
         sessionsUtils.onSingleSessionFetch(session, data, draw);
       };
+      params.update({ selectedSessionIds: [id] });
       this._selectSession(id, callback);
     },
 

--- a/app/javascript/angular/code/services/_sessions_utils.js
+++ b/app/javascript/angular/code/services/_sessions_utils.js
@@ -57,7 +57,7 @@ export const sessionsUtils = (
   onSingleSessionFetchWithoutCrowdMap: function(session, data, callback) {
     createSessionData(session, data);
     session.loaded = true;
-    callback();
+    callback(session);
   },
   refreshMapView: function(sessions) {
     if (sessions.type === "MobileSessions") {

--- a/app/javascript/angular/code/services/_sessions_utils.js
+++ b/app/javascript/angular/code/services/_sessions_utils.js
@@ -8,17 +8,6 @@ export const sessionsUtils = (
   flash,
   updateCrowdMapLayer
 ) => ({
-  sessionsChanged: function(self, newIds, oldIds) {
-    _(newIds)
-      .chain()
-      .difference(oldIds)
-      .each(_(self.selectSession).bind(self));
-    _(oldIds)
-      .chain()
-      .difference(newIds)
-      .each(_(self.deselectSession).bind(self));
-  },
-
   get: function(self) {
     return _.uniq(self.sessions, "id");
   },

--- a/app/javascript/angular/tests/_fixed_sessions.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions.test.js
@@ -210,7 +210,7 @@ test("fetch passes map corner coordinates to sessionsDownloader", t => {
 
 test("selectSession with indoor session after successfully fetching calls map.fitBoundsWithBottomPadding", t => {
   const map = mock("fitBoundsWithBottomPadding");
-  const sessionsUtils = { find: () => ({ is_indoor: false }) };
+  const sessionsUtils = { selectedSession: () => ({ is_indoor: false }) };
   const sensors = { sensors: { 123: { sensor_name: "sensor_name" } } };
   const fixedSessionsService = _fixedSessions({ map, sessionsUtils, sensors });
 
@@ -223,7 +223,7 @@ test("selectSession with indoor session after successfully fetching calls map.fi
 
 test("selectSession with outdoor session after successfully fetching does not call map.fitBounds", t => {
   const map = mock("fitBounds");
-  const sessionsUtils = { find: () => ({ is_indoor: true }) };
+  const sessionsUtils = { selectedSession: () => ({ is_indoor: true }) };
   const sensors = { sensors: { 123: { sensor_name: "sensor_name" } } };
   const fixedSessionsService = _fixedSessions({ map, sessionsUtils, sensors });
 
@@ -236,7 +236,7 @@ test("selectSession with outdoor session after successfully fetching does not ca
 
 test("deselectSession with existing session calls fitBounds", t => {
   const map = mock("fitBounds");
-  const sessionsUtils = { find: () => ({ id: 1 }) };
+  const sessionsUtils = { selectedSession: () => ({ id: 1 }) };
   const fixedSessionsService = _fixedSessions({ map, sessionsUtils });
 
   fixedSessionsService.deselectSession(1);
@@ -248,7 +248,7 @@ test("deselectSession with existing session calls fitBounds", t => {
 
 test("deselectSession with non-existing session does not call drawSession.undoDraw", t => {
   const map = mock("fitBounds");
-  const sessionsUtils = { find: () => null };
+  const sessionsUtils = { selectedSession: () => null };
   const fixedSessionsService = _fixedSessions({ map, sessionsUtils });
 
   fixedSessionsService.deselectSession(1);
@@ -271,7 +271,7 @@ test("deselectSession calls fitBounds with the bounds saved before selecting the
     getZoom: () => zoom,
     ...mock("fitBounds")
   };
-  const sessionsUtils = { find: () => ({ id: 1 }) };
+  const sessionsUtils = { selectedSession: () => ({ id: 1 }) };
   const sensors = { sensors: { 1: { sensor_name: "sensor_name" } } };
   const fixedSessionsService = _fixedSessions({ map, sessionsUtils, sensors });
   fixedSessionsService.selectSession(1);
@@ -292,7 +292,7 @@ test("deselectSession with no previously selected sessions calls fitBounds with 
     west: -123.65885018980651
   };
   const zoom = 10;
-  const sessionsUtils = { find: () => ({ id: 1 }) };
+  const sessionsUtils = { selectedSession: () => ({ id: 1 }) };
   const mapPosition = { bounds, zoom };
   const map = {
     getBounds: () => bounds,
@@ -497,7 +497,8 @@ const _fixedSessions = ({
     find: () => ({}),
     onSingleSessionFetch: (x, y, callback) => callback(),
     get: self => self.sessions,
-    onSingleSessionFetchWithoutCrowdMap: (x, y, callback) => callback(),
+    onSingleSessionFetchWithoutCrowdMap: (session, y, callback) =>
+      callback(session),
     isSessionSelected: () => false,
     selectedSession: () => {},
     selectedSessionId: () => 1,

--- a/app/javascript/angular/tests/_fixed_sessions.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions.test.js
@@ -500,6 +500,7 @@ const _fixedSessions = ({
     onSingleSessionFetchWithoutCrowdMap: (x, y, callback) => callback(),
     isSessionSelected: () => false,
     selectedSession: () => {},
+    selectedSessionId: () => 1,
     ...sessionsUtils
   };
   const $http = { get: () => ({ success: callback => callback() }) };

--- a/app/javascript/angular/tests/_mobile_sessions.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions.test.js
@@ -253,7 +253,7 @@ test("selectSession after successfully fetching undraws all sessions", t => {
 test("selectSession after successfully fetching calls drawSession.drawMobileSession with selected session", t => {
   const drawSession = mock("drawMobileSession");
   const session = { id: 1 };
-  const sessionsUtils = { find: () => session };
+  const sessionsUtils = { selectedSession: () => session };
   const mobileSessionsService = _mobileSessions({
     drawSession,
     sensors,
@@ -329,7 +329,7 @@ test("reSelectSession after successfully fetching does not call map.fitBounds", 
 
 test("deselectSession with existing session calls drawSession.undoDraw", t => {
   const drawSession = mock("undoDraw");
-  const sessionsUtils = { find: () => ({ id: 1 }) };
+  const sessionsUtils = { selectedSession: () => ({ id: 1 }) };
   const mobileSessionsService = _mobileSessions({ drawSession, sessionsUtils });
 
   mobileSessionsService.deselectSession(1);
@@ -341,7 +341,7 @@ test("deselectSession with existing session calls drawSession.undoDraw", t => {
 
 test("deselectSession with non-existing session does not call drawSession.undoDraw", t => {
   const drawSession = mock("undoDraw");
-  const sessionsUtils = { find: () => null };
+  const sessionsUtils = { selectedSession: () => null };
   const mobileSessionsService = _mobileSessions({ drawSession, sessionsUtils });
 
   mobileSessionsService.deselectSession(1);
@@ -361,7 +361,7 @@ test("deselectSession calls drawSession.undoDraw with the position saved before 
   const zoom = 10;
   const map = { getBounds: () => bounds, getZoom: () => zoom };
   const drawSession = mock("undoDraw");
-  const sessionsUtils = { find: () => ({ id: 1 }) };
+  const sessionsUtils = { selectedSession: () => ({ id: 1 }) };
   const mobileSessionsService = _mobileSessions({
     drawSession,
     sessionsUtils,
@@ -386,7 +386,7 @@ test("deselectSession with no previously selected sessions calls drawSession.und
   };
   const zoom = 10;
   const drawSession = mock("undoDraw");
-  const sessionsUtils = { find: () => ({ id: 1 }) };
+  const sessionsUtils = { selectedSession: () => ({ id: 1 }) };
   const mapPosition = { bounds, zoom };
   const map = { getBounds: () => bounds, getZoom: () => zoom };
   const mobileSessionsService = _mobileSessions({
@@ -549,7 +549,7 @@ const _mobileSessions = ({
     find: () => ({}),
     onSingleSessionFetch: (x, y, callback) => callback(),
     isSessionSelected: () => false,
-    selectedSession: () => {},
+    selectedSession: () => ({}),
     selectedSessionId: () => 1,
     ...sessionsUtils
   };

--- a/app/javascript/angular/tests/_mobile_sessions.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions.test.js
@@ -550,6 +550,7 @@ const _mobileSessions = ({
     onSingleSessionFetch: (x, y, callback) => callback(),
     isSessionSelected: () => false,
     selectedSession: () => {},
+    selectedSessionId: () => 1,
     ...sessionsUtils
   };
   const $http = { get: () => ({ success: callback => callback() }) };


### PR DESCRIPTION
Just some refactor I need to understand my next ticket :)

Also, what do you think of changing `selectedSessionIds  :: List Int` to `selectedSessionId :: Int` in the params at some point? That would change our API, but we already have other breaking changes, so maybe we should add this as well before the big release?