### PR TITLE
UI: Single session tweaks

### DIFF
--- a/app/assets/stylesheets/modules/action-buttons.css.scss
+++ b/app/assets/stylesheets/modules/action-buttons.css.scss
@@ -2,7 +2,6 @@
   @include flexbox();
   @include justify-content(space-between);
   @include align-items(center);
-  height: $action-container-height;
   width: 100%;
 }
 

--- a/app/assets/stylesheets/modules/buttons.css.scss
+++ b/app/assets/stylesheets/modules/buttons.css.scss
@@ -40,11 +40,3 @@
   background: transparent;
   border: none;
 }
-
-.close-button--session {
-  font-size: 32px;
-  line-height: 0;
-  position: absolute;
-  right: 10px;
-  top: 28px;
-}

--- a/app/assets/stylesheets/modules/buttons.css.scss
+++ b/app/assets/stylesheets/modules/buttons.css.scss
@@ -35,6 +35,7 @@
 
 .close-button {
   @include appearance(none);
+  cursor: pointer;
   font-weight: $font-stack-regular;
   background: transparent;
   border: none;

--- a/app/assets/stylesheets/modules/filters.css.scss
+++ b/app/assets/stylesheets/modules/filters.css.scss
@@ -9,14 +9,14 @@
   width: $filters-width;
 }
 
-.filters__div {
-  padding: 12px 12px $action-container-height 12px;
+.filters-container {
+  padding: 12px 12px 60px 12px; // bottom space holds action buttons
 }
 
 .filters__actions {
   bottom: 0;
   left: 0;
-  padding: 12px;
+  padding: 12px 12px 15px 12px;
   position: absolute;
 }
 

--- a/app/assets/stylesheets/modules/single-session.css.scss
+++ b/app/assets/stylesheets/modules/single-session.css.scss
@@ -99,10 +99,10 @@
 
 .single-session__close-button {
   font-size: 32px;
-  line-height: 0;
+  line-height: 1;
   position: absolute;
   right: 0;
-  top: 20px;
+  top: 5px;
 }
 
 .single-session__placeholder {

--- a/app/assets/stylesheets/modules/single-session.css.scss
+++ b/app/assets/stylesheets/modules/single-session.css.scss
@@ -97,6 +97,14 @@
   float: left;
 }
 
+.single-session__close-button {
+  font-size: 32px;
+  line-height: 0;
+  position: absolute;
+  right: 10px;
+  top: 28px;
+}
+
 .single-session__placeholder {
   height: 57px;
 }

--- a/app/assets/stylesheets/modules/single-session.css.scss
+++ b/app/assets/stylesheets/modules/single-session.css.scss
@@ -101,8 +101,8 @@
   font-size: 32px;
   line-height: 0;
   position: absolute;
-  right: 10px;
-  top: 28px;
+  right: 0;
+  top: 20px;
 }
 
 .single-session__placeholder {

--- a/app/assets/stylesheets/modules/single-session.css.scss
+++ b/app/assets/stylesheets/modules/single-session.css.scss
@@ -5,51 +5,63 @@
 }
 
 .single-session-container {
-  @include align-items(flex-start);
   @include flexbox();
   @include flex-direction(row);
-  @include justify-content(space-between);
   background-color: white;
   border-radius: $basic-radius;
   box-shadow: $lighter-shadow;
   margin: 0 auto $margin-default auto;
   overflow: hidden;
-  padding: 16px 16px 0 16px;
+  padding: 16px;
   position: relative;
   width: 95%;
 }
 
-.single-session-info {
-  flex: 0 0 228px;
+.single-session__aside {
+  display: flex;
   padding-right: 16px;
 }
 
-.single-session-graph {
+.single-session__graph {
   flex: 1;
+  height: 226px;
 }
 
-.single-session-name {
+.single-session__info {
+  @include flexbox();
+  flex-direction: column;
+  justify-content: space-between;
+  width: 215px;
+}
+
+.single-session__name {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   font-size: $medium-font;
+  max-height: 3em; // for browsers that don't support clamp, including Firefox <= 67 - still trims but with no ellipsis (...)
+  overflow: hidden;
+  word-break: break-word;
 }
 
-.single-session-username {
+.single-session__username {
   font-size: $small-font;
 }
 
-.single-session-max {
+.single-session__max {
   font-size: $tiny-font;
 }
 
-.single-session-avg {
+.single-session__avg {
   font-size: $medium-font;
 }
 
-.single-session-sensor {
+.single-session__sensor {
   font-size: $tiny-font;
   margin-bottom: 16px;
 }
 
-.single-session-date {
+.single-session__date {
   font-size: $tiny-font;
 }
 
@@ -59,11 +71,11 @@
   @include align-items(center);
 }
 
-.single-min-max-container {
+.session-min-max-container {
   padding: 6px 15px 6px 0;
 }
 
-.single-session-color {
+.single-session__color {
   min-width: 6px;
   min-height: 6px;
   max-width: 6px;
@@ -74,7 +86,7 @@
   float: left;
 }
 
-.single-session-avg-color {
+.single-session__avg-color {
   min-width: 9px;
   min-height: 9px;
   max-width: 9px;
@@ -85,6 +97,15 @@
   float: left;
 }
 
-.single-session-placeholder {
+.single-session__placeholder {
   height: 57px;
+}
+
+.highcharts-scrollbar-thumb {
+  cursor: pointer;
+}
+
+.highcharts-scrollbar-arrow,
+.highcharts-scrollbar-button {
+  cursor: pointer;
 }

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -112,47 +112,49 @@ view session heatMapThresholds linkIcon toMsg =
         tooltipId =
             "graph-copy-link-tooltip"
     in
-    div []
-        [ p [ class "single-session-name" ] [ text session.title ]
-        , p [ class "single-session-username" ] [ text session.username ]
-        , p [ class "single-session-sensor" ] [ text session.sensorName ]
-        , case session.selectedMeasurements of
-            [] ->
-                div [ class "single-session-placeholder" ] []
+    div [ class "single-session__info" ]
+        [ div []
+            [ p [ class "single-session__name" ] [ text session.title ]
+            , p [ class "single-session__username" ] [ text session.username ]
+            , p [ class "single-session__sensor" ] [ text session.sensorName ]
+            , case session.selectedMeasurements of
+                [] ->
+                    div [ class "single-session__placeholder" ] []
 
-            measurements ->
-                let
-                    min =
-                        List.minimum measurements |> Maybe.withDefault -1
+                measurements ->
+                    let
+                        min =
+                            List.minimum measurements |> Maybe.withDefault -1
 
-                    max =
-                        List.maximum measurements |> Maybe.withDefault -1
+                        max =
+                            List.maximum measurements |> Maybe.withDefault -1
 
-                    average =
-                        List.sum measurements / toFloat (List.length measurements)
-                in
-                div []
-                    [ div []
-                        [ div [ class "single-session-avg-color", class <| Data.Session.classByValue (Just average) heatMapThresholds ] []
-                        , span [] [ text "avg. " ]
-                        , span [ class "single-session-avg" ] [ text <| String.fromInt <| round average ]
-                        , span [] [ text <| " " ++ session.sensorUnit ]
-                        ]
-                    , div [ class "session-numbers-container" ]
-                        [ div [ class "single-min-max-container" ]
-                            [ div [ class "single-session-color", class <| Data.Session.classByValue (Just min) heatMapThresholds ] []
-                            , span [] [ text "min. " ]
-                            , span [ class "single-session-min" ] [ text <| String.fromFloat min ]
+                        average =
+                            List.sum measurements / toFloat (List.length measurements)
+                    in
+                    div []
+                        [ div []
+                            [ div [ class "single-session__avg-color", class <| Data.Session.classByValue (Just average) heatMapThresholds ] []
+                            , span [] [ text "avg. " ]
+                            , span [ class "single-session__avg" ] [ text <| String.fromInt <| round average ]
+                            , span [] [ text <| " " ++ session.sensorUnit ]
                             ]
-                        , div [ class "single-min-max-container" ]
-                            [ div [ class "single-session-color", class <| Data.Session.classByValue (Just max) heatMapThresholds ] []
-                            , span [] [ text "max. " ]
-                            , span [ class "single-session-max" ] [ text <| String.fromFloat max ]
+                        , div [ class "session-numbers-container" ]
+                            [ div [ class "session-min-max-container" ]
+                                [ div [ class "single-session__color", class <| Data.Session.classByValue (Just min) heatMapThresholds ] []
+                                , span [] [ text "min. " ]
+                                , span [ class "single-session__min" ] [ text <| String.fromFloat min ]
+                                ]
+                            , div [ class "session-min-max-container" ]
+                                [ div [ class "single-session__color", class <| Data.Session.classByValue (Just max) heatMapThresholds ] []
+                                , span [] [ text "max. " ]
+                                , span [ class "single-session__max" ] [ text <| String.fromFloat max ]
+                                ]
                             ]
                         ]
-                    ]
-        , span [ class "single-session-date" ] [ text <| Times.format session.startTime session.endTime ]
-        , div [ class "action-buttons " ]
+            , span [ class "single-session__date" ] [ text <| Times.format session.startTime session.endTime ]
+            ]
+        , div [ class "action-buttons" ]
             [ a [ class "button button--primary action-button action-button--export", target "_blank", href <| Api.exportLink [ session ] ] [ text "export session" ]
             , button [ class "button button--primary action-button action-button--copy-link", Events.onClick <| toMsg tooltipId, id tooltipId ] [ img [ src (Path.toString linkIcon), alt "Link icon" ] [] ]
             ]

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -797,7 +797,7 @@ viewSelectedSession heatMapThresholds maybeSession linkIcon =
             [ class "single-session__graph", id "graph-box" ]
             [ div [ id "graph" ] []
             ]
-        , button [ class "close-button close-button--session", Events.onClick DeselectSession ] [ text "×" ]
+        , button [ class "close-button single-session__close-button", Events.onClick DeselectSession ] [ text "×" ]
         ]
 
 

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -785,7 +785,7 @@ viewSessionsOrSelectedSession model =
 viewSelectedSession : WebData HeatMapThresholds -> Maybe SelectedSession -> Path -> Html Msg
 viewSelectedSession heatMapThresholds maybeSession linkIcon =
     div [ class "single-session-container" ]
-        [ div [ class "single-session-info" ]
+        [ div [ class "single-session__aside" ]
             (case maybeSession of
                 Nothing ->
                     [ text "loading" ]
@@ -794,7 +794,7 @@ viewSelectedSession heatMapThresholds maybeSession linkIcon =
                     [ SelectedSession.view session heatMapThresholds linkIcon ShowCopyLinkTooltip ]
             )
         , div
-            [ class "single-session-graph", id "graph-box" ]
+            [ class "single-session__graph", id "graph-box" ]
             [ div [ id "graph" ] []
             ]
         , button [ class "close-button close-button--session", Events.onClick DeselectSession ] [ text "×" ]
@@ -915,7 +915,7 @@ viewFilters model =
 
 viewMobileFilters : Model -> Html Msg
 viewMobileFilters model =
-    div [ class "filters__div" ]
+    div [ class "filters-container" ]
         [ viewParameterFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewSensorFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewLocationFilter model.location model.isIndoor model.tooltipIcon
@@ -928,7 +928,7 @@ viewMobileFilters model =
 
 viewFixedFilters : Model -> Html Msg
 viewFixedFilters model =
-    div [ class "filters__div" ]
+    div [ class "filters-container" ]
         [ viewParameterFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewSensorFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewLocationFilter model.location model.isIndoor model.tooltipIcon

--- a/app/javascript/javascript/buildGraphOptions.js
+++ b/app/javascript/javascript/buildGraphOptions.js
@@ -24,7 +24,7 @@ const navigator = {
 };
 
 const buildRangeSelector = ({ buttons, selected }) => ({
-  height: 30,
+  height: 32,
   buttonSpacing: 15,
 
   buttonTheme: {
@@ -214,7 +214,7 @@ const buildTooltip = ({
 
 const credits = {
   enabled: true,
-  position: { align: "right", verticalAlign: "top", x: -4, y: 40 }
+  position: { align: "right", verticalAlign: "top", x: -4, y: 32 }
 };
 
 export const buildOptions = ({

--- a/app/javascript/javascript/buildGraphOptions.js
+++ b/app/javascript/javascript/buildGraphOptions.js
@@ -2,7 +2,7 @@ import Highcharts from "highcharts/highstock";
 
 const buildChart = ({ renderTo }) => ({
   renderTo,
-  height: 200,
+  height: 230,
   spacingTop: 5,
   spacingBottom: 5,
   spacingRight: 0,
@@ -24,7 +24,7 @@ const navigator = {
 };
 
 const buildRangeSelector = ({ buttons, selected }) => ({
-  height: 40,
+  height: 30,
   buttonSpacing: 15,
 
   buttonTheme: {
@@ -45,9 +45,9 @@ const buildRangeSelector = ({ buttons, selected }) => ({
 
     states: {
       hover: {
-        fill: "none",
+        fill: "#09a7f0",
         style: {
-          color: "#000"
+          color: "white"
         }
       },
 
@@ -108,7 +108,7 @@ const scrollbarOptions = {
   buttonBackgroundColor: "#eee",
   buttonBorderWidth: 0,
   buttonBorderRadius: 7,
-  height: 15,
+  height: 10,
   rifleColor: "#D5D4D4",
   trackBackgroundColor: "none",
   trackBorderWidth: 0


### PR DESCRIPTION
- remove excessive whitespace below zoom buttons
- change hover state of zoom button to blue - before when hovering on
  active element it became white which was counterintuitive because
clicking on it doesn't turn it off
- slimmer scrollbar
- pointer cursor on scroll thumb and arrows
- clip session names to two lines
- restructure html to improve the flex layout, align columns
- rename classes using bem-style
- align the button of thescrollbar with the bottom ofaction buttons
- fix credits position after changes
- move close button away from credits so that users don't mistakenly click the credits when they want to close the session and vice versa
- fix close button broken in Safari

One requested change wasn't possible to fix: making the whole area of zoom buttons clickable.
I submitted an issue with Highcharts: https://github.com/highcharts/highcharts/issues/10986

Before - one line name:

![Screenshot 2019-06-13 at 15 09 09](https://user-images.githubusercontent.com/457999/59436038-27721980-8def-11e9-99a8-164119fe9f34.png)

Before - three line name:

![Screenshot 2019-06-13 at 16 12 45](https://user-images.githubusercontent.com/457999/59439768-209ad500-8df6-11e9-84e1-de66c3ed91a1.png)

After - one line name:

![Screenshot 2019-06-13 at 16 13 46](https://user-images.githubusercontent.com/457999/59439873-4d4eec80-8df6-11e9-870c-3beab24e38fb.png)

After - three line name (Chrome, webkit):

![Screenshot 2019-06-13 at 16 10 28](https://user-images.githubusercontent.com/457999/59439650-f1846380-8df5-11e9-80b6-37f3e6dbf14f.png)

After - threee line name (FF 67 - in 68 line-clip will work):

![Screenshot 2019-06-13 at 16 10 38](https://user-images.githubusercontent.com/457999/59439717-0a8d1480-8df6-11e9-9c69-3ed35411f1fc.png)





