### PR TITLE
Fix grey markers on first load

### DIFF
--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -43,7 +43,14 @@ export const FixedSessionsMapCtrl = (
       tags: "",
       usernames: "",
       timeFrom: FiltersUtils.oneYearAgo(),
-      timeTo: FiltersUtils.endOfToday()
+      timeTo: FiltersUtils.endOfToday(),
+      heat: {
+        lowest: 0,
+        low: 12,
+        mid: 35,
+        high: 55,
+        highest: 150
+      }
     };
 
     params.updateFromDefaults(defaults);

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -53,7 +53,14 @@ export const MobileSessionsMapCtrl = (
       gridResolution: 31,
       crowdMap: false,
       timeFrom: oneYearAgo,
-      timeTo: endOfToday
+      timeTo: endOfToday,
+      heat: {
+        lowest: 0,
+        low: 12,
+        mid: 35,
+        high: 55,
+        highest: 150
+      }
     };
 
     params.updateFromDefaults(defaults);

--- a/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
@@ -28,7 +28,14 @@ test("it updates defaults", t => {
     timeTo: moment()
       .utc()
       .endOf("day")
-      .format("X")
+      .format("X"),
+    heat: {
+      lowest: 0,
+      low: 12,
+      mid: 35,
+      high: 55,
+      highest: 150
+    }
   };
   t.deepEqual(defaults, expected);
 

--- a/app/javascript/angular/tests/_mobile_sessions_map_ctrl.test.js
+++ b/app/javascript/angular/tests/_mobile_sessions_map_ctrl.test.js
@@ -28,7 +28,14 @@ test("it updates defaults", t => {
     timeTo: moment()
       .utc()
       .endOf("day")
-      .format("X")
+      .format("X"),
+    heat: {
+      lowest: 0,
+      low: 12,
+      mid: 35,
+      high: 55,
+      highest: 150
+    }
   };
   t.deepEqual(defaults, expected);
 


### PR DESCRIPTION
Adds default heat levels to params. The values I put are the levels for `sensorId: "Particulate Matter-airbeam2-pm2.5 (µg/m³)"`. 
This is just a hotfix, we should revisit and refactor this in the next iteration. I created a ticket: https://llp.kanbanery.com/projects/8040/board/tasks/2415146