### PR TITLE
GTM snippet after the body tag starts

### DIFF
--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -871,17 +871,9 @@ setScrollPosition value =
 viewDocument : Model -> Browser.Document Msg
 viewDocument model =
     { title = "AirCasting"
-    , body = [ view model ]
+    , body = [ snippetGoogleTagManager 
+    ,  view model ]
     }
-
-
-view : Model -> Html Msg
-view model =
-    div [ id "elm-app", class (Theme.toString model.theme) ]
-        [ snippetGoogleTagManager
-        , viewNav model.navLogo model.isNavExpanded model.sensors model.selectedSensorId model.page
-        , viewMain model
-        ]
 
 
 snippetGoogleTagManager =
@@ -894,6 +886,14 @@ snippetGoogleTagManager =
             , attribute "width" "0"
             ]
             []
+        ]
+
+
+view : Model -> Html Msg
+view model =
+    div [ id "elm-app", class (Theme.toString model.theme) ]
+        [ viewNav model.navLogo model.isNavExpanded model.sensors model.selectedSensorId model.page
+        , viewMain model
         ]
 
 


### PR DESCRIPTION
Google Tag Assistant still have problems with reading the noscript snippet in the body (/fixed_map and /mobile_map), because it's in div and not right after the body tag starts.