### PR TITLE
Only show scroll on hover

### DIFF
--- a/app/assets/stylesheets/config/variables.css.scss
+++ b/app/assets/stylesheets/config/variables.css.scss
@@ -44,6 +44,7 @@ $heatmap-height: 65px;
 $logo-width: 110px;
 $sessions-list-width: 238px;
 $action-container-height: 60px;
+$scrollbar-height: 15px;
 
 // spacing
 $input-padding: 7px;

--- a/app/assets/stylesheets/modules/sessions.css.scss
+++ b/app/assets/stylesheets/modules/sessions.css.scss
@@ -2,7 +2,12 @@
   @include flexbox();
   @include flex-direction(row);
   width: calc(100vw - #{$filters-width});
+  overflow-x: hidden;
+  padding-bottom: $scrollbar-height;
+}
+.sessions-container:hover {
   overflow-x: scroll;
+  padding-bottom: 0;
 }
 
 .sessions {


### PR DESCRIPTION
Otherwise, google maps attribution is permanently obscured.