### PR TITLE
Prevent mobile browser keyboard popping up when tapping on the date range input

### DIFF
--- a/app/assets/stylesheets/config/utilities.css.scss
+++ b/app/assets/stylesheets/config/utilities.css.scss
@@ -3,3 +3,9 @@
     display: none;
   }
 }
+
+.u--hide-on-mobile {
+  @media screen and (max-width: $mobile) {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/global/forms.css.scss
+++ b/app/assets/stylesheets/global/forms.css.scss
@@ -14,11 +14,9 @@ input {
 
   &[disabled] {
     opacity: 0.4;
-    transition: opacity 0.5s;
 
     & + label {
       opacity: 0.4;
-      transition: opacity 0.5s;
     }
   }
 }

--- a/app/assets/stylesheets/modules/buttons.css.scss
+++ b/app/assets/stylesheets/modules/buttons.css.scss
@@ -15,6 +15,24 @@
   color: white;
 }
 
+.button--input {
+  border: none;
+  border-radius: $input-radius;
+  font-size: $small-font;
+  line-height: 2.2;
+  padding: 0 7px;
+  text-align: left;
+  transition: opacity 0.5s;
+
+  &[disabled] {
+    opacity: 0.4;
+
+    & + label {
+      opacity: 0.4;
+    }
+  }
+}
+
 .time-frame-button {
   font-size: $tiny-font;
   font-weight: $font-stack-bold;

--- a/app/assets/stylesheets/modules/filters.css.scss
+++ b/app/assets/stylesheets/modules/filters.css.scss
@@ -78,3 +78,15 @@
   text-decoration: underline !important;
   margin: 0 !important;
 }
+
+@media screen and (max-width: $mobile) {
+  [name="time-range"] {
+    display: none;
+  }
+}
+
+@media screen and (min-width: $ipad-portrait) {
+  [name="time-range-button"] {
+    display: none;
+  }
+}

--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -148,9 +148,17 @@ export const FixedSessionsMapCtrl = (
       };
 
       const setupActiveTimeRangeFilter = (timeFrom, timeTo) => {
-        if (document.getElementById("time-range")) {
+        if (
+          document.getElementById("time-range") &&
+          document.getElementById("time-range-button")
+        ) {
           $("#time-range").daterangepicker(
             FiltersUtils.daterangepickerConfig(timeFrom, timeTo)
+          );
+
+          $("#time-range-button").daterangepicker(
+            FiltersUtils.daterangepickerConfig(timeFrom, timeTo),
+            FiltersUtils.setTimerangeButtonText(timeFrom, timeTo)
           );
         } else {
           window.setTimeout(setupActiveTimeRangeFilter(timeFrom, timeTo), 100);
@@ -189,7 +197,6 @@ export const FixedSessionsMapCtrl = (
             FiltersUtils.endOfToday(),
             elmApp.ports.isShowingTimeRangeFilter.send
           );
-
           onTimeRangeChanged(
             FiltersUtils.oneYearAgo(),
             FiltersUtils.endOfToday()

--- a/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_fixed_sessions_map_ctrl.js
@@ -143,6 +143,7 @@ export const FixedSessionsMapCtrl = (
 
       const onTimeRangeChanged = (timeFrom, timeTo) => {
         elmApp.ports.timeRangeSelected.send({ timeFrom, timeTo });
+        FiltersUtils.setTimerangeButtonText(timeFrom, timeTo);
         params.update({ data: { timeFrom, timeTo } });
         $scope.sessions.fetch();
       };

--- a/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
+++ b/app/javascript/angular/code/controllers/_mobile_sessions_map_ctrl.js
@@ -158,7 +158,7 @@ export const MobileSessionsMapCtrl = (
 
       const onTimeRangeChanged = (timeFrom, timeTo) => {
         elmApp.ports.timeRangeSelected.send({ timeFrom, timeTo });
-
+        FiltersUtils.setTimerangeButtonText(timeFrom, timeTo);
         params.update({ data: { timeFrom, timeTo } });
         $scope.sessions.fetch();
       };

--- a/app/javascript/elm/src/TimeRange.elm
+++ b/app/javascript/elm/src/TimeRange.elm
@@ -72,8 +72,25 @@ view refreshTimeRange status tooltipIcon resetIcon =
             , disabled (status == Active)
             ]
             []
-        , label [ for "time-range" ] [ text "time frame:" ]
+        , label
+            [ class "u--hide-on-mobile"
+            , for "time-range"
+            ]
+            [ text "time frame:" ]
+        , label
+            [ class "u--show-on-mobile"
+            ]
+            [ text "time frame:" ]
         , Tooltip.view Tooltip.timeRangeFilter tooltipIcon
-        , button [ ariaLabel "Reset time frame", class "refresh-timerange-button", Events.onClick refreshTimeRange ]
-            [ img [ src (Path.toString resetIcon), alt "Reset icon" ] [] ]
+        , button
+            [ ariaLabel "Reset time frame"
+            , class "refresh-timerange-button"
+            , Events.onClick refreshTimeRange
+            ]
+            [ img
+                [ src (Path.toString resetIcon)
+                , alt "Reset icon"
+                ]
+                []
+            ]
         ]

--- a/app/javascript/elm/src/TimeRange.elm
+++ b/app/javascript/elm/src/TimeRange.elm
@@ -59,12 +59,16 @@ view refreshTimeRange status tooltipIcon resetIcon =
         [ input
             [ id "time-range"
             , attribute "autocomplete" "off"
-            , class "input-dark"
-            , class "input-filters"
-            , class "input-time"
-            , placeholder "time frame"
-            , type_ "text"
+            , class "input-dark input-filters input-time"
             , name "time-range"
+            , disabled (status == Active)
+            ]
+            []
+        , button
+            [ id "time-range-button"
+            , attribute "autocomplete" "off"
+            , class "input-dark input-filters input-time button--input"
+            , name "time-range-button"
             , disabled (status == Active)
             ]
             []

--- a/app/javascript/elm/tests/TimeRangeTests.elm
+++ b/app/javascript/elm/tests/TimeRangeTests.elm
@@ -4,6 +4,7 @@ import Data.Status exposing (Status(..))
 import Expect
 import Fuzz exposing (bool, int)
 import Html.Attributes exposing (disabled)
+import Html.Attributes.Aria exposing (ariaLabel)
 import Json.Encode as Encode
 import Test exposing (..)
 import Test.Html.Event as Event
@@ -50,11 +51,11 @@ all =
                 in
                 TimeRange.update TimeRange.defaultTimeRange value
                     |> Expect.equal expected
-        , test "viewTimeFilter has a button" <|
+        , test "viewTimeFilter has a reset time frame button" <|
             \_ ->
                 TimeRange.view Msg Active defaultIcon defaultIcon
                     |> Query.fromHtml
-                    |> Query.find [ tag "button" ]
+                    |> Query.find [ attribute <| ariaLabel "Reset time frame" ]
                     |> Event.simulate Event.click
                     |> Event.expect Msg
         ]

--- a/app/javascript/javascript/filtersUtils.js
+++ b/app/javascript/javascript/filtersUtils.js
@@ -21,27 +21,31 @@ export const presentMoment = () =>
     .format("X");
 
 export const oneHourAgo = () =>
-  moment()
+  moment
     .utc()
     .subtract(1, "hour")
     .format("X");
+
+const humanTime = time =>
+  moment
+    .unix(time)
+    .utc()
+    .format("MM/DD/YY HH:mm");
 
 export const daterangepickerConfig = (timeFrom, timeTo) => ({
   linkedCalendars: false,
   timePicker: true,
   timePicker24Hour: true,
-  startDate: moment
-    .unix(timeFrom)
-    .utc()
-    .format("MM/DD/YY HH:mm"),
-  endDate: moment
-    .unix(timeTo)
-    .utc()
-    .format("MM/DD/YY HH:mm"),
+  startDate: humanTime(timeFrom),
+  endDate: humanTime(timeTo),
   locale: {
     format: "MM/DD/YY HH:mm"
   }
 });
+
+export const setTimerangeButtonText = (timeFrom, timeTo) => {
+  $("#time-range-button").html(humanTime(timeFrom) + " - " + humanTime(timeTo));
+};
 
 export const setupTimeRangeFilter = (
   onTimeRangeChanged,
@@ -49,7 +53,10 @@ export const setupTimeRangeFilter = (
   timeTo,
   onIsVisibleChange
 ) => {
-  if (document.getElementById("time-range")) {
+  if (
+    document.getElementById("time-range") &&
+    document.getElementById("time-range-button")
+  ) {
     $("#time-range").daterangepicker(
       daterangepickerConfig(timeFrom, timeTo),
       function(timeFrom, timeTo) {
@@ -62,6 +69,18 @@ export const setupTimeRangeFilter = (
 
     $("#time-range").on("show.daterangepicker", () => onIsVisibleChange(true));
     $("#time-range").on("hide.daterangepicker", () => onIsVisibleChange(false));
+
+    $("#time-range-button").daterangepicker(
+      daterangepickerConfig(timeFrom, timeTo),
+      function(timeFrom, timeTo) {
+        onTimeRangeChanged(
+          timeFrom.utcOffset(0, true).unix(),
+          timeTo.utcOffset(0, true).unix()
+        );
+      }
+    );
+
+    setTimerangeButtonText(timeFrom, timeTo);
   } else {
     window.setTimeout(
       setupTimeRangeFilter(

--- a/app/javascript/javascript/filtersUtils.js
+++ b/app/javascript/javascript/filtersUtils.js
@@ -80,6 +80,25 @@ export const setupTimeRangeFilter = (
       }
     );
 
+    // update value of the default time range input when setting date via button
+    $("#time-range-button").on("apply.daterangepicker", (_, mobilePicker) => {
+      const newStartDate = mobilePicker.startDate;
+      const newEndDate = mobilePicker.endDate;
+
+      const desktopPicker = $("#time-range").data("daterangepicker");
+      desktopPicker.setStartDate(newStartDate);
+      desktopPicker.setEndDate(newEndDate);
+    });
+
+    $("#time-range").on("apply.daterangepicker", (_, desktopPicker) => {
+      const newStartDate = desktopPicker.startDate;
+      const newEndDate = desktopPicker.endDate;
+
+      const mobilePicker = $("#time-range-button").data("daterangepicker");
+      mobilePicker.setStartDate(newStartDate);
+      mobilePicker.setEndDate(newEndDate);
+    });
+
     setTimerangeButtonText(timeFrom, timeTo);
   } else {
     window.setTimeout(


### PR DESCRIPTION
The solution is to have two alternative, identical elements:
- a button displayed for "mobile" viewports
- the regular input displayed for wider viewports