### PR TITLE
UI: Tweak redo search styles

### DIFF
--- a/app/assets/stylesheets/modules/map-search-control.css.scss
+++ b/app/assets/stylesheets/modules/map-search-control.css.scss
@@ -37,9 +37,9 @@ $search-control-width: 300px;
 }
 
 .search-control__switch {
-  background: white;
-  border-radius: 2px;
-  box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 1px;
+  background: $dark-blue;
+  border-radius: $input-radius;
+  color: white;
   display: inline-block;
   height: 25px;
   padding-left: 10px;
@@ -50,7 +50,7 @@ $search-control-width: 300px;
 }
 
 .search-control__button {
-  border-radius: 4px;
+  border-radius: $input-radius;
   box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 1px;
   font-size: 13px;
   font-weight: bold;
@@ -75,7 +75,7 @@ label[for="checkbox-search-as-i-move"] {
   cursor: pointer;
   display: inline-block;
   font-size: 13px;
-  font-weight: $font-stack-regular;
+  font-weight: $font-stack-bold;
   line-height: 18px;
   padding: 4px 25px 3px 0;
 


### PR DESCRIPTION
Changes "Redo search when map is moved" element's layout.

<img width="1021" alt="Screenshot 2019-08-20 at 19 37 29" src="https://user-images.githubusercontent.com/457999/63370275-22e35780-c382-11e9-8993-abc53d7e8921.png">
