### PR TITLE
Crowd map fix group by query

### DIFF
--- a/lib/average_info.rb
+++ b/lib/average_info.rb
@@ -30,7 +30,7 @@ class AverageInfo
 
   def measurements
     @measurements ||=
-      Measurement.select(
+      Measurement.unscoped.select(
         'AVG(value) AS avg, ' +
           "ROUND(longitude / #{grid_x}, 0) AS middle_x, " +
           "ROUND(latitude / #{grid_y}, 0) AS middle_y "


### PR DESCRIPTION
Measurement has `default_scope { order('time ASC') }` which influences
every query on the model. We should move away from default scopes cause
they create this sort of problems. In other words, queries should be
explicit, the order should be used where necessary not in a
`default_scope`. This is just patching the problem for now

From what I can see this is the only query having this problem.