### PR TITLE
Show last year's data for mobile crowdmap

### DIFF
--- a/app/controllers/api/averages_controller.rb
+++ b/app/controllers/api/averages_controller.rb
@@ -17,7 +17,7 @@ module Api
     def index
       data = prepareData(params)
 
-      data[:time_from] = data[:time_from] || Time.new(2_010).to_i
+      data[:time_from] = data[:time_from] || 1.year.ago.to_i
       data[:time_to] = data[:time_to] || Time.new(2_100).end_of_year.to_i
 
       respond_with CrowdmapAverages::ForMobile.new(data).as_json

--- a/spec/models/stream_spec.rb
+++ b/spec/models/stream_spec.rb
@@ -57,13 +57,9 @@ describe Stream do
       it 'should cause an error' do
         expect {
           stream.build_measurements!([measurement_data])
-<<<<<<< 69a3434acb87956ada8df1d9173202ecc07ad242
         }.to raise_error(
           'Measurement import failed! Failed instances: [1, 2, 3]'
         )
-=======
-        }.to raise_error('Measurement import failed! Failed instances: [1, 2, 3]')
->>>>>>> refactor: fix the test checking error messages
       end
     end
   end

--- a/spec/models/stream_spec.rb
+++ b/spec/models/stream_spec.rb
@@ -57,9 +57,13 @@ describe Stream do
       it 'should cause an error' do
         expect {
           stream.build_measurements!([measurement_data])
+<<<<<<< 69a3434acb87956ada8df1d9173202ecc07ad242
         }.to raise_error(
           'Measurement import failed! Failed instances: [1, 2, 3]'
         )
+=======
+        }.to raise_error('Measurement import failed! Failed instances: [1, 2, 3]')
+>>>>>>> refactor: fix the test checking error messages
       end
     end
   end


### PR DESCRIPTION
For sensors with a huge number of measurements, like db, the crowdmap averages are fetched too slow, even in minutes. We are limiting the data to only last year, instead of since 2010, to help with the performance. 