### PR TITLE
Remove watch on session list

### DIFF
--- a/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/_sessions_list_ctrl.js
@@ -4,9 +4,7 @@ import { formatSessionForList } from "../../../javascript/values/session";
 export const SessionsListCtrl = (
   $scope,
   params,
-  sensors,
   $window,
-  drawSession,
   sessionsUtils,
   map
 ) => {
@@ -17,9 +15,7 @@ export const SessionsListCtrl = (
   $scope.setDefaults = function() {
     $scope.params = params;
     $scope.$window = $window;
-    $scope.sensors = sensors;
     $window.sessions = sessions = $scope.sessions;
-    $scope.sessionsForList = [];
 
     if (sessionsUtils.isSessionSelected())
       sessions.reSelectSession(sessionsUtils.selectedSessionId());
@@ -48,26 +44,6 @@ export const SessionsListCtrl = (
       }
 
       sessions.fetch();
-    },
-    true
-  );
-
-  $scope.newSessionsForList = function() {
-    return $scope.sessions
-      .get()
-      .map(selectedStream(sensors.selectedSensorName()))
-      .map(formatSessionForList);
-  };
-
-  $scope.$watch(
-    "newSessionsForList()",
-    function(newSessions, oldSessions) {
-      console.log("newSessionsForList()", newSessions, oldSessions);
-      $scope.sessionsForList = newSessions;
-      elmApp.ports.updateSessions.send({
-        fetched: newSessions.map(formatSessionForElm),
-        fetchableSessionsCount: $scope.sessions.fetchableSessionsCount
-      });
     },
     true
   );
@@ -145,24 +121,5 @@ export const SessionsListCtrl = (
         pulsatingSessionMarker = map.drawPulsatingMarker(location);
       });
     });
-  }
-};
-
-const selectedStream = sensorName => session => ({
-  ...session,
-  selectedStream: session.streams[sensorName]
-});
-
-const formatSessionForElm = s => ({
-  ...s,
-  shortTypes: s.shortTypes.map(({ name, type }) => ({ name, type_: type })),
-  average: nullOrValue(s.average)
-});
-
-const nullOrValue = value => {
-  if (value === undefined) {
-    return null;
-  } else {
-    return value;
   }
 };

--- a/app/javascript/angular/code/controllers/sessions_list_ctrl.js
+++ b/app/javascript/angular/code/controllers/sessions_list_ctrl.js
@@ -5,9 +5,7 @@ angular
   .controller("SessionsListCtrl", [
     "$scope",
     "params",
-    "sensors",
     "$window",
-    "drawSession",
     "sessionsUtils",
     "map",
     SessionsListCtrl

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -4,6 +4,7 @@ import * as Session from "../../../javascript/values/session";
 import { calculateBounds } from "../../../javascript/calculateBounds";
 import { prepareSessionData } from "./_sessions_utils";
 import { clearMap } from "../../../javascript/mapsUtils";
+import { sessionsInfoForElm } from "../../../javascript/sessionListUtils";
 
 export const fixedSessions = (
   params,
@@ -50,6 +51,14 @@ export const fixedSessions = (
     },
 
     onSessionsFetch: function(fetchableSessionsCount) {
+      $window.__elmApp.ports.updateSessions.send(
+        sessionsInfoForElm(
+          this.sessions,
+          fetchableSessionsCount || this.fetchableSessionsCount,
+          sensors.selectedSensorName()
+        )
+      );
+
       this.drawSessionsInLocation();
       if (fetchableSessionsCount) {
         this.fetchableSessionsCount = fetchableSessionsCount;

--- a/app/javascript/angular/code/services/_mobile_sessions.js
+++ b/app/javascript/angular/code/services/_mobile_sessions.js
@@ -4,6 +4,7 @@ import { clusterer } from "../../../javascript/clusterer";
 import { calculateBounds } from "../../../javascript/calculateBounds";
 import { prepareSessionData } from "./_sessions_utils";
 import { clearMap } from "../../../javascript/mapsUtils";
+import { sessionsInfoForElm } from "../../../javascript/sessionListUtils";
 
 export const mobileSessions = (
   params,
@@ -68,6 +69,14 @@ export const mobileSessions = (
     },
 
     onSessionsFetchWithCrowdMapLayerUpdate: function(fetchableSessionsCount) {
+      $window.__elmApp.ports.updateSessions.send(
+        sessionsInfoForElm(
+          this.sessions,
+          fetchableSessionsCount || this.fetchableSessionsCount,
+          sensors.selectedSensorName()
+        )
+      );
+
       this.onSessionsFetch(fetchableSessionsCount);
       sessionsUtils.updateCrowdMapLayer(this.sessionIds());
     },

--- a/app/javascript/angular/tests/_sessions_list_ctrl.test.js
+++ b/app/javascript/angular/tests/_sessions_list_ctrl.test.js
@@ -74,13 +74,5 @@ const _SessionsListCtrl = ({
   };
   const _sessionsUtils = { isSessionSelected: () => false };
 
-  return SessionsListCtrl(
-    _$scope,
-    _params,
-    null,
-    {},
-    null,
-    _sessionsUtils,
-    _map
-  );
+  return SessionsListCtrl(_$scope, _params, {}, _sessionsUtils, _map);
 };

--- a/app/javascript/javascript/sessionListUtils.js
+++ b/app/javascript/javascript/sessionListUtils.js
@@ -1,0 +1,28 @@
+import { formatSessionForList } from "./values/session";
+
+export const sessionsInfoForElm = (sessions, count, sensorName) => ({
+  fetched: sessions
+    .map(selectedStream(sensorName))
+    .map(formatSessionForList)
+    .map(formatSessionForElm),
+  fetchableSessionsCount: count
+});
+
+const selectedStream = sensorName => session => ({
+  ...session,
+  selectedStream: session.streams[sensorName]
+});
+
+const formatSessionForElm = s => ({
+  ...s,
+  shortTypes: s.shortTypes.map(({ name, type }) => ({ name, type_: type })),
+  average: nullOrValue(s.average)
+});
+
+const nullOrValue = value => {
+  if (value === undefined) {
+    return null;
+  } else {
+    return value;
+  }
+};


### PR DESCRIPTION
This watch was triggered in some cases that were like when we fetch sessions sometimes we first set our old list of sessions to [] (the watch is triggered once) and then we push newly fetched sessions to this empty list (watch is triggered again). This was messing with my logic to preserve scroll position and we had to remove this watch anyway at some point.