### PR TITLE
Remove old endpoint

### DIFF
--- a/app/controllers/api/measurement_sessions_controller.rb
+++ b/app/controllers/api/measurement_sessions_controller.rb
@@ -25,12 +25,6 @@ module Api
 
     respond_to :json
 
-    def show_multiple
-      data = decoded_query_data(params.to_unsafe_hash[:q])
-
-      respond_with sessions: MobileSession.selected_sessions_json(data)
-    end
-
     def create
       if ActiveModel::Type::Boolean.new.cast(params[:compression])
         decoded = Base64.decode64(params[:session])

--- a/app/controllers/api/realtime/sessions_controller.rb
+++ b/app/controllers/api/realtime/sessions_controller.rb
@@ -58,12 +58,6 @@ module Api
         respond_with response
       end
 
-      def show_multiple
-        data = decoded_query_data(params[:q])
-
-        respond_with sessions: FixedSession.selected_sessions_json(data)
-      end
-
       def create
         if params[:compression]
           decoded = Base64.decode64(params[:session])

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -192,6 +192,7 @@ export const fixedSessions = (
     },
 
     fetch: function(values = {}) {
+      if (sessionsUtils.isSessionSelected()) return;
       const limit = values.amount || 50;
       const offset = values.fetchedSessionsCount || 0;
 
@@ -203,8 +204,7 @@ export const fixedSessions = (
         time_from: data.timeFrom,
         time_to: data.timeTo,
         tags: data.tags,
-        usernames: data.usernames,
-        session_ids: params.selectedSessionIds()
+        usernames: data.usernames
       };
 
       if (data.isIndoor) {
@@ -230,19 +230,12 @@ export const fixedSessions = (
 
       drawSession.clear(this.sessions);
 
-      if (sessionsUtils.isSessionSelected()) {
-        this.downloadSessions("/api/realtime/multiple_sessions.json", reqData);
-      } else {
-        if (offset === 0) this.sessions = [];
+      if (offset === 0) this.sessions = [];
 
-        if (data.isStreaming) {
-          this.downloadSessions(
-            "/api/realtime/streaming_sessions.json",
-            reqData
-          );
-        } else {
-          this.downloadSessions("/api/fixed/dormant/sessions.json", reqData);
-        }
+      if (data.isStreaming) {
+        this.downloadSessions("/api/realtime/streaming_sessions.json", reqData);
+      } else {
+        this.downloadSessions("/api/fixed/dormant/sessions.json", reqData);
       }
     }
   };

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -230,6 +230,7 @@ export const mobileSessions = (
     },
 
     fetch: function(values = {}) {
+      if (sessionsUtils.isSessionSelected()) return;
       const limit = values.amount || 50;
       const offset = values.fetchedSessionsCount || 0;
 
@@ -240,8 +241,7 @@ export const mobileSessions = (
         time_from: data.timeFrom,
         time_to: data.timeTo,
         tags: data.tags,
-        usernames: data.usernames,
-        session_ids: params.selectedSessionIds()
+        usernames: data.usernames
       };
 
       _(reqData).extend({
@@ -263,27 +263,16 @@ export const mobileSessions = (
 
       drawSession.clear(this.sessions);
 
-      if (sessionsUtils.isSessionSelected()) {
-        sessionsDownloader(
-          "/api/multiple_sessions.json",
-          reqData,
-          this.sessions,
-          params,
-          _(this.onSessionsFetch).bind(this),
-          _(this.onSessionsFetchError).bind(this)
-        );
-      } else {
-        if (offset === 0) this.sessions = [];
+      if (offset === 0) this.sessions = [];
 
-        sessionsDownloader(
-          "/api/mobile/sessions.json",
-          reqData,
-          this.sessions,
-          params,
-          _(this.onSessionsFetchWithCrowdMapLayerUpdate).bind(this),
-          _(this.onSessionsFetchError).bind(this)
-        );
-      }
+      sessionsDownloader(
+        "/api/mobile/sessions.json",
+        reqData,
+        this.sessions,
+        params,
+        _(this.onSessionsFetchWithCrowdMapLayerUpdate).bind(this),
+        _(this.onSessionsFetchError).bind(this)
+      );
     }
   };
   return new MobileSessions();

--- a/app/javascript/angular/tests/_fixed_sessions.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions.test.js
@@ -6,36 +6,17 @@ import {
 } from "../code/services/_fixed_sessions";
 import sinon from "sinon";
 
-test("fetch with no sessions ids in params passes empty array to sessionsDownloader", t => {
+test("fetch with no sessions ids in params doesn't call sessionsDownloader", t => {
   const sessionsDownloaderCalls = [];
-  const data = buildData();
-  const sessionIds = [];
+  const sessionsUtils = { isSessionSelected: () => true };
   const fixedSessionsService = _fixedSessions({
     sessionsDownloaderCalls,
-    data,
-    sessionIds
+    sessionsUtils
   });
 
   fixedSessionsService.fetch();
 
-  t.deepEqual(sessionsDownloaderCalls[0].session_ids, sessionIds);
-
-  t.end();
-});
-
-test("fetch with sessions ids in params passes them to sessionsDownloader", t => {
-  const sessionsDownloaderCalls = [];
-  const data = buildData();
-  const sessionIds = [1, 2, 3];
-  const fixedSessionsService = _fixedSessions({
-    sessionsDownloaderCalls,
-    data,
-    sessionIds
-  });
-
-  fixedSessionsService.fetch();
-
-  t.deepEqual(sessionsDownloaderCalls[0].session_ids, sessionIds);
+  t.deepEqual(sessionsDownloaderCalls, []);
 
   t.end();
 });

--- a/app/javascript/angular/tests/_mobile_sessions.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions.test.js
@@ -4,36 +4,17 @@ import { mobileSessions } from "../code/services/_mobile_sessions";
 import * as Clusterer from "../../javascript/clusterer";
 import sinon from "sinon";
 
-test("fetch with no sessions ids in params passes empty array to sessionsDownloader", t => {
+test("fetch with no sessions ids in params doesn't call sessionsDownloader", t => {
   const sessionsDownloaderCalls = [];
-  const data = buildData();
-  const sessionIds = [];
+  const sessionsUtils = { isSessionSelected: () => true };
   const mobileSessionsService = _mobileSessions({
     sessionsDownloaderCalls,
-    data,
-    sessionIds
+    sessionsUtils
   });
 
   mobileSessionsService.fetch();
 
-  t.deepEqual(sessionsDownloaderCalls[0].session_ids, sessionIds);
-
-  t.end();
-});
-
-test("fetch with sessions ids in params passes them to sessionsDownloader", t => {
-  const sessionsDownloaderCalls = [];
-  const data = buildData();
-  const sessionIds = [1, 2, 3];
-  const mobileSessionsService = _mobileSessions({
-    sessionsDownloaderCalls,
-    data,
-    sessionIds
-  });
-
-  mobileSessionsService.fetch();
-
-  t.deepEqual(sessionsDownloaderCalls[0].session_ids, sessionIds);
+  t.deepEqual(sessionsDownloaderCalls, []);
 
   t.end();
 });

--- a/app/models/api/dormant_sessions.rb
+++ b/app/models/api/dormant_sessions.rb
@@ -14,7 +14,6 @@ module Api::DormantSessions
     required(:unit_symbol).filled(:str?)
     required(:tags)
     required(:usernames)
-    required(:session_ids).each(:str?)
     optional(:is_indoor).filled(:bool?)
     optional(:west).filled(:float?)
     optional(:east).filled(:float?)
@@ -34,7 +33,6 @@ module Api::DormantSessions
     attribute :unit_symbol, Types::Strict::String
     attribute :tags, Types::Strict::String
     attribute :usernames, Types::Strict::String
-    attribute :session_ids, Types::Strict::Array.of(Types::Coercible::Integer)
     attribute :is_indoor, Types::Bool.meta(omittable: true)
     attribute :west, Types::Coercible::Float.meta(omittable: true)
     attribute :east, Types::Coercible::Float.meta(omittable: true)

--- a/app/models/api/mobile_sessions.rb
+++ b/app/models/api/mobile_sessions.rb
@@ -14,7 +14,6 @@ module Api::MobileSessions
     required(:unit_symbol).filled(:str?)
     required(:tags)
     required(:usernames)
-    required(:session_ids).each(:str?)
     required(:west).filled(:float?)
     required(:east).filled(:float?)
     required(:south).filled(:float?)
@@ -33,7 +32,6 @@ module Api::MobileSessions
     attribute :unit_symbol, Types::Strict::String
     attribute :tags, Types::Strict::String
     attribute :usernames, Types::Strict::String
-    attribute :session_ids, Types::Strict::Array.of(Types::Coercible::Integer)
     attribute :west, Types::Coercible::Float
     attribute :east, Types::Coercible::Float
     attribute :south, Types::Coercible::Float

--- a/app/models/fixed_session.rb
+++ b/app/models/fixed_session.rb
@@ -38,15 +38,6 @@ class FixedSession < Session
     )
   end
 
-  def self.selected_sessions_json(data)
-    filter_sessions_ids_and_streams(data)
-    .with_user_and_streams
-    .as_json(
-      only: filtered_json_fields,
-      methods: [:username, :streams, :last_hour_average]
-    )
-  end
-
   def after_measurements_created
     update_end_time!
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -61,7 +61,7 @@ class Session < ApplicationRecord
 
   def self.filter_(data={})
     sessions = order("sessions.created_at DESC")
-    .where("contribute = true OR sessions.id in (?)", data[:session_ids])
+    .where(contribute: true)
     .joins(:user)
 
     tags = data[:tags].to_s.split(/[\s,]/)
@@ -122,15 +122,6 @@ class Session < ApplicationRecord
       (:time_from BETWEEN start_time_local AND end_time_local)",
       :time_from => time_from, :time_to => time_to)
       .local_minutes_range(Utils.minutes_of_day(time_from), Utils.minutes_of_day(time_to))
-  end
-
-  def self.selected_sessions_json(data)
-    where("id IN (?)", data[:session_ids])
-    .with_user_and_streams
-    .as_json(
-      only: filtered_json_fields,
-      methods: session_methods
-    )
   end
 
   def self.session_methods

--- a/app/services/api/to_mobile_sessions_array.rb
+++ b/app/services/api/to_mobile_sessions_array.rb
@@ -20,7 +20,8 @@ class Api::ToMobileSessionsArray
     sessions = MobileSession
     .offset(offset)
     .limit(limit)
-    .with_user_and_streams.filter_(data)
+    .with_user_and_streams
+    .filter_(data)
     .map do |session|
       {
         id: session.id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,8 +34,6 @@ Rails.application.routes.draw do
       end
     end
 
-    get 'multiple_sessions' =>'measurement_sessions#show_multiple'
-
     resources :averages, only: [:index]
     resources :thresholds, only: [:show], id: /.*/
     resources :regressions, only: [:create, :index, :destroy]
@@ -54,7 +52,6 @@ Rails.application.routes.draw do
     resources :sensors, only: [:index]
 
     namespace :realtime do
-      get 'multiple_sessions'   => 'sessions#show_multiple'
       get 'streaming_sessions'  => 'sessions#index_streaming'
       get 'sync_measurements'   => 'sessions#sync_measurements'
       resources :sessions, only: [:create, :show]

--- a/spec/controllers/api/measurement_sessions_controller_spec.rb
+++ b/spec/controllers/api/measurement_sessions_controller_spec.rb
@@ -52,20 +52,6 @@ describe Api::MeasurementSessionsController do
 
   before { sign_in user }
 
-  describe "GET 'show_multiple'" do
-    let(:session1) { FactoryBot.create(:mobile_session) }
-    let(:session2) { FactoryBot.create(:mobile_session) }
-
-    before do
-      get :show_multiple, params: { q: { session_ids: [session1.id, session2.id] } }, format: :json
-    end
-
-    it { expect(response.status).to eq 200 }
-    it 'returns multiple sessions' do
-      expect(response.body).to eq ({ sessions: MobileSession.selected_sessions_json(session_ids: [session1.id, session2.id]) }).to_json
-    end
-  end
-
   describe "POST 'create'" do
     let(:builder) { double }
     let(:data) { {type: "MobileSession"} }

--- a/spec/models/mobile_session_spec.rb
+++ b/spec/models/mobile_session_spec.rb
@@ -98,12 +98,6 @@ describe MobileSession do
       expect(MobileSession.filter_.to_a).to eq([session1])
     end
 
-    it 'should include explicitly requested but not contributed sessions' do
-      session =  create_session_with_streams_and_measurements!(id: 1, contribute: false)
-
-      expect(MobileSession.filter_(:session_ids => [1]).to_a).to eq([session])
-    end
-
     it "#filter includes sessions overlapping the time range" do
       now = Time.now
       plus_one_hour = (now + 1.hour)


### PR DESCRIPTION
Since single session view doesn't need to download the session list in the background anymore, we can remove this endpoint.