### PR TITLE
Use custom markers to draw selected session measurements

### DIFF
--- a/app/assets/images/location_marker.svg
+++ b/app/assets/images/location_marker.svg
@@ -1,3 +1,0 @@
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="8" cy="8" r="8" fill="#09a8f0"/>
-</svg>

--- a/app/assets/images/location_marker0.svg
+++ b/app/assets/images/location_marker0.svg
@@ -1,3 +1,0 @@
-<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="6" cy="6" r="6" fill="##a0a2ad"/>
-</svg>

--- a/app/assets/images/location_marker1.svg
+++ b/app/assets/images/location_marker1.svg
@@ -1,3 +1,0 @@
-<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="6" cy="6" r="6" fill="#96d788"/>
-</svg>

--- a/app/assets/images/location_marker2.svg
+++ b/app/assets/images/location_marker2.svg
@@ -1,3 +1,0 @@
-<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="6" cy="6" r="6" fill="#ffd960"/>
-</svg>

--- a/app/assets/images/location_marker3.svg
+++ b/app/assets/images/location_marker3.svg
@@ -1,3 +1,0 @@
-<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="6" cy="6" r="6" fill="#fca443"/>
-</svg>

--- a/app/assets/images/location_marker4.svg
+++ b/app/assets/images/location_marker4.svg
@@ -1,3 +1,0 @@
-<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="6" cy="6" r="6" fill="#e95f5f"/>
-</svg>

--- a/app/assets/stylesheets/modules/markers.css.scss
+++ b/app/assets/stylesheets/modules/markers.css.scss
@@ -8,6 +8,7 @@
   top: -6px;
   color: transparent;
   cursor: pointer;
+  z-index: -2;
 
   &.trace {
     background-color: $blue;
@@ -15,6 +16,7 @@
     height: 16px;
     left: -8px;
     top: -8px;
+    z-index: 1;
   }
 
   &.default {

--- a/app/javascript/angular/code/services/_draw_session.js
+++ b/app/javascript/angular/code/services/_draw_session.js
@@ -3,13 +3,6 @@ import * as assets from "../../../assets";
 import { drawNotes } from "../../../javascript/note";
 import * as Session from "../../../javascript/values/session";
 
-const locationMarkersByLevel = {
-  1: assets.locationMarker1Path,
-  2: assets.locationMarker2Path,
-  3: assets.locationMarker3Path,
-  4: assets.locationMarker4Path
-};
-
 export const drawSession = (sensors, map, heat, empty) => {
   var DrawSession = function() {};
 
@@ -27,14 +20,8 @@ export const drawSession = (sensors, map, heat, empty) => {
       var suffix = " " + sensors.anySelected().unit_symbol;
       var points = [];
 
-      this.measurements(session).forEach(function(measurement, idx) {
-        const marker = createMeasurementMarker(
-          measurement,
-          idx,
-          heat,
-          map,
-          suffix
-        );
+      this.measurements(session).forEach(function(measurement) {
+        const marker = createMeasurementMarker(measurement, heat, map, suffix);
 
         points.push(measurement);
       });
@@ -70,23 +57,21 @@ export const drawSession = (sensors, map, heat, empty) => {
   return new DrawSession();
 };
 
-const calculateHeatLevel = (heat, value) => heat.getLevel(value);
+const calculateHeatLevel = (heat, value) => heat.levelName(value);
 
-const createMeasurementMarker = (measurement, idx, heat, map, suffix) => {
+const createMeasurementMarker = (measurement, heat, map, suffix) => {
   const roundedValue = Math.round(measurement.value);
   if (heat.outsideOfScope(roundedValue)) return;
 
   const level = calculateHeatLevel(heat, roundedValue);
+  const latLng = {
+    lat: () => measurement.latitude,
+    lng: () => measurement.longitude
+  };
 
-  const marker = map.drawMarker({
-    position: { lat: measurement.latitude, lng: measurement.longitude },
-    title: roundedValue.toString() + suffix,
-    zIndex: idx,
-    icon: {
-      anchor: new google.maps.Point(6, 6),
-      size: new google.maps.Size(12, 12),
-      url: locationMarkersByLevel[level]
-    }
+  const marker = map.drawMarkerWithoutLabel({
+    object: { latLng, title: roundedValue.toString() + suffix },
+    colorClass: level
   });
 
   return marker;

--- a/app/javascript/angular/code/services/google/custom_marker.js
+++ b/app/javascript/angular/code/services/google/custom_marker.js
@@ -18,6 +18,7 @@ export function buildCustomMarker({
     marker.classList.add(type);
     marker.classList.add(colorClass);
     marker.innerText = content;
+    marker.title = object.title || "";
     marker.addEventListener("click", callback);
 
     this.markerContainer = document.createElement("div");

--- a/app/javascript/assets.js
+++ b/app/javascript/assets.js
@@ -1,28 +1,3 @@
-export const locationMarker1Path =
-  process.env.NODE_ENV === "test"
-    ? ""
-    : require("../assets/images/location_marker1.svg");
-
-export const locationMarker2Path =
-  process.env.NODE_ENV === "test"
-    ? ""
-    : require("../assets/images/location_marker2.svg");
-
-export const locationMarker3Path =
-  process.env.NODE_ENV === "test"
-    ? ""
-    : require("../assets/images/location_marker3.svg");
-
-export const locationMarker4Path =
-  process.env.NODE_ENV === "test"
-    ? ""
-    : require("../assets/images/location_marker4.svg");
-
-export const locationMarkerPath =
-  process.env.NODE_ENV === "test"
-    ? ""
-    : require("../assets/images/location_marker.svg");
-
 export const pulsingLocationMarkerPath =
   process.env.NODE_ENV === "test"
     ? ""


### PR DESCRIPTION
Using HTML instead of SVG icons will make it easier to switch colours themes. 
Also, there was no reason to use different logic for drawing similar markers.

But I can't do the same for the clusters for fixed sessions. Cause we are using google maps clusterer and it only accepts url as icons. How do you feel about having HTML files instead of svg files and passing a url to them???