### PR TITLE
Refactor Active/Dormant 

### DIFF
--- a/app/controllers/api/realtime/sessions_controller.rb
+++ b/app/controllers/api/realtime/sessions_controller.rb
@@ -30,13 +30,13 @@ module Api
 
       respond_to :json
 
-      def index_streaming
+      def index_active
         data = decoded_query_data(params[:q])
         INT_Q_ATTRS.each { |key| data[key] = data[key].to_i if data.key?(key) }
 
         data[:time_from] = Time.strptime(data[:time_from].to_s, '%s')
         data[:time_to] = Time.strptime(data[:time_to].to_s, '%s')
-        sessions = FixedSession.filtered_streaming_json(data)
+        sessions = FixedSession.filtered_active_json(data)
 
         respond_with sessions: sessions, fetchableSessionsCount: sessions.count
       end

--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -39,7 +39,7 @@ export const FixedSessionsMapCtrl = (
       sensorId,
       location: "",
       isIndoor: false,
-      isStreaming: true,
+      isActive: true,
       tags: "",
       usernames: "",
       timeFrom: FiltersUtils.oneYearAgo(),
@@ -93,8 +93,8 @@ export const FixedSessionsMapCtrl = (
         $scope.sessions.fetch();
       });
 
-      elmApp.ports.toggleStreaming.subscribe(isStreaming => {
-        params.update({ data: { isStreaming } });
+      elmApp.ports.toggleActive.subscribe(isActive => {
+        params.update({ data: { isActive } });
         resetTimeRangeFilter();
         $scope.sessions.fetch();
       });
@@ -131,21 +131,18 @@ export const FixedSessionsMapCtrl = (
         $scope.sessions.fetch();
       };
 
-      const setupStreamingTimeRangeFilter = (timeFrom, timeTo) => {
+      const setupActiveTimeRangeFilter = (timeFrom, timeTo) => {
         if (document.getElementById("time-range")) {
           $("#time-range").daterangepicker(
             FiltersUtils.daterangepickerConfig(timeFrom, timeTo)
           );
         } else {
-          window.setTimeout(
-            setupStreamingTimeRangeFilter(timeFrom, timeTo),
-            100
-          );
+          window.setTimeout(setupActiveTimeRangeFilter(timeFrom, timeTo), 100);
         }
       };
 
-      if (params.get("data").isStreaming) {
-        setupStreamingTimeRangeFilter(
+      if (params.get("data").isActive) {
+        setupActiveTimeRangeFilter(
           FiltersUtils.oneHourAgo(),
           FiltersUtils.presentMoment()
         );
@@ -163,8 +160,8 @@ export const FixedSessionsMapCtrl = (
       });
 
       const resetTimeRangeFilter = () => {
-        if (params.get("data").isStreaming) {
-          setupStreamingTimeRangeFilter(
+        if (params.get("data").isActive) {
+          setupActiveTimeRangeFilter(
             FiltersUtils.oneHourAgo(),
             FiltersUtils.presentMoment()
           );

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -103,7 +103,7 @@ export const fixedSessions = (
     },
 
     drawSelectedSession: function(sessionData) {
-      if (params.isStreaming()) {
+      if (params.isActive()) {
         this.drawMarkersWithLabel(sessionData, sensors.selectedSensorName());
       } else {
         this.drawMarkersWithoutLabel(sessionData);
@@ -140,7 +140,7 @@ export const fixedSessions = (
 
       const sessions = this.get();
 
-      if (!sensors.anySelected() || !params.get("data").isStreaming) {
+      if (!sensors.anySelected() || !params.get("data").isActive) {
         sessions.forEach(session => this.drawMarkersWithoutLabel(session));
         return;
       }
@@ -228,7 +228,7 @@ export const fixedSessions = (
 
       if (offset === 0) this.sessions = [];
 
-      if (data.isStreaming) {
+      if (data.isActive) {
         this.downloadSessions("/api/realtime/streaming_sessions.json", reqData);
       } else {
         this.downloadSessions("/api/fixed/dormant/sessions.json", reqData);

--- a/app/javascript/angular/code/services/_fixed_sessions.js
+++ b/app/javascript/angular/code/services/_fixed_sessions.js
@@ -229,7 +229,7 @@ export const fixedSessions = (
       if (offset === 0) this.sessions = [];
 
       if (data.isActive) {
-        this.downloadSessions("/api/realtime/streaming_sessions.json", reqData);
+        this.downloadSessions("/api/fixed/active/sessions.json", reqData);
       } else {
         this.downloadSessions("/api/fixed/dormant/sessions.json", reqData);
       }

--- a/app/javascript/angular/code/services/params.js
+++ b/app/javascript/angular/code/services/params.js
@@ -50,8 +50,8 @@ angular.module("aircasting").factory("params", [
       selectedSessionIds: function() {
         return this.paramsData["selectedSessionIds"] || [];
       },
-      isStreaming: function() {
-        return this.paramsData.data.isStreaming || false;
+      isActive: function() {
+        return this.paramsData.data.isActive || false;
       }
     };
     return new Params();

--- a/app/javascript/angular/tests/_fixed_sessions.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions.test.js
@@ -272,10 +272,10 @@ test("drawSessionsInLocation draws default marker when no sensor selected", t =>
   t.end();
 });
 
-test("drawSessionsInLocation draws default marker for sessions that are not streaming currently", t => {
+test("drawSessionsInLocation draws default marker for sessions that aren't active", t => {
   const map = mock("drawMarkerWithoutLabel");
   const session = { latitude: 1, longitude: 2 };
-  const data = buildData({ isStreaming: false });
+  const data = buildData({ isActive: false });
 
   const fixedSessionsService = _fixedSessions({ data, map });
   fixedSessionsService.sessions = [session];
@@ -287,7 +287,7 @@ test("drawSessionsInLocation draws default marker for sessions that are not stre
   t.end();
 });
 
-test("drawSessionsInLocation draws colorcoded marker for currently streaming sessions when sensor selected", t => {
+test("drawSessionsInLocation draws colorcoded marker for active sessions when sensor selected", t => {
   const map = mock("drawMarkerWithLabel");
   const session = {
     id: 123,
@@ -300,7 +300,7 @@ test("drawSessionsInLocation draws colorcoded marker for currently streaming ses
     anySelected: () => true,
     selectedSensorName: () => "sensorName"
   };
-  const data = buildData({ isStreaming: true });
+  const data = buildData({ isActive: true });
 
   const fixedSessionsService = _fixedSessions({ data, map, sensors });
   fixedSessionsService.sessions = [session];
@@ -312,11 +312,11 @@ test("drawSessionsInLocation draws colorcoded marker for currently streaming ses
   t.end();
 });
 
-test("drawSessionsInLocation calls map.clusterMarkers for currently streaming sessions when sensor selected", t => {
+test("drawSessionsInLocation calls map.clusterMarkers for active sessions when sensor selected", t => {
   const clusterMarkers = sinon.spy();
   const map = { clusterMarkers };
   const sensors = { anySelected: () => true };
-  const data = buildData({ isStreaming: true });
+  const data = buildData({ isActive: true });
   const fixedSessionsService = _fixedSessions({ data, map, sensors });
 
   fixedSessionsService.drawSessionsInLocation();
@@ -395,7 +395,7 @@ const _fixedSessions = ({
     },
     update: () => {},
     selectedSessionIds: () => sessionIds,
-    isStreaming: () => false
+    isActive: () => false
   };
   const _map = {
     getBounds: () => ({}),

--- a/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
+++ b/app/javascript/angular/tests/_fixed_sessions_map_ctrl.test.js
@@ -17,7 +17,7 @@ test("it updates defaults", t => {
     sensorId,
     location: "",
     isIndoor: false,
-    isStreaming: true,
+    isActive: true,
     tags: "",
     usernames: "",
     timeFrom: moment()

--- a/app/javascript/elm/src/Data/Status.elm
+++ b/app/javascript/elm/src/Data/Status.elm
@@ -1,0 +1,6 @@
+module Data.Status exposing (Status(..))
+
+
+type Status
+    = Active
+    | Dormant

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -115,6 +115,7 @@ type alias Flags =
     , isCrowdMapOn : Bool
     , crowdMapResolution : Int
     , timeRange : Encode.Value
+    , isActive : Bool
     , isIndoor : Bool
     , selectedSessionId : Maybe Int
     , sensors : Encode.Value
@@ -171,7 +172,12 @@ init flags url key =
         , isSearchAsIMoveOn = flags.isSearchAsIMoveOn
         , overlay = Overlay.init flags.isIndoor
         , scrollPosition = flags.scrollPosition
-        , status = Active
+        , status =
+            if flags.isActive then
+                Active
+
+            else
+                Dormant
       }
     , Cmd.batch
         [ fetchSelectedSession sensors flags.selectedSessionId flags.selectedSensorId page

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -13,6 +13,7 @@ import Data.Page exposing (Page(..))
 import Data.Path as Path exposing (Path)
 import Data.SelectedSession as SelectedSession exposing (SelectedSession)
 import Data.Session exposing (..)
+import Data.Status exposing (Status(..))
 import Data.Times as Times
 import Html exposing (Html, a, button, div, h2, h3, header, img, input, label, li, main_, nav, p, span, text, ul)
 import Html.Attributes exposing (alt, attribute, autocomplete, checked, class, classList, disabled, for, href, id, max, min, name, placeholder, rel, src, target, title, type_, value)
@@ -62,13 +63,13 @@ type alias Model =
     , resetIconWhite : Path
     , tooltipIcon : Path
     , heatMapThresholds : WebData HeatMapThresholds
-    , isStreaming : Bool
     , isSearchAsIMoveOn : Bool
     , wasMapMoved : Bool
     , overlay : Overlay.Model
     , scrollPosition : Float
     , debouncingCounter : Int
     , isNavExpanded : Bool
+    , status : Status
     }
 
 
@@ -89,7 +90,6 @@ defaultModel =
     , crowdMapResolution = BoundedInteger.build (LowerBound 1) (UpperBound 40) (Value 20)
     , timeRange = TimeRange.defaultTimeRange
     , isIndoor = False
-    , isStreaming = True
     , selectedSession = NotAsked
     , navLogo = Path.empty
     , linkIcon = Path.empty
@@ -104,6 +104,7 @@ defaultModel =
     , scrollPosition = 0
     , debouncingCounter = 0
     , isNavExpanded = False
+    , status = Active
     }
 
 
@@ -115,7 +116,6 @@ type alias Flags =
     , crowdMapResolution : Int
     , timeRange : Encode.Value
     , isIndoor : Bool
-    , isStreaming : Bool
     , selectedSessionId : Maybe Int
     , sensors : Encode.Value
     , selectedSensorId : String
@@ -158,7 +158,6 @@ init flags url key =
         , timeRange = TimeRange.update defaultModel.timeRange flags.timeRange
         , isIndoor = flags.isIndoor
         , sensors = sensors
-        , isStreaming = flags.isStreaming
         , selectedSensorId = flags.selectedSensorId
         , navLogo = Path.fromString flags.navLogo
         , linkIcon = Path.fromString flags.linkIcon
@@ -172,6 +171,7 @@ init flags url key =
         , isSearchAsIMoveOn = flags.isSearchAsIMoveOn
         , overlay = Overlay.init flags.isIndoor
         , scrollPosition = flags.scrollPosition
+        , status = Active
       }
     , Cmd.batch
         [ fetchSelectedSession sensors flags.selectedSessionId flags.selectedSensorId page
@@ -225,7 +225,7 @@ type Msg
     | LoadMoreSessions
     | UpdateIsHttping Bool
     | ToggleIndoor
-    | ToggleStreaming
+    | ToggleStatus
     | DeselectSession
     | ToggleSessionSelectionFromAngular (Maybe Int)
     | ToggleSessionSelection Int
@@ -405,13 +405,21 @@ update msg model =
                 , Cmd.batch [ Ports.toggleIndoor True, Ports.updateProfiles [], subCmd ]
                 )
 
-        ToggleStreaming ->
+        ToggleStatus ->
             let
                 ( subModel, subCmd ) =
                     deselectSession model
+
+                newStatus =
+                    case model.status of
+                        Active ->
+                            Dormant
+
+                        Dormant ->
+                            Active
             in
-            ( { subModel | isStreaming = not subModel.isStreaming }
-            , Cmd.batch [ Ports.toggleStreaming (not subModel.isStreaming), subCmd ]
+            ( { subModel | status = newStatus }
+            , Cmd.batch [ Ports.toggleActive (newStatus == Active), subCmd ]
             )
 
         DeselectSession ->
@@ -1024,7 +1032,7 @@ viewMobileFilters model =
         [ viewParameterFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewSensorFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewLocationFilter model.location model.isIndoor model.tooltipIcon
-        , TimeRange.view RefreshTimeRange False model.tooltipIcon model.resetIconWhite
+        , TimeRange.view RefreshTimeRange Dormant model.tooltipIcon model.resetIconWhite
         , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" False Tooltip.profilesFilter model.tooltipIcon
         , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False Tooltip.tagsFilter model.tooltipIcon
         , viewCrowdMapOptions model.isCrowdMapOn model.crowdMapResolution model.selectedSession model.tooltipIcon
@@ -1037,7 +1045,7 @@ viewFixedFilters model =
         [ viewParameterFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewSensorFilter model.sensors model.selectedSensorId model.tooltipIcon
         , viewLocationFilter model.location model.isIndoor model.tooltipIcon
-        , TimeRange.view RefreshTimeRange model.isStreaming model.tooltipIcon model.resetIconWhite
+        , TimeRange.view RefreshTimeRange model.status model.tooltipIcon model.resetIconWhite
         , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" model.isIndoor Tooltip.profilesFilter model.tooltipIcon
         , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False Tooltip.tagsFilter model.tooltipIcon
         , div [ class "filters__toggle-group" ]
@@ -1048,9 +1056,9 @@ viewFixedFilters model =
             ]
         , div [ class "filters__toggle-group" ]
             [ label [] [ text "status:" ]
-            , Tooltip.view Tooltip.streamingToggleFilter model.tooltipIcon
-            , viewToggleButton "active" model.isStreaming ToggleStreaming
-            , viewToggleButton "dormant" (not model.isStreaming) ToggleStreaming
+            , Tooltip.view Tooltip.activeToggleFilter model.tooltipIcon
+            , viewToggleButton "active" (model.status == Active) ToggleStatus
+            , viewToggleButton "dormant" (model.status == Dormant) ToggleStatus
             ]
         ]
 

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -18,12 +18,12 @@ port module Ports exposing
     , showCopyLinkTooltip
     , tagSelected
     , timeRangeSelected
+    , toggleActive
     , toggleCrowdMap
     , toggleIndoor
     , toggleIsSearchOn
     , toggleSession
     , toggleSessionSelection
-    , toggleStreaming
     , updateHeatMapThresholds
     , updateHeatMapThresholdsFromAngular
     , updateIsHttping
@@ -63,7 +63,7 @@ port toggleCrowdMap : Bool -> Cmd a
 port toggleIndoor : Bool -> Cmd a
 
 
-port toggleStreaming : Bool -> Cmd a
+port toggleActive : Bool -> Cmd a
 
 
 port updateResolution : Int -> Cmd a

--- a/app/javascript/elm/src/TimeRange.elm
+++ b/app/javascript/elm/src/TimeRange.elm
@@ -1,6 +1,7 @@
 module TimeRange exposing (TimeRange(..), defaultTimeRange, update, view)
 
 import Data.Path as Path exposing (Path)
+import Data.Status exposing (Status(..))
 import Html exposing (Html, button, div, img, input, label, text)
 import Html.Attributes exposing (alt, attribute, class, disabled, for, id, name, placeholder, src, type_)
 import Html.Attributes.Aria exposing (ariaLabel)
@@ -52,8 +53,8 @@ timeRangeDecoder =
         (Decode.field "timeTo" Decode.int)
 
 
-view : msg -> Bool -> Path -> Path -> Html msg
-view refreshTimeRange isDisabled tooltipIcon resetIcon =
+view : msg -> Status -> Path -> Path -> Html msg
+view refreshTimeRange status tooltipIcon resetIcon =
     div [ class "filters__input-group" ]
         [ input
             [ id "time-range"
@@ -64,7 +65,7 @@ view refreshTimeRange isDisabled tooltipIcon resetIcon =
             , placeholder "time frame"
             , type_ "text"
             , name "time-range"
-            , disabled isDisabled
+            , disabled (status == Active)
             ]
             []
         , label [ for "time-range" ] [ text "time frame:" ]

--- a/app/javascript/elm/src/Tooltip.elm
+++ b/app/javascript/elm/src/Tooltip.elm
@@ -1,5 +1,6 @@
 module Tooltip exposing
     ( TooltipText
+    , activeToggleFilter
     , crowdMap
     , fixedTab
     , locationFilter
@@ -7,7 +8,6 @@ module Tooltip exposing
     , parameterFilter
     , profilesFilter
     , sensorFilter
-    , streamingToggleFilter
     , tagsFilter
     , timeRangeFilter
     , typeToggleFilter
@@ -68,5 +68,5 @@ typeToggleFilter =
     TooltipText "Outdoor sessions are recorded by instruments located outdoors. Indoor measurements are recorded by instruments located indoors. Indoor sessions do not include geocoordinates and are therefore not geolocated on the map."
 
 
-streamingToggleFilter =
+activeToggleFilter =
     TooltipText "Fixed sessions that have submitted a measurement in the past hour are considered active. Fixed sessions that have not submitted measurements in the past hour are considered dormant."

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -1,7 +1,8 @@
-module MainTests exposing (crowdMapArea, locationFilter, parameterSensorFilter, popups, profilesArea, tagsArea, timeFilter, toggleIndoorFilter, toggleStreamingFilter, updateTests, viewTests)
+module MainTests exposing (crowdMapArea, locationFilter, parameterSensorFilter, popups, profilesArea, tagsArea, timeFilter, toggleIndoorFilter, toggleStatusFilter, updateTests, viewTests)
 
 import Data.BoundedInteger as BoundedInteger exposing (BoundedInteger, LowerBound(..), UpperBound(..), Value(..))
 import Data.Page exposing (Page(..))
+import Data.Status exposing (Status(..))
 import Expect
 import Fuzz exposing (bool, int, intRange, list, string)
 import Html exposing (text)
@@ -166,16 +167,23 @@ timeFilter =
                     |> update (UpdateTimeRange value)
                     |> Tuple.first
                     |> Expect.equal expected
-        , fuzz bool "is enabled for dormant and disabled for active Fixed sessions" <|
-            \isStreaming ->
-                { defaultModel | isStreaming = isStreaming, page = Fixed }
+        , test "disabled for active fixed sessions" <|
+            \_ ->
+                { defaultModel | status = Active, page = Fixed }
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.id "time-range" ]
-                    |> Query.has [ Slc.attribute <| disabled isStreaming ]
-        , fuzz bool "is always enabled for Mobile sessions" <|
-            \isStreaming ->
-                { defaultModel | isStreaming = isStreaming, page = Mobile }
+                    |> Query.has [ Slc.attribute <| disabled True ]
+        , test "is enabled for dormant fixed sessions" <|
+            \_ ->
+                { defaultModel | status = Dormant, page = Fixed }
+                    |> view
+                    |> Query.fromHtml
+                    |> Query.find [ Slc.id "time-range" ]
+                    |> Query.has [ Slc.attribute <| disabled False ]
+        , test "is always enabled for mobile sessions" <|
+            \_ ->
+                { defaultModel | status = Active, page = Mobile }
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.id "time-range" ]
@@ -456,8 +464,8 @@ toggleIndoorFilter =
         ]
 
 
-toggleStreamingFilter : Test
-toggleStreamingFilter =
+toggleStatusFilter : Test
+toggleStatusFilter =
     describe "active/dormant filter tests:"
         [ test "toggle is displayed" <|
             \_ ->
@@ -475,14 +483,14 @@ toggleStreamingFilter =
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute <| ariaLabel "active" ]
                     |> Query.has [ Slc.attribute <| class "toggle-button--pressed" ]
-        , test "clicking dormant button triggers ToggleStreaming" <|
+        , test "clicking dormant button triggers ToggleStatus" <|
             \_ ->
                 { defaultModel | page = Fixed }
                     |> view
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute <| ariaLabel "dormant" ]
                     |> Event.simulate Event.click
-                    |> Event.expect ToggleStreaming
+                    |> Event.expect ToggleStatus
         ]
 
 

--- a/app/javascript/elm/tests/TimeRangeTests.elm
+++ b/app/javascript/elm/tests/TimeRangeTests.elm
@@ -1,5 +1,6 @@
 module TimeRangeTests exposing (all)
 
+import Data.Status exposing (Status(..))
 import Expect
 import Fuzz exposing (bool, int)
 import Html.Attributes exposing (disabled)
@@ -21,7 +22,7 @@ all =
     describe "TimeRange"
         [ test ".view has an input field" <|
             \_ ->
-                TimeRange.view (\_ -> ()) True defaultIcon defaultIcon
+                TimeRange.view (\_ -> ()) Active defaultIcon defaultIcon
                     |> Query.fromHtml
                     |> Query.has [ tag "input" ]
         , fuzz2 int int ".update returns updated TimeRange if value has correct format" <|
@@ -51,15 +52,9 @@ all =
                     |> Expect.equal expected
         , test "viewTimeFilter has a button" <|
             \_ ->
-                TimeRange.view Msg True defaultIcon defaultIcon
+                TimeRange.view Msg Active defaultIcon defaultIcon
                     |> Query.fromHtml
                     |> Query.find [ tag "button" ]
                     |> Event.simulate Event.click
                     |> Event.expect Msg
-        , fuzz bool "may be disabled" <|
-            \isDisabled ->
-                TimeRange.view (\_ -> ()) isDisabled defaultIcon defaultIcon
-                    |> Query.fromHtml
-                    |> Query.find [ id "time-range" ]
-                    |> Query.has [ attribute <| disabled isDisabled ]
         ]

--- a/app/javascript/javascript/values/session.js
+++ b/app/javascript/javascript/values/session.js
@@ -6,8 +6,8 @@ export const formatSessionForList = session => ({
   endTime: session.endTime,
   shortTypes: session.shortTypes,
   // `stream.average_value` for mobile sessions
-  // `session.last_hour_average` for streaming fixed sessions
-  // non-streaming fixed sessions do not have average
+  // `session.last_hour_average` for active fixed sessions
+  // dormant fixed sessions do not have average
   // The `hasOwnProperty` check is needed because 0 is falsy in JS
   average:
     session.type === "MobileSession"

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -50,7 +50,7 @@ document.addEventListener("DOMContentLoaded", () => {
         crowdMap: false,
         gridResolution: 31, // this translates to grid cell size: 20; formula: f(x) = 51 - x
         isIndoor: false,
-        isStreaming: true,
+        isActive: true,
         sensorId: "Particulate Matter-airbeam2-pm2.5 (µg/m³)",
         isSearchAsIMoveOn: false
       };
@@ -95,7 +95,7 @@ document.addEventListener("DOMContentLoaded", () => {
         resetIconWhite,
         tooltipIcon,
         heatMapThresholdValues,
-        isStreaming: data.isStreaming,
+        isActive: data.isActive,
         isSearchAsIMoveOn: data.isSearchAsIMoveOn,
         scrollPosition: params.scroll || 0
       };

--- a/app/models/fixed_session.rb
+++ b/app/models/fixed_session.rb
@@ -2,7 +2,7 @@ class FixedSession < Session
   validates :is_indoor, inclusion: { in: [true, false] }
   validates :latitude, :longitude, presence: true
 
-  def self.streaming
+  def self.active
     where('last_measurement_at > ?', Time.current - 1.hour)
   end
 
@@ -18,8 +18,8 @@ class FixedSession < Session
     %i[id title start_time_local end_time_local is_indoor latitude longitude]
   end
 
-  def self.filtered_streaming_json(data)
-    streaming.with_user_and_streams.filter_(data).as_json(
+  def self.filtered_active_json(data)
+    active.with_user_and_streams.filter_(data).as_json(
       only: filtered_json_fields,
       methods: %i[username streams last_hour_average]
     )
@@ -77,7 +77,7 @@ class FixedSession < Session
       sensorId: stream.sensor_id,
       usernames: user.username,
       isIndoor: is_indoor,
-      isStreaming: is_steaming,
+      isActive: is_active,
       heat: {
         highest: stream.threshold_very_high,
         high: stream.threshold_high,
@@ -94,7 +94,7 @@ class FixedSession < Session
 
   private
 
-  def is_steaming
+  def is_active
     last_measurement_at > (Time.current - 1.hour)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,10 @@ Rails.application.routes.draw do
       namespace :dormant do
         get 'sessions' => 'sessions#index'
       end
+
+      namespace :active do
+        get 'sessions' => 'sessions#index_active'
+      end
     end
 
     namespace :mobile do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   get 's/:url_token' => 'measurement_sessions#show',
       constraints: { query_string: /.+/ },
       as: :short_session
-  get 's/:url_token' => 'measurement_sessions#show_old' # supports mobile apps relesed before 06.2019
+  get 's/:url_token' => 'measurement_sessions#show_old' # legacy API - supports mobile apps relesed before 06.2019
 
   namespace :api do
     namespace :v2 do
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
     resources :sensors, only: %i[index]
 
     namespace :realtime do
-      get 'streaming_sessions' => 'sessions#index_active'
+      get 'streaming_sessions' => 'sessions#index_active' # legacy API - supports mobile apps relesed before 07.2019
       get 'sync_measurements' => 'sessions#sync_measurements'
       resources :sessions, only: %i[create show]
       resources :measurements, only: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
     resources :sensors, only: %i[index]
 
     namespace :realtime do
-      get 'streaming_sessions' => 'sessions#index_streaming'
+      get 'streaming_sessions' => 'sessions#index_active'
       get 'sync_measurements' => 'sessions#sync_measurements'
       resources :sessions, only: %i[create show]
       resources :measurements, only: :create

--- a/doc/api.md
+++ b/doc/api.md
@@ -6,7 +6,7 @@ Every response is returned in JSON format.
 
 Endpoints
 
-- GET `/api/realtime/streaming_sessions.json` -> streaming fixed sessions
+- GET `/api/fixed/active/sessions.json` -> fixed active sessions
 - GET `/api/fixed/dormant/sessions.json` -> fixed dormant sessions
 - GET `/api/mobile/sessions.json` -> mobile sessions
 


### PR DESCRIPTION
- add custom type in elm
- use active/dormant naming instead of streaming/non-streaming throughout the application