### PR TITLE
Popup tweaks

### DIFF
--- a/app/javascript/elm/src/Data/SelectedSession.elm
+++ b/app/javascript/elm/src/Data/SelectedSession.elm
@@ -180,7 +180,7 @@ view session heatMapThresholds linkIcon toMsg showExportPopup popup emailForm =
             [ button [ class "button button--primary action-button action-button--export", Popup.clickWithoutDefault showExportPopup ] [ text "export session" ]
             , button [ class "button button--primary action-button action-button--copy-link", Events.onClick <| toMsg tooltipId, id tooltipId ] [ img [ src (Path.toString linkIcon), alt "Link icon" ] [] ]
             , if Popup.isEmailFormPopupShown popup then
-                Popup.viewEmailForm emailForm
+                emailForm
 
               else
                 text ""

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -1115,7 +1115,7 @@ viewFiltersButtons selectedSession sessions linkIcon popup emailForm =
                 , button [ class "button button--primary action-button action-button--copy-link", Events.onClick <| ShowCopyLinkTooltip tooltipId, id tooltipId ]
                     [ img [ src <| Path.toString linkIcon, alt "Link icon" ] [] ]
                 , if Popup.isEmailFormPopupShown popup then
-                    Popup.viewEmailForm (EmailForm.view emailForm ExportSessions NoOp UpdateEmailFormValue)
+                    EmailForm.view emailForm ExportSessions NoOp UpdateEmailFormValue
 
                   else
                     text ""

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -357,7 +357,7 @@ update msg model =
             ( { model | popup = popup, isPopupListExpanded = False, overlay = Overlay.update (AddOverlay PopupOverlay) model.overlay }, Cmd.none )
 
         ShowExportPopup ->
-            ( { model | popup = Popup.EmailForm }, Cmd.none )
+            ( { model | popup = Popup.EmailForm, overlay = Overlay.update (RemoveOverlay PopupOverlay) model.overlay }, Cmd.none )
 
         ExportSessions emailFormResult ->
             let

--- a/app/javascript/elm/src/Popup.elm
+++ b/app/javascript/elm/src/Popup.elm
@@ -1,4 +1,4 @@
-module Popup exposing (Popup(..), clickWithoutDefault, isEmailFormPopupShown, isParameterPopupShown, isSensorPopupShown, viewEmailForm, viewListPopup)
+module Popup exposing (Popup(..), clickWithoutDefault, isEmailFormPopupShown, isParameterPopupShown, isSensorPopupShown, viewListPopup)
 
 import Html exposing (Html, button, div, text)
 import Html.Attributes exposing (class, classList, id)
@@ -45,11 +45,6 @@ viewListPopup toggle onSelect isListExpanded ( main, others ) itemType selectedI
                   else
                     togglePopupStateButton ("more " ++ itemType) toggle
                 ]
-
-
-viewEmailForm : Html msg -> Html msg
-viewEmailForm emailForm =
-    emailForm
 
 
 togglePopupStateButton : String -> msg -> Html msg


### PR DESCRIPTION
- remove obsolete `Popup.viewEmailForm` function
- clear semi-transparent overlay when opening "export sessions" popup, which closes other popups that the overlay made sense with