### PR TITLE
Make indoor sessions truly anonymous

### DIFF
--- a/app/javascript/angular/tests/session.test.js
+++ b/app/javascript/angular/tests/session.test.js
@@ -25,23 +25,9 @@ test("when title is present it uses it", t => {
   t.end();
 });
 
-test("when session is indoor it uses anonymous as username", t => {
-  const session = {
-    is_indoor: true,
-    selectedStream: {}
-  };
-
-  const actual = Session.formatSessionForList(session);
-
-  t.deepEqual(actual.username, "anonymous");
-
-  t.end();
-});
-
-test("when session is outdoor it uses its username", t => {
+test("when returns a username", t => {
   const username = "user1234";
   const session = {
-    is_indoor: false,
     username,
     selectedStream: {}
   };

--- a/app/javascript/javascript/values/session.js
+++ b/app/javascript/javascript/values/session.js
@@ -1,6 +1,6 @@
 export const formatSessionForList = session => ({
   title: session.title || "unnamed",
-  username: session.is_indoor ? "anonymous" : session.username,
+  username: session.username,
   id: session.id,
   startTime: session.startTime,
   endTime: session.endTime,

--- a/app/services/api/to_active_sessions_array.rb
+++ b/app/services/api/to_active_sessions_array.rb
@@ -19,7 +19,7 @@ class Api::ToActiveSessionsArray
             latitude: session.latitude,
             longitude: session.longitude,
             type: session.type,
-            username: session.user.username,
+            username: session.is_indoor ? 'anonymous' : session.user.username,
             streams:
               session.streams.reduce({}) do |acc, stream|
                 acc.merge(

--- a/app/services/api/to_dormant_sessions_array.rb
+++ b/app/services/api/to_dormant_sessions_array.rb
@@ -18,7 +18,7 @@ class Api::ToDormantSessionsArray
             latitude: session.latitude,
             longitude: session.longitude,
             type: session.type,
-            username: session.user.username,
+            username: session.is_indoor ? 'anonymous' : session.user.username,
             streams:
               session.streams.reduce({}) do |acc, stream|
                 acc.merge(

--- a/app/services/api/to_session_hash.rb
+++ b/app/services/api/to_session_hash.rb
@@ -14,7 +14,7 @@ class Api::ToSessionHash
 
     Success.new(
       title: session.title,
-      username: session.user.username,
+      username: session.is_indoor ? 'anonymous' : session.user.username,
       sensorName: session.streams.first.sensor_name,
       startTime: format_time(session.start_time_local),
       endTime: format_time(session.end_time_local),

--- a/spec/controllers/api/fixed/active/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/active/sessions_controller_spec.rb
@@ -140,7 +140,7 @@ describe Api::Fixed::Active::SessionsController do
       start_time_local: time,
       end_time: DateTime.current,
       end_time_local: time,
-      is_indoor: true,
+      is_indoor: false,
       latitude: latitude,
       longitude: longitude,
       contribute: contribute,

--- a/spec/controllers/api/fixed/dormant/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/dormant/sessions_controller_spec.rb
@@ -139,7 +139,7 @@ describe Api::Fixed::Dormant::SessionsController do
       start_time_local: time,
       end_time: DateTime.current,
       end_time_local: time,
-      is_indoor: true,
+      is_indoor: false,
       latitude: latitude,
       longitude: longitude,
       contribute: contribute,


### PR DESCRIPTION
This way even if someone checks the network response in the console, they won't see the usernames.