### PR TITLE
Check last measurement time individually for each stream

### DIFF
--- a/app/services/fixed_region_info.rb
+++ b/app/services/fixed_region_info.rb
@@ -1,42 +1,37 @@
 class FixedRegionInfo
   def call(data)
     streams_ids = streams_ids(data)
-    last_measurement_time = last_measurement_time(streams_ids)
 
      {
-      average: calculate_average(streams_ids, last_measurement_time).to_f,
+      average: calculate_average(streams_ids).to_f,
       number_of_contributors: number_of_contributors(streams_ids),
-      number_of_samples: number_of_samples(streams_ids, last_measurement_time),
+      number_of_samples: number_of_samples(streams_ids),
       number_of_instruments: streams_ids.count,
     }
   end
 
-   private
+  private
 
-   def streams_ids(data)
+  def streams_ids(data)
     Stream.
       select("id").
       where(sensor_name: data[:sensor_name], session_id: data[:session_ids])
   end
 
-   def last_measurement_time(streams_ids)
-    Measurement.with_streams(streams_ids).select("MAX(time) as last_time").first.last_time
+  def calculate_average(streams_ids)
+    streams_ids.reduce(0) do |acc, stream_id|
+      acc + one_hour_average(stream_id, end_time(stream_id))
+    end / streams_ids.length
   end
 
-   def calculate_average(streams_ids, end_time)
-    streams_ids
-    .map { |stream_id| one_hour_average(stream_id, end_time) }
-    .sum / streams_ids.size
-  end
-
-   def one_hour_average(stream_id, end_time)
+  def one_hour_average(stream_id, end_time)
     Measurement.
       with_streams(stream_id).
       where(time: (end_time - 1.hour)..end_time).
       average(:value) || 0
   end
 
-   def number_of_contributors(streams_ids)
+  def number_of_contributors(streams_ids)
     Measurement.
       with_streams(streams_ids).
       joins(:session).
@@ -44,10 +39,15 @@ class FixedRegionInfo
       count
   end
 
-   def number_of_samples(streams_ids, end_time)
-    Measurement.
-      with_streams(streams_ids).
-      where(time: (end_time - 1.hour)..end_time).
-      count
+  def number_of_samples(streams_ids)
+     streams_ids.reduce(0) do |acc, stream_id|
+      end_time = end_time(stream_id)
+
+      acc + Measurement.with_streams(stream_id).where(time: (end_time - 1.hour)..end_time).count
+    end
+  end
+
+  def end_time(stream_id)
+    Measurement.with_streams(stream_id).select("MAX(time) as last_time").first.last_time
   end
 end


### PR DESCRIPTION
Before this change, if the AirBeams were recording measurements with a different time zone some of them were not included in the last hour average and number of samples.
This created a bug where clusters marker had a different color than the average in the info window would suggest.