### PR TITLE
Adjust heat map levels

### DIFF
--- a/app/javascript/elm/src/Data/GraphData.elm
+++ b/app/javascript/elm/src/Data/GraphData.elm
@@ -1,4 +1,4 @@
-module Data.GraphData exposing (GraphData)
+module Data.GraphData exposing (GraphData, GraphHeatData)
 
 
 type alias GraphData =
@@ -6,19 +6,22 @@ type alias GraphData =
         { parameter : String
         , unit : String
         }
-    , heat :
-        { threshold1 : Int
-        , threshold5 : Int
-        , levels :
-            List
-                { from : Int
-                , to : Int
-                , className : String
-                }
-        }
+    , heat : GraphHeatData
     , times :
         { start : Int
         , end : Int
         }
     , streamIds : List Int
+    }
+
+
+type alias GraphHeatData =
+    { threshold1 : Int
+    , threshold5 : Int
+    , levels :
+        List
+            { from : Int
+            , to : Int
+            , className : String
+            }
     }

--- a/app/javascript/elm/src/Data/HeatMapThresholds.elm
+++ b/app/javascript/elm/src/Data/HeatMapThresholds.elm
@@ -5,6 +5,7 @@ module Data.HeatMapThresholds exposing
     , Threshold
     , extremes
     , fetch
+    , fitThresholds
     , fromValues
     , rangeFor
     , toDefaults
@@ -106,6 +107,54 @@ toDefaults heatMapThresholds =
     , threshold4 = resetThresholdValueToDefault heatMapThresholds.threshold4
     , threshold5 = resetThresholdValueToDefault heatMapThresholds.threshold5
     }
+
+
+fitThresholds : Maybe { min : Float, max : Float } -> HeatMapThresholds -> HeatMapThresholds
+fitThresholds maybeBounds heatMapThresholds =
+    case maybeBounds of
+        Just bounds ->
+            let
+                min =
+                    floor bounds.min
+
+                max =
+                    ceiling bounds.max
+
+                step =
+                    (max - min) // 4 |> biggest 1
+
+                threshold2 =
+                    min + step
+
+                threshold3 =
+                    threshold2 + step
+
+                threshold4 =
+                    threshold3 + step
+
+                threshold5 =
+                    threshold4 + step |> biggest max
+            in
+            updateFromValues
+                { threshold1 = min
+                , threshold2 = threshold2
+                , threshold3 = threshold3
+                , threshold4 = threshold4
+                , threshold5 = threshold5
+                }
+                heatMapThresholds
+
+        Nothing ->
+            heatMapThresholds
+
+
+biggest : Int -> Int -> Int
+biggest x y =
+    if x > y then
+        x
+
+    else
+        y
 
 
 extremes : HeatMapThresholds -> ( Int, Int )

--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -2,6 +2,7 @@ module Data.SelectedSession exposing
     ( SelectedSession
     , decoder
     , fetch
+    , measurementBounds
     , times
     , toId
     , toStreamIds
@@ -53,6 +54,23 @@ toStreamIds { streamIds } =
 toId : SelectedSession -> Int
 toId { id } =
     id
+
+
+measurementBounds : SelectedSession -> Maybe { min : Float, max : Float }
+measurementBounds session =
+    let
+        maybeMin =
+            List.minimum session.selectedMeasurements
+
+        maybeMax =
+            List.maximum session.selectedMeasurements
+    in
+    case ( maybeMin, maybeMax ) of
+        ( Just min, Just max ) ->
+            Just { min = min, max = max }
+
+        _ ->
+            Nothing
 
 
 millisToPosixDecoder : Decoder Posix

--- a/app/javascript/elm/src/Ports.elm
+++ b/app/javascript/elm/src/Ports.elm
@@ -25,6 +25,7 @@ port module Ports exposing
     , toggleSession
     , toggleSessionSelection
     , toggleTheme
+    , updateGraphYAxis
     , updateHeatMapThresholds
     , updateHeatMapThresholdsFromAngular
     , updateIsHttping
@@ -34,7 +35,7 @@ port module Ports exposing
     , updateTags
     )
 
-import Data.GraphData exposing (GraphData)
+import Data.GraphData exposing (GraphData, GraphHeatData)
 import Data.HeatMapThresholds exposing (HeatMapThresholdValues)
 import Data.Session exposing (Location)
 import Json.Encode as Encode
@@ -137,3 +138,6 @@ port observeSessionsList : () -> Cmd a
 
 
 port toggleTheme : String -> Cmd a
+
+
+port updateGraphYAxis : GraphHeatData -> Cmd a

--- a/app/javascript/elm/tests/Data/HeatMapThresholdsTests.elm
+++ b/app/javascript/elm/tests/Data/HeatMapThresholdsTests.elm
@@ -74,7 +74,7 @@ suite =
                         , threshold4 = 3
                         , threshold5 = 4
                         }
-        , test "fitThresholds sets the uppper threshold always bigger than max bound and bootom threshold always smaller than min bound" <|
+        , test "fitThresholds sets the upper threshold always bigger than max bound and bottom threshold always smaller than min bound" <|
             \_ ->
                 let
                     bounds =

--- a/app/javascript/elm/tests/Data/HeatMapThresholdsTests.elm
+++ b/app/javascript/elm/tests/Data/HeatMapThresholdsTests.elm
@@ -74,7 +74,7 @@ suite =
                         , threshold4 = 3
                         , threshold5 = 4
                         }
-        , test "fitThresholds sets the upper threshold always bigger than max bound and bottom threshold always smaller than min bound" <|
+        , test "fitThresholds sets the uppper threshold always bigger than max bound and bootom threshold always smaller than min bound" <|
             \_ ->
                 let
                     bounds =

--- a/app/javascript/elm/tests/Data/HeatMapThresholdsTests.elm
+++ b/app/javascript/elm/tests/Data/HeatMapThresholdsTests.elm
@@ -1,6 +1,6 @@
 module Data.HeatMapThresholdsTests exposing (suite)
 
-import Data.HeatMapThresholds exposing (HeatMapThresholds, Threshold, toValues, updateMaximum, updateMinimum)
+import Data.HeatMapThresholds exposing (HeatMapThresholds, Threshold, fitThresholds, toValues, updateMaximum, updateMinimum)
 import Expect
 import Test exposing (..)
 
@@ -41,5 +41,53 @@ suite =
                         , threshold3 = 2
                         , threshold4 = 3
                         , threshold5 = 4
+                        }
+        , test "fitThresholds sets the thresholds evenly between bounds" <|
+            \_ ->
+                let
+                    bounds =
+                        Just { min = 0.0, max = 40.0 }
+                in
+                thresholds
+                    |> fitThresholds bounds
+                    |> toValues
+                    |> Expect.equal
+                        { threshold1 = 0
+                        , threshold2 = 10
+                        , threshold3 = 20
+                        , threshold4 = 30
+                        , threshold5 = 40
+                        }
+        , test "fitThresholds sets the thresholds 1 point apart if the diff between bounds < 4" <|
+            \_ ->
+                let
+                    bounds =
+                        Just { min = 0.0, max = 3.0 }
+                in
+                thresholds
+                    |> fitThresholds bounds
+                    |> toValues
+                    |> Expect.equal
+                        { threshold1 = 0
+                        , threshold2 = 1
+                        , threshold3 = 2
+                        , threshold4 = 3
+                        , threshold5 = 4
+                        }
+        , test "fitThresholds sets the uppper threshold always bigger than max bound and bootom threshold always smaller than min bound" <|
+            \_ ->
+                let
+                    bounds =
+                        Just { min = 0.9, max = 40.1 }
+                in
+                thresholds
+                    |> fitThresholds bounds
+                    |> toValues
+                    |> Expect.equal
+                        { threshold1 = 0
+                        , threshold2 = 10
+                        , threshold3 = 20
+                        , threshold4 = 30
+                        , threshold5 = 41
                         }
         ]

--- a/app/javascript/javascript/graph.js
+++ b/app/javascript/javascript/graph.js
@@ -191,9 +191,6 @@ const draw = ({
 }) => {
   const low = heat.threshold1;
   const high = heat.threshold5;
-  const tick = Math.round((high - low) / 4);
-  const ticks = [low, low + tick, low + 2 * tick, high - tick, high];
-
   const series = [
     {
       name: sensor.parameter,
@@ -209,7 +206,7 @@ const draw = ({
     xAxis,
     low,
     high,
-    ticks,
+    ticks: buildTicks(low, high),
     scrollbar,
     measurementType: sensor.parameter,
     unitSymbol: sensor.unit,
@@ -262,3 +259,25 @@ const getValuesInRange = (data, min, max) =>
   data
     .filter(dataPoint => dataPoint.x >= min && dataPoint.x <= max)
     .map(dataPoint => dataPoint.y);
+
+export const updateYAxis = heat => {
+  const min = heat.threshold1;
+  const max = heat.threshold5;
+  const options = {
+    yAxis: {
+      plotBands: heat.levels,
+      min: min,
+      max: max,
+      tickPositions: buildTicks(min, max)
+    }
+  };
+
+  if (chart) {
+    chart.update(options);
+  }
+};
+
+const buildTicks = (low, high) => {
+  const tick = Math.round((high - low) / 4);
+  return [low, low + tick, low + 2 * tick, high - tick, high];
+};

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -198,6 +198,10 @@ const setupHeatMap = () => {
       draw(graph.fetchAndDrawMobile(callback))
     );
 
+    window.__elmApp.ports.updateGraphYAxis.subscribe(heat => {
+      graph.updateYAxis(heat);
+    });
+
     window.__elmApp.ports.observeSessionsList.subscribe(() => {
       createObserver({
         selector: ".session-cards-container",


### PR DESCRIPTION
Added a button that adjusts heatmap levels to fit the measurements that are currently displayed on the graph.
It's only visible on a single session view.

Then I changed what happens to the graph when heat map level change. Cause before we were reloading the entire graph. This had a side effect of resetting the graph zoom level to default (and also took a lot of time to fetch the measurement again). Now we only update the graph y-axis options.
