### PR TITLE
Aggregate columns not included in the GROUP BY clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,42 +113,6 @@ SET foreign_key_checks = 1; --Remember to enable foreign key checks when procedu
 
 ## Troubleshooting
 
-In case you encounter a similar error
-
-```
-Mysql2::Error: Expression #3 of SELECT list is not in GROUP BY clause and contains nonaggregated column ...
-```
-
-please check if any of these files
-
-- /etc/my.cnf
-- /etc/mysql/my.cnf
-- /usr/local/etc/my.cnf
-- ~/.my.cnf
-
-contain `sql_mode = "..."`. If that's the case, make sure to remove `ONLY_FULL_GROUP_BY` from the string. Otherwise, just add
-
-```
-sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
-```
-
-to any existing configuration file. If none exists just create `~/.my.cnf` as follows
-
-```
-[mysqld]
-sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
-```
-
-Note: If you installed mysql using a dmg file, you will have to create ~/.my.cnf according to the insturctions above, Even if some of the other files listed above contains `sql_mode = "..."` - this is just a left over from the previous instalations and will not be used by mysql installed by dmg.
-
-To double check the configuration works
-
-```bash
-bundle exec rails c
-ActiveRecord::Base.connection.execute("show variables like 'sql_mode'").to_a
-# the return value should not contain ONLY_FULL_GROUP_BY
-```
-
 ### Problems with mysql2 gem
 
 If you run into the error `libmysqlclient is missing` while installing mysql2 then run `brew install mysql-connector-c`.

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -148,8 +148,8 @@ class Stream < ApplicationRecord
   def self.sensors
     joins(:session).
       where("sessions.contribute" => true).
-      select("sensor_name, measurement_type, threshold_very_low, threshold_low, unit_symbol,
-           threshold_medium, threshold_high, threshold_very_high, count(*) as session_count").
+      select(:sensor_name, :measurement_type, "MIN(threshold_very_low) as threshold_very_low", "MIN(threshold_low) as threshold_low", :unit_symbol,
+           "MIN(threshold_medium) as threshold_medium", "MAX(threshold_high) as threshold_high", "MAX(threshold_very_high) as threshold_very_high", "count(*) as session_count").
       group(:sensor_name, :measurement_type, :unit_symbol).
       map { |stream| stream.attributes.symbolize_keys }
   end


### PR DESCRIPTION
We assume that for a given sensor_name, measurement_type and unit_symbol
all thresholds are the same, so it is ok to select a random value.