### PR TITLE
Fetch measurements for all streams for a given sensor name

### DIFF
--- a/app/javascript/elm/src/Data/GraphData.elm
+++ b/app/javascript/elm/src/Data/GraphData.elm
@@ -20,5 +20,5 @@ type alias GraphData =
         { start : Int
         , end : Int
         }
-    , streamId : Int
+    , streamIds : List Int
     }

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -4,7 +4,7 @@ module Data.SelectedSession exposing
     , fetch
     , times
     , toId
-    , toStreamId
+    , toStreamIds
     , updateRange
     , view
     )
@@ -33,7 +33,7 @@ type alias SelectedSession =
     , startTime : Posix
     , endTime : Posix
     , id : Int
-    , streamId : Int
+    , streamIds : List Int
     , selectedMeasurements : List Float
     }
 
@@ -43,9 +43,9 @@ times { startTime, endTime } =
     { start = Time.posixToMillis startTime, end = Time.posixToMillis endTime }
 
 
-toStreamId : SelectedSession -> Int
-toStreamId { streamId } =
-    streamId
+toStreamIds : SelectedSession -> List Int
+toStreamIds { streamIds } =
+    streamIds
 
 
 toId : SelectedSession -> Int
@@ -68,19 +68,19 @@ decoder =
         |> required "startTime" millisToPosixDecoder
         |> required "endTime" millisToPosixDecoder
         |> required "id" Decode.int
-        |> required "streamId" Decode.int
+        |> required "streamIds" (Decode.list Decode.int)
         |> hardcoded []
 
 
-toSelectedSession : String -> String -> String -> Posix -> Posix -> Int -> Int -> List Float -> SelectedSession
-toSelectedSession title username sensorName startTime endTime sessionId streamId selectedMeasurements =
+toSelectedSession : String -> String -> String -> Posix -> Posix -> Int -> List Int -> List Float -> SelectedSession
+toSelectedSession title username sensorName startTime endTime sessionId streamIds selectedMeasurements =
     { title = title
     , username = username
     , sensorName = sensorName
     , startTime = startTime
     , endTime = endTime
     , id = sessionId
-    , streamId = streamId
+    , streamIds = streamIds
     , selectedMeasurements = selectedMeasurements
     }
 

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -591,7 +591,7 @@ toGraphParams thresholds selectedSession sensors selectedSensorId =
     { sensor = { parameter = parameter, unit = unit }
     , heat = { threshold1 = threshold1, threshold5 = threshold5, levels = levels }
     , times = SelectedSession.times selectedSession
-    , streamId = SelectedSession.toStreamId selectedSession
+    , streamIds = SelectedSession.toStreamIds selectedSession
     }
 
 

--- a/app/javascript/elm/tests/TestUtils.elm
+++ b/app/javascript/elm/tests/TestUtils.elm
@@ -77,7 +77,7 @@ defaultSelectedSession =
     , startTime = Time.millisToPosix 0
     , endTime = Time.millisToPosix 0
     , id = 123
-    , streamId = 123
+    , streamIds = [ 123 ]
     , selectedMeasurements = []
     }
 

--- a/app/javascript/javascript/graph.js
+++ b/app/javascript/javascript/graph.js
@@ -15,21 +15,21 @@ export const fetchAndDrawFixed = showStatsCallback => ({
   sensor,
   heat,
   times,
-  streamId
+  streamIds
 }) => {
   // render empty graph with loading message
   drawFixed({
     measurements: [],
     sensor,
     heat,
-    afterSetExtremes: afterSetExtremes({ streamId, times })
+    afterSetExtremes: afterSetExtremes({ streamIds, times })
   });
 
   const pageStartTime = times.end - 24 * 60 * 60 * 1000;
 
   http
     .get("/api/measurements.json", {
-      stream_id: streamId,
+      stream_ids: streamIds,
       start_time: pageStartTime,
       end_time: times.end
     })
@@ -44,7 +44,7 @@ export const fetchAndDrawFixed = showStatsCallback => ({
         sensor,
         heat,
         afterSetExtremes: afterSetExtremes({
-          streamId,
+          streamIds,
           times,
           showStatsCallback
         })
@@ -56,14 +56,14 @@ export const fetchAndDrawMobile = showStatsCallback => ({
   sensor,
   heat,
   times,
-  streamId
+  streamIds
 }) => {
   // render empty graph with loading message
   drawMobile({ measurements: [], sensor, heat, showStatsCallback });
 
   http
     .get("/api/measurements.json", {
-      stream_id: streamId
+      stream_ids: streamIds
     })
     .then(measurements => {
       measurements = measurementsToTime(measurements);
@@ -94,12 +94,12 @@ const onMouseOverMultiple = (start, end) => {
   graphHighlight.show([points[pointNum]]);
 };
 
-const afterSetExtremes = ({ streamId, times, showStatsCallback }) => e => {
+const afterSetExtremes = ({ streamIds, times, showStatsCallback }) => e => {
   chart.showLoading("Loading data from server...");
 
   http
     .get("/api/measurements.json", {
-      stream_id: streamId,
+      stream_ids: streamIds,
       start_time: Math.round(e.min),
       end_time: Math.round(e.max)
     })

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -180,8 +180,8 @@ const setupHeatMap = () => {
   }
 };
 
-const draw = fnc => ({ times, streamId, heat, sensor }) =>
-  window.requestAnimationFrame(() => fnc({ sensor, heat, times, streamId }));
+const draw = fnc => ({ times, streamIds, heat, sensor }) =>
+  window.requestAnimationFrame(() => fnc({ sensor, heat, times, streamIds }));
 
 const toValues = noUiSlider => ({
   threshold1: noUiSlider.options.range.min,

--- a/app/models/api/measurements.rb
+++ b/app/models/api/measurements.rb
@@ -8,7 +8,7 @@ module Api::Measurements
 
   Schema =
     Dry::Validation.Schema do
-      required(:stream_id).filled(:str?)
+      required(:stream_ids).filled(:str?)
       optional(:start_time).filled(:str?)
       optional(:end_time).filled(:str?)
     end
@@ -16,7 +16,7 @@ module Api::Measurements
   class Struct < Dry::Struct
     transform_keys(&:to_sym)
 
-    attribute :stream_id, Types::Coercible::Integer
+    attribute :stream_ids, Types::Strict::String
     attribute :start_time, Types::Coercible::Integer.default(0)
     attribute :end_time, Types::Coercible::Integer.default(0)
   end

--- a/app/services/api/to_measurements_array.rb
+++ b/app/services/api/to_measurements_array.rb
@@ -21,13 +21,13 @@ class Api::ToMeasurementsArray
     start_time = Time.at(form.to_h[:start_time] / 1_000)
     end_time = Time.at(form.to_h[:end_time] / 1_000)
 
-    Measurement.with_streams(form.to_h[:stream_id]).where(
+    Measurement.with_streams(form.to_h[:stream_ids].split(',')).where(
       time: start_time..end_time
     )
   end
 
   def all
-    Measurement.with_streams(form.to_h[:stream_id])
+    Measurement.with_streams(form.to_h[:stream_ids])
   end
 
   def to_hash(measurement)

--- a/app/services/api/to_session_hash.rb
+++ b/app/services/api/to_session_hash.rb
@@ -19,7 +19,7 @@ class Api::ToSessionHash
       startTime: format_time(session.start_time_local),
       endTime: format_time(session.end_time_local),
       id: session.id,
-      streamId: session.streams.first.id
+      streamIds: session.streams.map(&:id)
     )
   end
 

--- a/spec/controllers/api/fixed/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/sessions_controller_spec.rb
@@ -29,7 +29,7 @@ describe Api::Fixed::SessionsController do
         'startTime' => 970_365_780_000,
         'endTime' => 1_004_850_360_000,
         'id' => session.id,
-        'streamId' => stream.id
+        'streamIds' => [stream.id]
       }
       expect(json_response).to eq(expected)
     end

--- a/spec/controllers/api/measurements_controller_spec.rb
+++ b/spec/controllers/api/measurements_controller_spec.rb
@@ -19,7 +19,7 @@ describe Api::MeasurementsController do
           time: time
         )
 
-        get :index, params: { stream_id: stream.id }
+        get :index, params: { stream_ids: "#{stream.id}" }
 
         expected = [
           {
@@ -69,7 +69,7 @@ describe Api::MeasurementsController do
 
         get :index,
             params: {
-              stream_id: stream.id,
+              stream_ids: "#{stream.id}",
               start_time: (time - 1).to_datetime.strftime('%Q').to_i,
               end_time: (time + 1).to_datetime.strftime('%Q').to_i
             }

--- a/spec/controllers/api/mobile/sessions_controller_spec.rb
+++ b/spec/controllers/api/mobile/sessions_controller_spec.rb
@@ -106,7 +106,7 @@ describe Api::Mobile::SessionsController do
         'startTime' => 970_365_780_000,
         'endTime' => 1_004_850_360_000,
         'id' => session.id,
-        'streamId' => stream.id
+        'streamIds' => [stream.id]
       }
       expect(json_response).to eq(expected)
     end


### PR DESCRIPTION
Sometimes a session has more than one stream with a given `sensor_name`. When `to_session_hash.rb` was just taking `session.streams.first` there was data missing from the graph for these sessions.