### PR TITLE
Fetch sessions after moving the map to new location

### DIFF
--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -84,8 +84,13 @@ export const FixedSessionsMapCtrl = (
         $scope.sessions.fetch();
       });
 
-      elmApp.ports.findLocation.subscribe(location => {
-        FiltersUtils.findLocation(location, params, map);
+      elmApp.ports.goToLocation.subscribe(location => {
+        FiltersUtils.goToLocation({
+          location,
+          params,
+          map,
+          callback: () => $scope.sessions.fetch()
+        });
       });
 
       elmApp.ports.toggleIndoor.subscribe(isIndoor => {

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -110,8 +110,13 @@ export const MobileSessionsMapCtrl = (
         sessionsUtils.updateCrowdMapLayer($scope.sessions.allSessionIds());
       });
 
-      elmApp.ports.findLocation.subscribe(location => {
-        FiltersUtils.findLocation(location, params, map);
+      elmApp.ports.goToLocation.subscribe(location => {
+        FiltersUtils.goToLocation({
+          location,
+          params,
+          map,
+          callback: () => $scope.sessions.fetch()
+        });
       });
 
       map.onPanOrZoom(() => {

--- a/app/javascript/angular/code/services/google/_map.js
+++ b/app/javascript/angular/code/services/google/_map.js
@@ -68,7 +68,7 @@ export const map = (
       googleMaps.listenPanOrZoom(this.mapObj, callback);
     },
 
-    goToAddress: function(address) {
+    goToAddress: function(address, callback2) {
       if (!address) return;
 
       const callback = (results, status) => {
@@ -76,6 +76,7 @@ export const map = (
 
         const latLngBounds = results[0].geometry.viewport;
         this._fitBoundsWithoutPanOrZoomCallback(latLngBounds);
+        callback2();
       };
 
       geocoder.get(address, callback);

--- a/app/javascript/angular/tests/_map.test.js
+++ b/app/javascript/angular/tests/_map.test.js
@@ -43,7 +43,7 @@ test("goToAddress with successful geocoding calls fitBounds", t => {
   const googleMaps = mockGoogleMaps({ successfulGeocoding: true });
   const service = _map({ geocoder, googleMaps });
 
-  service.goToAddress("new york");
+  service.goToAddress("new york", () => {});
 
   t.true(googleMaps.wasCalled());
 
@@ -59,7 +59,7 @@ test("goToAddress when calling fitBounds removes callbacks from the map", t => {
 
   const service = _map({ geocoder, googleMaps });
 
-  service.goToAddress("new york");
+  service.goToAddress("new york", () => {});
 
   t.false(googleMaps.hasCallbacks());
 
@@ -73,7 +73,7 @@ test("goToAddress re-adds callbacks from the map after calling fitBounds", t => 
 
   const service = _map({ geocoder, googleMaps });
 
-  service.goToAddress("new york");
+  service.goToAddress("new york", () => {});
 
   setTimeout(() => {
     t.true(googleMaps.hasCallbacks());

--- a/app/javascript/angular/tests/filtersUtils.test.js
+++ b/app/javascript/angular/tests/filtersUtils.test.js
@@ -1,26 +1,26 @@
 import test from "blue-tape";
 import sinon from "sinon";
-import { findLocation, clearLocation } from "../../javascript/filtersUtils";
+import { goToLocation, clearLocation } from "../../javascript/filtersUtils";
 
-test("findLocation asks google maps to pan to the given location", t => {
+test("goToLocation asks google maps to pan to the given location", t => {
   const goToAddress = sinon.spy();
   const map = { goToAddress };
   const params = { update: () => {} };
   const location = "krakow";
 
-  findLocation(location, params, map);
+  goToLocation({ location, params, map });
 
   sinon.assert.calledWith(goToAddress, location);
 
   t.end();
 });
 
-test("findLocation adds the new location to the params", t => {
+test("goToLocation adds the new location to the params", t => {
   const update = sinon.spy();
   const map = { goToAddress: () => {} };
   const params = { update };
 
-  findLocation("krakow", params, map);
+  goToLocation({ location: "krakow", params, map });
 
   sinon.assert.calledWith(update, { data: { location: "krakow" } });
 

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -239,7 +239,7 @@ update msg model =
                 ( sudModel, subCmd ) =
                     deselectSession model
             in
-            ( sudModel, Cmd.batch [ subCmd, Ports.findLocation sudModel.location ] )
+            ( sudModel, Cmd.batch [ subCmd, Ports.goToLocation sudModel.location ] )
 
         TagsLabels subMsg ->
             let

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -2,7 +2,7 @@ port module Ports exposing
     ( drawFixed
     , drawMobile
     , fetchSessions
-    , findLocation
+    , goToLocation
     , graphRangeSelected
     , isShowingTimeRangeFilter
     , loadMoreSessions
@@ -48,7 +48,7 @@ port timeRangeSelected : (Encode.Value -> msg) -> Sub msg
 port locationCleared : (() -> msg) -> Sub msg
 
 
-port findLocation : String -> Cmd a
+port goToLocation : String -> Cmd a
 
 
 port showCopyLinkTooltip : String -> Cmd a

--- a/app/javascript/javascript/filtersUtils.js
+++ b/app/javascript/javascript/filtersUtils.js
@@ -148,9 +148,9 @@ const updateTooltipContent = (link, tooltip) => {
   });
 };
 
-export const findLocation = (location, params, map) => {
+export const goToLocation = ({ location, params, map, callback }) => {
   params.update({ data: { location: location } });
-  map.goToAddress(location);
+  map.goToAddress(location, callback);
 };
 
 export const clearLocation = (callback, params) => {


### PR DESCRIPTION
`$scope.sessions.fetch()` has to be passed in a callback to make sure it's executed after the map moves to the new location. 

I'm not sure I like that solution. It would be nice to have this in elm so we can have more control over the flow and just fetch session when needed, but I don't see that happening around google maps code 😕 