### PR TITLE
Fix misshaped dots in session list

### DIFF
--- a/app/assets/stylesheets/modules/sessions.css.scss
+++ b/app/assets/stylesheets/modules/sessions.css.scss
@@ -56,13 +56,6 @@
   padding: 0 24px 0 18px;
 }
 
-.session-header-container {
-  @include flexbox();
-  @include flex-direction(row);
-  @include justify-content(flex-start);
-  @include align-items(flex-start);
-}
-
 .sessions-header {
   display: inline-block;
   font-size: $medium-font;

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -994,15 +994,13 @@ viewSessionCard heatMapThresholds session =
         , Events.onMouseEnter <| HighlightSessionMarker (Just session.location)
         , Events.onMouseLeave <| HighlightSessionMarker Nothing
         ]
-        [ div [ class "session-header-container" ]
-            [ div
-                [ class "session-color"
-                , class <| Data.Session.classByValue session.average heatMapThresholds
-                ]
-                []
-            , h3 [ class "session-name" ]
-                [ text session.title ]
+        [ div
+            [ class "session-color"
+            , class <| Data.Session.classByValue session.average heatMapThresholds
             ]
+            []
+        , h3 [ class "session-name" ]
+            [ text session.title ]
         , p [ class "session-owner" ]
             [ text session.username ]
         , span [ class "session-dates" ]


### PR DESCRIPTION
Fixes misshaped dots in the session list cards and simplifies the HTML structure.

This was the problem:

![Screen_Shot_2019-06-25_at_10 18 07_AM](https://user-images.githubusercontent.com/457999/60201755-56ee4080-9849-11e9-8e4a-75e9cefe51ef.png)
