### PR TITLE
Syncing mobile app sessions

### DIFF
--- a/app/controllers/api/user_sessions_controller.rb
+++ b/app/controllers/api/user_sessions_controller.rb
@@ -22,6 +22,38 @@ class Api::UserSessionsController < Api::BaseController
     end
   end
 
+  def sync2
+    form =
+      Api::JsonForm.new(
+        json: "{ \"data\": #{params.to_unsafe_hash[:data]} }",
+        schema: Api::UserSessions2::Schema,
+        struct: Api::UserSessions2::Struct
+      )
+    result = Api::ToUserSessionsHash2.new(form: form).call(current_user)
+
+    if result.success?
+      render json: result.value, status: :ok
+    else
+      render json: result.errors, status: :bad_request
+    end
+  end
+
+  def update_session
+    form =
+      Api::JsonForm.new(
+        json: params.to_unsafe_hash[:data],
+        schema: Api::UserSession::Schema,
+        struct: Api::UserSession::Struct
+      )
+    result = Api::UpdateSession.new(form: form).call(current_user)
+
+    if result.success?
+      render json: result.value, status: :ok
+    else
+      render json: result.errors, status: :bad_request
+    end
+  end
+
   def show
     session =
       (

--- a/app/controllers/api/user_sessions_controller.rb
+++ b/app/controllers/api/user_sessions_controller.rb
@@ -22,7 +22,7 @@ class Api::UserSessionsController < Api::BaseController
     end
   end
 
-  def sync2
+  def sync_with_versioning
     form =
       Api::JsonForm.new(
         json: "{ \"data\": #{params.to_unsafe_hash[:data]} }",

--- a/app/controllers/api/user_sessions_controller.rb
+++ b/app/controllers/api/user_sessions_controller.rb
@@ -29,7 +29,7 @@ class Api::UserSessionsController < Api::BaseController
         schema: Api::UserSessions2::Schema,
         struct: Api::UserSessions2::Struct
       )
-    result = Api::ToUserSessionsHash2.new(form: form).call(current_user)
+    result = Api::ToUserSessionsHash2.new(form: form, user: current_user).call
 
     if result.success?
       render json: result.value, status: :ok
@@ -45,7 +45,7 @@ class Api::UserSessionsController < Api::BaseController
         schema: Api::UserSession::Schema,
         struct: Api::UserSession::Struct
       )
-    result = Api::UpdateSession.new(form: form).call(current_user)
+    result = Api::UpdateSession.new(form: form).call
 
     if result.success?
       render json: result.value, status: :ok

--- a/app/models/api/user_session.rb
+++ b/app/models/api/user_session.rb
@@ -1,0 +1,52 @@
+require 'dry-validation'
+require 'dry-struct'
+
+module Api::UserSession
+  module Types
+    include Dry::Types.module
+  end
+
+  StreamSchema =
+    Dry::Validation.Schema do
+      required(:deleted).filled(:bool?)
+      required(:average_value).filled(:float?)
+      required(:measurement_type).filled(:str?)
+      required(:sensor_package_name).filled(:str?)
+      required(:sensor_name).filled(:str?)
+    end
+
+  Schema =
+    Dry::Validation.Schema do
+      configure do
+        def self.messages
+          super.merge(en: { errors: { valid_streams: 'streams is not valid' } })
+        end
+      end
+
+      required(:uuid).filled(:str?)
+      required(:tag_list)
+      required(:title)
+      required(:notes).each do
+        schema do
+          required(:number).filled(:int?)
+          required(:text).filled(:str?)
+        end
+      end
+      validate(valid_streams: :streams) do |stream|
+        stream.all? do |sensor_name, stream_data|
+          StreamSchema.call(stream_data).success?
+        end
+      end
+    end
+
+  class Struct < Dry::Struct
+    attribute :uuid, Types::Strict::String
+    attribute :title, Types::Strict::String
+    attribute :tag_list, Types::Strict::String
+    attribute :notes, Types::Strict::Array do
+      attribute :number, Types::Strict::Integer
+      attribute :text, Types::Strict::String
+    end
+    attribute :streams, Types::Strict::Hash
+  end
+end

--- a/app/models/api/user_sessions2.rb
+++ b/app/models/api/user_sessions2.rb
@@ -1,0 +1,25 @@
+require 'dry-validation'
+require 'dry-struct'
+
+module Api::UserSessions2
+  module Types
+    include Dry::Types.module
+  end
+
+  Schema =
+    Dry::Validation.Schema do
+      required(:data).each do
+        schema do
+          required(:uuid).filled(:str?)
+          required(:deleted).filled(:bool?)
+        end
+      end
+    end
+
+  class Struct < Dry::Struct
+    attribute :data, Types::Array do
+      attribute :uuid, Types::Strict::String
+      attribute :deleted, Types::Strict::Bool
+    end
+  end
+end

--- a/app/models/api/user_sessions2.rb
+++ b/app/models/api/user_sessions2.rb
@@ -12,6 +12,7 @@ module Api::UserSessions2
         schema do
           required(:uuid).filled(:str?)
           required(:deleted).filled(:bool?)
+          required(:version).filled(:int?)
         end
       end
     end
@@ -20,6 +21,7 @@ module Api::UserSessions2
     attribute :data, Types::Array do
       attribute :uuid, Types::Strict::String
       attribute :deleted, Types::Strict::Bool
+      attribute :version, Types::Strict::Integer
     end
   end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,21 +1,3 @@
-# AirCasting - Share your Air!
-# Copyright (C) 2011-2012 HabitatMap, Inc.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-# You can contact the authors by email at <info@habitatmap.org>
-
 require_dependency 'aircasting/username_param'
 
 class Session < ApplicationRecord
@@ -229,7 +211,7 @@ class Session < ApplicationRecord
     transaction do
       self.title = session_data[:title]
       self.tag_list = session_data[:tag_list]
-      self.version = self.version + 1
+      self.version += 1
       self.save!
 
       (session_data[:streams] || []).each do |key, stream_data|

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -229,6 +229,7 @@ class Session < ApplicationRecord
     transaction do
       self.title = session_data[:title]
       self.tag_list = session_data[:tag_list]
+      self.version = self.version + 1
       self.save!
 
       (session_data[:streams] || []).each do |key, stream_data|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,30 +62,6 @@ class User < ApplicationRecord
     record
   end
 
-  def sync2(sessions_data)
-    uuids_to_delete = uuids(sessions_data.select { |datum| datum[:deleted] })
-    delete_sessions(uuids_to_delete)
-
-    deleted = uuids(DeletedSession.where(user: self))
-    present_in_mobile_app =
-      uuids(sessions_data.select { |datum| !datum[:deleted] })
-    present_in_db = uuids(sessions)
-
-    {
-      upload: present_in_mobile_app - (present_in_db + deleted),
-      download: present_in_db - (present_in_mobile_app + deleted),
-      deleted: deleted & uuids(sessions_data)
-    }
-  end
-
-  def delete_sessions(uuids)
-    uuids.map { |uuid| sessions.find_by_uuid(uuid) }.compact.each(&:destroy)
-  end
-
-  def uuids(sessions)
-    sessions.map { |session| session[:uuid] }
-  end
-
   def sync(data)
     upload = []
     deleted = []

--- a/app/services/api/to_user_sessions_hash2.rb
+++ b/app/services/api/to_user_sessions_hash2.rb
@@ -1,15 +1,66 @@
 class Api::ToUserSessionsHash2
-  def initialize(form:)
+  def initialize(form:, user:)
     @form = form
+    @user = user
   end
 
-  def call(user)
+  def call
     return Failure.new(form.errors) if form.invalid?
 
-    Success.new(user.sync2(form.to_h.data.map(&:to_h)))
+    delete_sessions(data.select(&:deleted))
+
+    Success.new(
+      {
+        upload: new_in_mobile_app,
+        download: new_in_db + outdated,
+        deleted: deleted
+      }
+    )
   end
 
   private
 
-  attr_reader :form
+  attr_reader :form, :user
+
+  def data
+    form.to_h.data
+  end
+
+  def delete_sessions(session)
+    session.map { |session| user.sessions.find_by_uuid(session.uuid) }.compact
+      .each(&:destroy)
+  end
+
+  def deleted
+    DeletedSession.where(user: user, uuid: data.map(&:uuid)).map(&:uuid)
+  end
+
+  def present_in_mobile_app
+    data.select { |datum| !datum.deleted }
+  end
+
+  def present_in_db
+    user.sessions.select(:uuid, :version)
+  end
+
+  def new_in_db
+    present_in_db.map(&:uuid) - present_in_mobile_app.map(&:uuid)
+  end
+
+  def old_in_db
+    present_in_db.select do |ses|
+      present_in_mobile_app.map(&:uuid).include?(ses.uuid)
+    end
+  end
+
+  def outdated
+    old_in_db.select do |ses|
+      ses.version >
+        present_in_mobile_app.detect { |ses2| ses2.uuid == ses.uuid }.version
+    end.map(&:uuid)
+  end
+
+  def new_in_mobile_app
+    present_in_mobile_app.map(&:uuid) - (present_in_db.map(&:uuid) + deleted)
+  end
 end

--- a/app/services/api/to_user_sessions_hash2.rb
+++ b/app/services/api/to_user_sessions_hash2.rb
@@ -62,10 +62,10 @@ class Api::ToUserSessionsHash2
     present_in_database.select do |session_in_database|
       uuids_present_in_params.include?(session_in_database.uuid)
     end.select do |session_in_database|
-        session_in_database.version >
-          present_in_params.detect do |session_in_params|
-            session_in_params.uuid == session_in_database.uuid
-          end.version
+      session_in_database.version >
+        present_in_params.find do |session_in_params|
+          session_in_params.uuid == session_in_database.uuid
+        end.version
     end.pluck(:uuid)
   end
 end

--- a/app/services/api/to_user_sessions_hash2.rb
+++ b/app/services/api/to_user_sessions_hash2.rb
@@ -1,0 +1,15 @@
+class Api::ToUserSessionsHash2
+  def initialize(form:)
+    @form = form
+  end
+
+  def call(user)
+    return Failure.new(form.errors) if form.invalid?
+
+    Success.new(user.sync2(form.to_h.data.map(&:to_h)))
+  end
+
+  private
+
+  attr_reader :form
+end

--- a/app/services/api/update_session.rb
+++ b/app/services/api/update_session.rb
@@ -3,7 +3,7 @@ class Api::UpdateSession
     @form = form
   end
 
-  def call(user)
+  def call
     return Failure.new(form.errors) if form.invalid?
 
     session = Session.find_by_uuid(data[:uuid])

--- a/app/services/api/update_session.rb
+++ b/app/services/api/update_session.rb
@@ -7,13 +7,11 @@ class Api::UpdateSession
     return Failure.new(form.errors) if form.invalid?
 
     session = Session.find_by_uuid(data[:uuid])
-
     unless session
       return Failure.new("Session with uuid: #{data[:uuid]} doesn't exist")
     end
 
     session.sync(data)
-
     session.reload
 
     Success.new(session)

--- a/app/services/api/update_session.rb
+++ b/app/services/api/update_session.rb
@@ -1,0 +1,25 @@
+class Api::UpdateSession
+  def initialize(form:)
+    @form = form
+  end
+
+  def call(user)
+    return Failure.new(form.errors) if form.invalid?
+
+    session = Session.find_by_uuid(data[:uuid])
+
+    unless session
+      return Failure.new("Session with uuid: #{data[:uuid]} doesn't exist")
+    end
+
+    Success.new(session.sync(data))
+  end
+
+  private
+
+  attr_reader :form
+
+  def data
+    form.to_h.to_h
+  end
+end

--- a/app/services/api/update_session.rb
+++ b/app/services/api/update_session.rb
@@ -12,7 +12,11 @@ class Api::UpdateSession
       return Failure.new("Session with uuid: #{data[:uuid]} doesn't exist")
     end
 
-    Success.new(session.sync(data))
+    session.sync(data)
+
+    session.reload
+
+    Success.new(session)
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
     resource :user, only: %i[show create] do
       resources :sessions, only: %i[show], controller: 'user_sessions' do
         collection do
-          post :sync
+          post :sync # legacy API - supports mobile apps relesed before 07.2019
           post :sync2
           post :update_session
           post :delete_session

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
       resources :sessions, only: %i[show], controller: 'user_sessions' do
         collection do
           post :sync
+          post :sync2
+          post :update_session
           post :delete_session
           post :delete_session_streams
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
       resources :sessions, only: %i[show], controller: 'user_sessions' do
         collection do
           post :sync # legacy API - supports mobile apps relesed before 07.2019
-          post :sync2
+          post :sync_with_versioning
           post :update_session
           post :delete_session
           post :delete_session_streams

--- a/db/migrate/20190711105606_add_version_to_session.rb
+++ b/db/migrate/20190711105606_add_version_to_session.rb
@@ -1,0 +1,5 @@
+class AddVersionToSession < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sessions, :version, :int, default: 1
+  end
+end

--- a/db/migrate/20190716095427_fix_indexes_naming.rb
+++ b/db/migrate/20190716095427_fix_indexes_naming.rb
@@ -1,0 +1,6 @@
+class FixIndexesNaming < ActiveRecord::Migration[5.2]
+  def change
+    rename_index :sessions, 'index_sessions_on_local_end_time', 'index_sessions_on_end_time_local'
+    rename_index :sessions, 'index_sessions_on_local_start_time', 'index_sessions_on_start_time_local'
+  end
+end

--- a/db/migrate/20190716095427_fix_indexes_naming.rb
+++ b/db/migrate/20190716095427_fix_indexes_naming.rb
@@ -1,6 +1,10 @@
 class FixIndexesNaming < ActiveRecord::Migration[5.2]
   def change
-    rename_index :sessions, 'index_sessions_on_local_end_time', 'index_sessions_on_end_time_local'
-    rename_index :sessions, 'index_sessions_on_local_start_time', 'index_sessions_on_start_time_local'
+    rename_index :sessions,
+                 'index_sessions_on_local_end_time',
+                 'index_sessions_on_end_time_local'
+    rename_index :sessions,
+                 'index_sessions_on_local_start_time',
+                 'index_sessions_on_start_time_local'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_11_091153) do
+ActiveRecord::Schema.define(version: 2019_07_11_105606) do
 
   create_table "deleted_sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -95,12 +95,13 @@ ActiveRecord::Schema.define(version: 2019_06_11_091153) do
     t.decimal "latitude", precision: 12, scale: 9
     t.decimal "longitude", precision: 12, scale: 9
     t.datetime "last_measurement_at"
+    t.integer "version", default: 1
     t.index ["contribute"], name: "index_sessions_on_contribute"
     t.index ["end_time"], name: "index_sessions_on_end_time"
-    t.index ["end_time_local"], name: "index_sessions_on_end_time_local"
+    t.index ["end_time_local"], name: "index_sessions_on_local_end_time"
     t.index ["last_measurement_at"], name: "index_sessions_on_last_measurement_at"
     t.index ["start_time"], name: "index_sessions_on_start_time"
-    t.index ["start_time_local"], name: "index_sessions_on_start_time_local"
+    t.index ["start_time_local"], name: "index_sessions_on_local_start_time"
     t.index ["url_token"], name: "index_sessions_on_url_token"
     t.index ["user_id"], name: "index_sessions_on_user_id"
     t.index ["uuid"], name: "index_sessions_on_uuid"
@@ -138,10 +139,10 @@ ActiveRecord::Schema.define(version: 2019_06_11_091153) do
 
   create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "tag_id"
-    t.string "taggable_type"
     t.integer "taggable_id"
-    t.string "tagger_type"
+    t.string "taggable_type"
     t.integer "tagger_id"
+    t.string "tagger_type"
     t.string "context"
     t.datetime "created_at"
     t.index ["context"], name: "index_taggings_on_context"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_11_105606) do
+ActiveRecord::Schema.define(version: 2019_07_16_095427) do
 
   create_table "deleted_sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -98,10 +98,10 @@ ActiveRecord::Schema.define(version: 2019_07_11_105606) do
     t.integer "version", default: 1
     t.index ["contribute"], name: "index_sessions_on_contribute"
     t.index ["end_time"], name: "index_sessions_on_end_time"
-    t.index ["end_time_local"], name: "index_sessions_on_local_end_time"
+    t.index ["end_time_local"], name: "index_sessions_on_end_time_local"
     t.index ["last_measurement_at"], name: "index_sessions_on_last_measurement_at"
     t.index ["start_time"], name: "index_sessions_on_start_time"
-    t.index ["start_time_local"], name: "index_sessions_on_local_start_time"
+    t.index ["start_time_local"], name: "index_sessions_on_start_time_local"
     t.index ["url_token"], name: "index_sessions_on_url_token"
     t.index ["user_id"], name: "index_sessions_on_user_id"
     t.index ["uuid"], name: "index_sessions_on_uuid"

--- a/spec/controllers/api/user_sessions_controller_spec.rb
+++ b/spec/controllers/api/user_sessions_controller_spec.rb
@@ -167,7 +167,7 @@ describe Api::UserSessionsController do
 
   describe '#update_session' do
     it 'updates session title and tag list' do
-      session = create_session!({ title: 'old title', tag_list: 'oldtag' })
+      session = create_session!(title: 'old title', tag_list: 'oldtag' )
       new_title = 'new title'
       new_tag_list = 'newtag'
 
@@ -188,8 +188,8 @@ describe Api::UserSessionsController do
     end
 
     it 'deletes streams marked for deletion' do
-      session = create_session!({ title: 'old title', tag_list: 'oldtag' })
-      stream = create_stream!({ session: session })
+      session = create_session!( title: 'old title', tag_list: 'oldtag' )
+      stream = create_stream!( session: session )
 
       post :update_session,
            params: {
@@ -199,7 +199,7 @@ describe Api::UserSessionsController do
                tag_list: session.tag_list.to_s,
                notes: [],
                streams: {
-                 whatever: {
+                 ignored_key: {
                    sensor_package_name: stream.sensor_package_name,
                    sensor_name: stream.sensor_name,
                    deleted: true
@@ -213,8 +213,8 @@ describe Api::UserSessionsController do
     end
 
     it "updates note's text" do
-      session = create_session!({ title: 'old title', tag_list: 'oldtag' })
-      note = create_note!({ session: session })
+      session = create_session!( title: 'old title', tag_list: 'oldtag' )
+      note = create_note!( session: session )
       new_text = 'new text'
 
       post :update_session,
@@ -234,8 +234,8 @@ describe Api::UserSessionsController do
     end
 
     it 'deletes notes that are not present in the mobile app' do
-      session = create_session!({ title: 'old title', tag_list: 'oldtag' })
-      note = create_note!({ session: session })
+      session = create_session!( title: 'old title', tag_list: 'oldtag' )
+      note = create_note!( session: session )
 
       post :update_session,
            params: {
@@ -252,7 +252,7 @@ describe Api::UserSessionsController do
     end
 
     it 'returns bumped session version' do
-      session = create_session!({ version: 1 })
+      session = create_session!( version: 1 )
       post :update_session,
            params: {
              data: {
@@ -333,15 +333,10 @@ describe Api::UserSessionsController do
   private
 
   def session_data2(attributes)
-    "[
-    {  \"deleted\":#{
-      attributes.fetch(:deleted, false)
-    },
-      \"uuid\":\"#{attributes.fetch(:uuid, 'uuid')}\",
-      \"version\":#{
-      attributes.fetch(:version, 1)
-    }}
-    ]"
+    [{  deleted: attributes.fetch(:deleted, false),
+      uuid: attributes.fetch(:uuid, 'uuid'),
+      version: attributes.fetch(:version, 1)
+    }].to_json
   end
 
   def session_data(attributes)

--- a/spec/controllers/api/user_sessions_controller_spec.rb
+++ b/spec/controllers/api/user_sessions_controller_spec.rb
@@ -251,7 +251,7 @@ describe Api::UserSessionsController do
       expect(session.notes).to eq([])
     end
 
-    it 'bumps session version' do
+    it 'returns bumped session version' do
       session = create_session!({ version: 1 })
       post :update_session,
            params: {
@@ -263,8 +263,10 @@ describe Api::UserSessionsController do
                streams: {}
              }.to_json
            }
+
       session.reload
-      expect(session.version).to eq(2)
+
+      expect(json_response).to include({ version: 2 }.as_json)
     end
   end
 

--- a/spec/controllers/api/user_sessions_controller_spec.rb
+++ b/spec/controllers/api/user_sessions_controller_spec.rb
@@ -167,7 +167,7 @@ describe Api::UserSessionsController do
 
   describe '#update_session' do
     it 'updates session title and tag list' do
-      session = create_session!(title: 'old title', tag_list: 'oldtag' )
+      session = create_session!(title: 'old title', tag_list: 'oldtag')
       new_title = 'new title'
       new_tag_list = 'newtag'
 
@@ -188,8 +188,8 @@ describe Api::UserSessionsController do
     end
 
     it 'deletes streams marked for deletion' do
-      session = create_session!( title: 'old title', tag_list: 'oldtag' )
-      stream = create_stream!( session: session )
+      session = create_session!(title: 'old title', tag_list: 'oldtag')
+      stream = create_stream!(session: session)
 
       post :update_session,
            params: {
@@ -213,8 +213,8 @@ describe Api::UserSessionsController do
     end
 
     it "updates note's text" do
-      session = create_session!( title: 'old title', tag_list: 'oldtag' )
-      note = create_note!( session: session )
+      session = create_session!(title: 'old title', tag_list: 'oldtag')
+      note = create_note!(session: session)
       new_text = 'new text'
 
       post :update_session,
@@ -234,8 +234,8 @@ describe Api::UserSessionsController do
     end
 
     it 'deletes notes that are not present in the mobile app' do
-      session = create_session!( title: 'old title', tag_list: 'oldtag' )
-      note = create_note!( session: session )
+      session = create_session!(title: 'old title', tag_list: 'oldtag')
+      note = create_note!(session: session)
 
       post :update_session,
            params: {
@@ -252,7 +252,7 @@ describe Api::UserSessionsController do
     end
 
     it 'returns bumped session version' do
-      session = create_session!( version: 1 )
+      session = create_session!(version: 1)
       post :update_session,
            params: {
              data: {
@@ -270,9 +270,10 @@ describe Api::UserSessionsController do
     end
   end
 
-  describe '#sync2' do
+  describe '#sync_with_versioning' do
     it "returns session for upload when it's not present in the db" do
-      post :sync2, format: :json, params: { data: session_data2(uuid: 'abc') }
+      post :sync_with_versioning,
+           format: :json, params: { data: session_data2(uuid: 'abc') }
 
       expected = { 'download' => [], 'upload' => %w[abc], 'deleted' => [] }
 
@@ -283,7 +284,8 @@ describe Api::UserSessionsController do
       session = create_session!(user: user, uuid: 'abc')
       session.destroy
 
-      post :sync2, format: :json, params: { data: session_data2(uuid: 'abc') }
+      post :sync_with_versioning,
+           format: :json, params: { data: session_data2(uuid: 'abc') }
 
       expected = { 'download' => [], 'upload' => [], 'deleted' => %w[abc] }
 
@@ -293,7 +295,7 @@ describe Api::UserSessionsController do
     it 'deletes a session and returns it as deleted if it was mark for deletion' do
       session = create_session!(user: user, uuid: 'abc')
 
-      post :sync2,
+      post :sync_with_versioning,
            format: :json,
            params: { data: session_data2(uuid: 'abc', deleted: true) }
 
@@ -308,7 +310,7 @@ describe Api::UserSessionsController do
       stream = create_stream!(session: session)
       create_measurements!(stream: stream)
 
-      post :sync2, format: :json, params: { data: '[]' }
+      post :sync_with_versioning, format: :json, params: { data: '[]' }
 
       expected = { 'download' => %w[abc], 'upload' => [], 'deleted' => [] }
 
@@ -320,7 +322,7 @@ describe Api::UserSessionsController do
       stream = create_stream!(session: session)
       create_measurements!(stream: stream)
 
-      post :sync2,
+      post :sync_with_versioning,
            format: :json,
            params: { data: session_data2(uuid: 'abc', version: 1) }
 
@@ -333,10 +335,13 @@ describe Api::UserSessionsController do
   private
 
   def session_data2(attributes)
-    [{  deleted: attributes.fetch(:deleted, false),
-      uuid: attributes.fetch(:uuid, 'uuid'),
-      version: attributes.fetch(:version, 1)
-    }].to_json
+    [
+      {
+        deleted: attributes.fetch(:deleted, false),
+        uuid: attributes.fetch(:uuid, 'uuid'),
+        version: attributes.fetch(:version, 1)
+      }
+    ].to_json
   end
 
   def session_data(attributes)

--- a/spec/controllers/api/user_sessions_controller_spec.rb
+++ b/spec/controllers/api/user_sessions_controller_spec.rb
@@ -298,6 +298,18 @@ describe Api::UserSessionsController do
 
       expect(json_response).to eq(expected)
     end
+
+    xit "return session for download if newer version is in the db" do
+      session = create_session!(user: user,  uuid: 'abc', version: 2)
+      stream = create_stream!(session: session)
+      create_measurements!(stream: stream)
+
+      post :sync2, format: :json, params: { data: session_data(uuid: 'abc', version: 1) }
+
+      expected = { 'download' => %w[abc] , 'upload' => [], 'deleted' => [] }
+
+      expect(json_response).to eq(expected)
+    end
   end
 
   private

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -32,6 +32,7 @@ module TestUtils
       longitude: 1.0,
       latitude: 1.0,
       is_indoor: false,
+      version: attributes.fetch(:version, 1),
       contribute: attributes.fetch(:contribute, true)
     )
   end

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -103,3 +103,14 @@ module TestUtils
     )
   end
 end
+
+def create_note!(attributes = {})
+  Note.create!(
+    text: 'text',
+    date: DateTime.current,
+    latitude: 123,
+    longitude: 123,
+    session: attributes.fetch(:session),
+    number: rand(100_000)
+  )
+end


### PR DESCRIPTION
We decided to separate updating a session that was edited in the mobile app form syncing the session list. I'm still leaving the old endpoint to support old versions of mobile apps.

We added versioning to sessions to make sure that when two users use the same account the sessions would be synced correctly. So now every time session is updated via `update_session` endpoint we bump the version. And every time a user hits `sync2` we check if they have the newest version and if not we add this to the `download` array.

