### PR TITLE
feat(session-link): center map to selected session

### DIFF
--- a/app/controllers/measurement_sessions_controller.rb
+++ b/app/controllers/measurement_sessions_controller.rb
@@ -21,23 +21,11 @@ class MeasurementSessionsController < ApplicationController
 
   def show
     session = Session.find_by_url_token(params[:url_token]) or raise NotFound
-    lat = session.streams.first.min_latitude.to_f
-    lng = session.streams.first.min_longitude.to_f
-    stream = session.streams.first
 
-    map = { zoom:16, lat:lat, lng:lng }
     selected_session_ids = [session.id]
-    data = {
-      heat: { highest: stream.threshold_very_high,
-              high: stream.threshold_high,
-              mid: stream.threshold_medium,
-              low: stream.threshold_low,
-              lowest: stream.threshold_very_low },
-      usernames: session.user.username,
-      sensorId: stream.sensor_id
-    }
+    data = { sensorId: "Temperature-airbeam2-f (F)" }
 
-    anchor = "?data=#{data.to_json}&selectedSessionIds=#{selected_session_ids.to_json}&map=#{map.to_json}"
+    anchor = "?selectedSessionIds=#{selected_session_ids.to_json}&data=#{data.to_json}"
 
     if (session.type == "FixedSession")
       redirect_to fixed_map_path(:anchor => anchor)


### PR DESCRIPTION
In order to properly center the session, we need to delegate it to the frontend to use fit bounds. Thanks to the refactor in the other [PR](https://github.com/HabitatMap/AirCasting/pull/245) now a link with just session id and selected sensor id is sufficient to select a session.