### PR TITLE
Direct toggle only

### DIFF
--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -222,7 +222,7 @@ type Msg
     | SubmitLocation
     | TagsLabels LabelsInput.Msg
     | ProfileLabels LabelsInput.Msg
-    | ToggleCrowdMap
+    | ToggleCrowdMap Bool
     | UpdateCrowdMapResolution Int
     | UpdateTimeRange Encode.Value
     | RefreshTimeRange
@@ -236,8 +236,8 @@ type Msg
     | UpdateSessions Encode.Value
     | LoadMoreSessions
     | UpdateIsHttping Bool
-    | ToggleIndoor
-    | ToggleStatus
+    | ToggleIndoor Bool
+    | ToggleStatus Status
     | DeselectSession
     | ToggleSessionSelectionFromAngular (Maybe Int)
     | ToggleSessionSelection Int
@@ -295,8 +295,12 @@ update msg model =
             in
             ( subModel2, Cmd.batch [ subCmd1, subCmd2 ] )
 
-        ToggleCrowdMap ->
-            ( { model | isCrowdMapOn = not model.isCrowdMapOn }, Ports.toggleCrowdMap (not model.isCrowdMapOn) )
+        ToggleCrowdMap newValue ->
+            if model.isCrowdMapOn == newValue then
+                ( model, Cmd.none )
+
+            else
+                ( { model | isCrowdMapOn = newValue }, Ports.toggleCrowdMap newValue )
 
         UpdateCrowdMapResolution resolution ->
             let
@@ -403,32 +407,36 @@ update msg model =
             in
             ( { model | overlay = Overlay.update overlay model.overlay }, Cmd.none )
 
-        ToggleIndoor ->
+        ToggleIndoor newValue ->
             let
                 ( subModel, subCmd ) =
                     deselectSession model
             in
-            if subModel.isIndoor then
-                ( { subModel | isIndoor = False, overlay = Overlay.update (RemoveOverlay IndoorOverlay) model.overlay }
-                , Cmd.batch [ Ports.toggleIndoor False, subCmd ]
-                )
+            if subModel.isIndoor == newValue then
+                ( subModel, Cmd.none )
 
-            else
+            else if newValue then
                 ( { subModel | isIndoor = True, profiles = LabelsInput.empty, overlay = Overlay.update (AddOverlay IndoorOverlay) model.overlay }
                 , Cmd.batch [ Ports.toggleIndoor True, Ports.updateProfiles [], subCmd ]
                 )
 
-        ToggleStatus ->
+            else
+                ( { subModel | isIndoor = False, overlay = Overlay.update (RemoveOverlay IndoorOverlay) model.overlay }
+                , Cmd.batch [ Ports.toggleIndoor False, subCmd ]
+                )
+
+        ToggleStatus newStatus ->
             let
                 ( subModel, subCmd ) =
                     deselectSession model
-
-                newStatus =
-                    Status.toggle model.status
             in
-            ( { subModel | status = newStatus }
-            , Cmd.batch [ Ports.toggleActive (Status.toBool newStatus), subCmd ]
-            )
+            if subModel.status == newStatus then
+                ( subModel, Cmd.none )
+
+            else
+                ( { subModel | status = newStatus }
+                , Cmd.batch [ Ports.toggleActive (Status.toBool newStatus), subCmd ]
+                )
 
         DeselectSession ->
             deselectSession model
@@ -1081,14 +1089,14 @@ viewFixedFilters model =
         , div [ class "filters__toggle-group" ]
             [ label [] [ text "placement:" ]
             , Tooltip.view Tooltip.typeToggleFilter model.tooltipIcon
-            , viewToggleButton "outdoor" (not model.isIndoor) ToggleIndoor
-            , viewToggleButton "indoor" model.isIndoor ToggleIndoor
+            , viewToggleButton "outdoor" (not model.isIndoor) (ToggleIndoor False)
+            , viewToggleButton "indoor" model.isIndoor (ToggleIndoor True)
             ]
         , div [ class "filters__toggle-group" ]
             [ label [] [ text "status:" ]
             , Tooltip.view Tooltip.activeToggleFilter model.tooltipIcon
-            , viewToggleButton "active" (model.status == Active) ToggleStatus
-            , viewToggleButton "dormant" (model.status == Dormant) ToggleStatus
+            , viewToggleButton "active" (model.status == Active) (ToggleStatus Active)
+            , viewToggleButton "dormant" (model.status == Dormant) (ToggleStatus Dormant)
             ]
         ]
 
@@ -1165,8 +1173,8 @@ viewCrowdMapToggle : Bool -> Path -> Html Msg
 viewCrowdMapToggle isCrowdMapOn tooltipIcon =
     div [ class "filters__toggle-group" ]
         [ label [] [ text "CrowdMap:" ]
-        , viewToggleButton "off" (not isCrowdMapOn) ToggleCrowdMap
-        , viewToggleButton "on" isCrowdMapOn ToggleCrowdMap
+        , viewToggleButton "off" (not isCrowdMapOn) (ToggleCrowdMap False)
+        , viewToggleButton "on" isCrowdMapOn (ToggleCrowdMap True)
         , Tooltip.view Tooltip.crowdMap tooltipIcon
         ]
 

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -413,7 +413,7 @@ update msg model =
                     deselectSession model
             in
             if subModel.isIndoor == newValue then
-                ( subModel, Cmd.none )
+                ( model, Cmd.none )
 
             else if newValue then
                 ( { subModel | isIndoor = True, profiles = LabelsInput.empty, overlay = Overlay.update (AddOverlay IndoorOverlay) model.overlay }
@@ -431,7 +431,7 @@ update msg model =
                     deselectSession model
             in
             if subModel.status == newStatus then
-                ( subModel, Cmd.none )
+                ( model, Cmd.none )
 
             else
                 ( { subModel | status = newStatus }

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -348,7 +348,7 @@ crowdMapArea =
         [ fuzz bool "ToggleCrowdMap toggles the value of model.isCrowdMapOn" <|
             \onOffValue ->
                 { defaultModel | isCrowdMapOn = onOffValue }
-                    |> update ToggleCrowdMap
+                    |> update (ToggleCrowdMap (not onOffValue))
                     |> Tuple.first
                     |> .isCrowdMapOn
                     |> Expect.equal (not onOffValue)
@@ -380,7 +380,7 @@ crowdMapArea =
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute <| ariaLabel "on" ]
                     |> Event.simulate Event.click
-                    |> Event.expect ToggleCrowdMap
+                    |> Event.expect (ToggleCrowdMap True)
         , test "slider has a description with current crowd map grid cell size" <|
             \_ ->
                 { defaultModel
@@ -460,7 +460,7 @@ toggleIndoorFilter =
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute <| ariaLabel "indoor" ]
                     |> Event.simulate Event.click
-                    |> Event.expect ToggleIndoor
+                    |> Event.expect (ToggleIndoor True)
         ]
 
 
@@ -490,7 +490,7 @@ toggleStatusFilter =
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute <| ariaLabel "dormant" ]
                     |> Event.simulate Event.click
-                    |> Event.expect ToggleStatus
+                    |> Event.expect (ToggleStatus Dormant)
         ]
 
 

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -366,13 +366,6 @@ crowdMapArea =
                     |> Tuple.first
                     |> .crowdMapResolution
                     |> Expect.equal (BoundedInteger.build (LowerBound 1) (UpperBound 40) (Value 40))
-        , test "'off' is selected by default" <|
-            \_ ->
-                defaultModel
-                    |> view
-                    |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| ariaLabel "off" ]
-                    |> Query.has [ Slc.attribute <| class "toggle-button--pressed" ]
         , test "toggling sends ToggleCrowdMap message" <|
             \_ ->
                 defaultModel
@@ -446,13 +439,6 @@ toggleIndoorFilter =
                         [ Query.has [ Slc.attribute <| ariaLabel "indoor" ]
                         , Query.has [ Slc.attribute <| ariaLabel "outdoor" ]
                         ]
-        , test "outdoor is selected by default" <|
-            \_ ->
-                { defaultModel | page = Fixed }
-                    |> view
-                    |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| ariaLabel "outdoor" ]
-                    |> Query.has [ Slc.attribute <| class "toggle-button--pressed" ]
         , test "toggling triggers ToggleIndoor" <|
             \_ ->
                 { defaultModel | page = Fixed }
@@ -476,13 +462,6 @@ toggleStatusFilter =
                         [ Query.has [ Slc.attribute <| ariaLabel "active" ]
                         , Query.has [ Slc.attribute <| ariaLabel "dormant" ]
                         ]
-        , test "active is selected by default" <|
-            \_ ->
-                { defaultModel | page = Fixed }
-                    |> view
-                    |> Query.fromHtml
-                    |> Query.find [ Slc.attribute <| ariaLabel "active" ]
-                    |> Query.has [ Slc.attribute <| class "toggle-button--pressed" ]
         , test "clicking dormant button triggers ToggleStatus" <|
             \_ ->
                 { defaultModel | page = Fixed }


### PR DESCRIPTION
Changes behavior of the toggle buttons in a way that double clicking a toggle option doesn't toggle to the opposite selection.

This PR re-applies changes made in https://github.com/HabitatMap/AirCasting/pull/303 which had to be reverted.

