### PR TITLE
Preserve the scroll position

### DIFF
--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -120,6 +120,11 @@ export const SessionsListCtrl = (
 
         pulsatingSessionMarker = map.drawPulsatingMarker(location);
       });
+
+      elmApp.ports.saveScrollPosition.subscribe(value => {
+        params.update({ scroll: value });
+        $scope.$apply();
+      });
     });
   }
 };

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -119,6 +119,7 @@ type alias Flags =
     , tooltipIcon : String
     , heatMapThresholdValues : Maybe HeatMapThresholdValues
     , isSearchAsIMoveOn : Bool
+    , scrollPosition : Float
     }
 
 
@@ -161,6 +162,7 @@ init flags url key =
                 |> Maybe.withDefault defaultModel.heatMapThresholds
         , isSearchAsIMoveOn = flags.isSearchAsIMoveOn
         , overlay = Overlay.init flags.isIndoor
+        , scrollPosition = flags.scrollPosition
       }
     , Cmd.batch
         [ fetchSelectedSession sensors flags.selectedSessionId flags.selectedSensorId page
@@ -448,7 +450,7 @@ update msg model =
                     ( model, Cmd.none )
 
         SaveScrollPosition position ->
-            ( { model | scrollPosition = position }, Cmd.none )
+            ( { model | scrollPosition = position }, Ports.saveScrollPosition position )
 
         GotSession response ->
             case ( model.heatMapThresholds, response ) of

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -8,11 +8,13 @@ port module Ports exposing
     , loadMoreSessions
     , locationCleared
     , mapMoved
+    , observeSessionsList
     , profileSelected
     , pulseSessionMarker
     , refreshTimeRange
     , saveScrollPosition
     , selectSensorId
+    , setScroll
     , showCopyLinkTooltip
     , tagSelected
     , timeRangeSelected
@@ -125,3 +127,9 @@ port isShowingTimeRangeFilter : (Bool -> msg) -> Sub msg
 
 
 port saveScrollPosition : Float -> Cmd a
+
+
+port setScroll : (() -> msg) -> Sub msg
+
+
+port observeSessionsList : () -> Cmd a

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -11,6 +11,7 @@ port module Ports exposing
     , profileSelected
     , pulseSessionMarker
     , refreshTimeRange
+    , saveScrollPosition
     , selectSensorId
     , showCopyLinkTooltip
     , tagSelected
@@ -121,3 +122,6 @@ port graphRangeSelected : (List Float -> msg) -> Sub msg
 
 
 port isShowingTimeRangeFilter : (Bool -> msg) -> Sub msg
+
+
+port saveScrollPosition : Float -> Cmd a

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -761,19 +761,6 @@ updateTests =
                     |> update DeselectSession
                     |> Tuple.first
                     |> Expect.equal expected
-        , fuzz int "DeselectSession tells javascript what to deselect" <|
-            \id ->
-                let
-                    model =
-                        { defaultModel | selectedSession = Success <| { defaultSelectedSession | id = id } }
-
-                    expected =
-                        Ports.toggleSession { deselected = Just id, selected = Nothing }
-                in
-                model
-                    |> update DeselectSession
-                    |> Tuple.second
-                    |> Expect.equal expected
         , fuzz int "with Nothing ToggleSessionSelectionFromAngular deselects the selected id" <|
             \id ->
                 let

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -94,7 +94,8 @@ document.addEventListener("DOMContentLoaded", () => {
         tooltipIcon,
         heatMapThresholdValues,
         isStreaming: data.isStreaming,
-        isSearchAsIMoveOn: data.isSearchAsIMoveOn
+        isSearchAsIMoveOn: data.isSearchAsIMoveOn,
+        scrollPosition: params.scroll || 0
       };
 
       console.warn(flags);

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -182,6 +182,15 @@ const setupHeatMap = () => {
     window.__elmApp.ports.drawMobile.subscribe(
       draw(graph.fetchAndDrawMobile(callback))
     );
+
+    window.__elmApp.ports.observeSessionsList.subscribe(() => {
+      createObserver({
+        selector: ".sessions-container",
+        onMount: () => {
+          window.__elmApp.ports.setScroll.send(null);
+        }
+      });
+    });
   }
 };
 


### PR DESCRIPTION
When deselecting a session, the sessions list preserves the scroll position. 
This also works for links saved with a selected session. However, I had to use ports and rely on the mutation observer to make sure that the `setScrollPosition` is executed after the sessions list already loaded. I'm not sure if there's a simpler solution.