### PR TITLE
Average long mobile streams

### DIFF
--- a/app/models/averaging_rules.rb
+++ b/app/models/averaging_rules.rb
@@ -1,0 +1,19 @@
+class AveragingRules
+  def initialize(rules)
+    @rules = rules
+  end
+
+  def self.add(threshold:, window:)
+    self.new([[threshold, window]])
+  end
+
+  def add(threshold:, window:)
+    self.class.new(@rules + [[threshold, window]])
+  end
+
+  def window_size(total:)
+    @rules.filter do |threshold, _|
+      total > threshold
+    end.max { |(t1, _), (t2, _)| t1 <=> t2 }&.second
+  end
+end

--- a/app/repositories/streams_find_each.rb
+++ b/app/repositories/streams_find_each.rb
@@ -1,0 +1,9 @@
+class StreamsFindEach
+  def initialize(streams: Stream.belong_to_mobile_sessions)
+    @streams = streams
+  end
+
+  def call
+    @streams.find_each { |stream| yield stream }
+  end
+end

--- a/app/services/average_streams.rb
+++ b/app/services/average_streams.rb
@@ -1,0 +1,66 @@
+class AverageStreams
+  def initialize(
+    rules: AveragingRules.add(threshold: 14_400, window: 5).add(
+      threshold: 32_400, window: 60
+    ),
+    streams_find_each: StreamsFindEach.new,
+    streams_repository: StreamsRepository.new,
+    logger: Rails.logger
+  )
+    @rules = rules
+    @streams_find_each = streams_find_each
+    @streams_repository = streams_repository
+    @logger = logger
+  end
+
+  def call
+    @streams_find_each.call do |stream|
+      next if average_stream(stream) == :next
+      @streams_repository.calculate_average_value!(stream)
+    end
+  end
+
+  private
+
+  def average_stream(stream)
+    ids = stream.measurements.order('time ASC').pluck(:id)
+    window_size = @rules.window_size(total: ids.count)
+    if window_size.nil?
+      @logger.info(
+        "Stream ##{stream.id} having #{ids.size} measurements skipped."
+      )
+      return :next
+    end
+    @logger.info(
+      "Averaging stream ##{stream.id} having #{
+        ids.size
+      } measurements with a window of #{window_size} size"
+    )
+    Stream.transaction do
+      measurements_windows(ids, window_size) do |window|
+        average_measurements(window)
+      end
+    end
+  end
+
+  # cannot use `find_each` or similar because they do not guarantee ordering
+  def measurements_windows(all_ids, window)
+    all_ids.each_slice(query_window_from(window)) do |ids|
+      Measurement.where(id: ids).order('time ASC').each_slice(window)
+        .each { |measurement| yield measurement }
+    end
+  end
+
+  def average_measurements(measurements)
+    middle = measurements[measurements.size / 2]
+    average = measurements.map(&:value).reduce(:+) / measurements.size
+    middle.update!(value: average)
+    (measurements - [middle]).each(&:destroy!)
+  end
+
+  # returns number as close as 1_000 which is what `find_each` uses by default
+  def query_window_from(amount)
+    return amount if amount > 1_000
+    query_window_from(amount * 2)
+  end
+end

--- a/lib/aircasting/bomb_server_with_measurements.rb
+++ b/lib/aircasting/bomb_server_with_measurements.rb
@@ -32,7 +32,7 @@ module AirCasting
                   timezone_offset: 0,
                   milliseconds: 141,
                   measured_value: 60.06220481546737,
-                  value: 60.06220481546737
+                  value: i % 60
                 }
               end,
             sensor_package_name: 'Builtin',

--- a/spec/models/stream_spec.rb
+++ b/spec/models/stream_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
 
 describe Stream do
-  let(:stream) { FactoryBot.create(:stream) }
-  let!(:measurement) { FactoryBot.create(:measurement, stream: stream) }
-
   describe '#build_measurements!' do
+    let(:stream) { FactoryBot.create(:stream) }
+    let(:measurement) { FactoryBot.create(:measurement, stream: stream) }
     let(:measurement_data) { double('measurement data') }
 
     before do
@@ -46,20 +45,14 @@ describe Stream do
     end
   end
 
-  describe '#destroy' do
-    it 'should destroy measurements' do
-      stream.reload.destroy
-
-      expect(Measurement.exists?(measurement.id)).to be(false)
-    end
-  end
-
   describe '.as_json' do
-    subject { stream.as_json(methods: %i[measurements]) }
-
     it 'should include stream size and measurements' do
-      expect(subject['size']).not_to be_nil
-      expect(subject['measurements']).not_to be_nil
+      stream = FactoryBot.create(:stream)
+
+      actual = stream.as_json(methods: %i[measurements])
+
+      expect(actual['size']).not_to be_nil
+      expect(actual['measurements']).not_to be_nil
     end
   end
 
@@ -104,6 +97,19 @@ describe Stream do
             Stream.with_usernames([user.username, user2.username])
           ).to include stream, stream2
         end
+      end
+    end
+
+    describe '#belong_to_mobile_sessions' do
+      it 'returns only mobile streams' do
+        mobile_session = create_mobile_session!
+        mobile_stream = create_stream!(session: mobile_session)
+        fixed_session = create_fixed_session!
+        fixed_stream = create_stream!(session: fixed_session)
+
+        expect(Stream.belong_to_mobile_sessions).to contain_exactly(
+          mobile_stream
+        )
       end
     end
   end

--- a/spec/services/average_streams_spec.rb
+++ b/spec/services/average_streams_spec.rb
@@ -1,0 +1,181 @@
+require 'rails_helper'
+
+describe AverageStreams do
+  it 'with amount of measurements less than the threshold measurements are not averaged' do
+    session = create_mobile_session!
+    stream = create_stream!(session: session)
+    measurements = [
+      create_measurement!(stream: stream),
+      create_measurement!(stream: stream)
+    ]
+
+    AverageStreams.new(
+      rules:
+        AveragingRules.add(threshold: measurements.size + 1, window: random_int)
+    )
+      .call
+
+    expect(Measurement.count).to eq(measurements.size)
+    expect(stream.attributes).to eq(Stream.first.attributes)
+    expect(measurements.map(&:attributes)).to eq(
+      Measurement.all.map(&:attributes)
+    )
+  end
+
+  it 'with amount of measurements equal to the threshold measurements are not averaged' do
+    session = create_mobile_session!
+    stream = create_stream!(session: session)
+    measurements = [
+      create_measurement!(stream: stream),
+      create_measurement!(stream: stream)
+    ]
+
+    AverageStreams.new(
+      rules:
+        AveragingRules.add(threshold: measurements.size, window: random_int)
+    )
+      .call
+
+    expect(Measurement.count).to eq(measurements.size)
+    expect(stream.attributes).to eq(Stream.first.attributes)
+    expect(measurements.map(&:attributes)).to eq(
+      Measurement.all.map(&:attributes)
+    )
+  end
+
+  it 'with amount of measurements above the threshold measurements are averaged in groups of window size by keeping the middle measurement' do
+    session = create_mobile_session!
+    stream = create_stream!(session: session)
+    middle_1 =
+      create_measurement!(stream: stream, value: 1, time: DateTime.current)
+    middle_2 =
+      create_measurement!(
+        stream: stream, value: 4, time: DateTime.current + 3.days
+      )
+    create_measurement!(
+      stream: stream, value: 2, time: DateTime.current + 1.day
+    )
+    create_measurement!(
+      stream: stream, value: 0, time: DateTime.current - 1.day
+    )
+    create_measurement!(
+      stream: stream, value: 3, time: DateTime.current + 2.days
+    )
+
+    AverageStreams.new(rules: AveragingRules.add(threshold: 2, window: 3)).call
+
+    expect(Measurement.count).to eq(2)
+    expect(Measurement.first.attributes).to eq(
+      middle_1.attributes.merge('value' => 1)
+    )
+    expect(Measurement.second.attributes).to eq(
+      middle_2.attributes.merge('value' => 3.5)
+    )
+  end
+
+  it 'when measurements are averaged then the average value on the stream is recalculated' do
+    session = create_mobile_session!
+    stream = create_stream!(session: session, average_value: random_int)
+    [1, 2].map { |value| create_measurement!(stream: stream, value: value) }
+
+    AverageStreams.new(
+      rules: AveragingRules.add(threshold: 1, window: random_int)
+    )
+      .call
+
+    expect(Stream.all.map(&:average_value)).to eq([1.5])
+  end
+
+  it 'when measurements are not averaged then the average value on the stream is not recalculated' do
+    session = create_mobile_session!
+    stream = create_stream!(session: session, average_value: random_int)
+    [1, 2].map { |value| create_measurement!(stream: stream, value: value) }
+
+    AverageStreams.new(
+      rules: AveragingRules.add(threshold: 2, window: random_int)
+    )
+      .call
+
+    expect(Stream.all.map(&:average_value)).to eq([stream.average_value])
+  end
+
+  it 'when more than one rule has a threshold smaller than the amount of measurements it uses the rule with the biggest threshold' do
+    session = create_mobile_session!
+    stream = create_stream!(session: session)
+    3.times { |_| create_measurement!(stream: stream) }
+
+    AverageStreams.new(
+      rules:
+        AveragingRules.add(threshold: 1, window: 2).add(threshold: 2, window: 3)
+    )
+      .call
+
+    expect(Measurement.count).to eq(1)
+  end
+
+  it 'with a window bigger than the amount of measurements it averages all the measurements' do
+    session = create_mobile_session!
+    stream = create_stream!(session: session)
+    middle =
+      create_measurement!(stream: stream, value: 1, time: DateTime.current)
+    create_measurement!(
+      stream: stream, value: 2, time: DateTime.current + 1.day
+    )
+    create_measurement!(
+      stream: stream, value: 0, time: DateTime.current - 1.day
+    )
+
+    AverageStreams.new(rules: AveragingRules.add(threshold: 1, window: 4)).call
+
+    expect(Measurement.all.map(&:attributes)).to eq(
+      [middle.attributes.merge('value' => 1)]
+    )
+  end
+
+  it 'averages multiple streams' do
+    session = create_mobile_session!
+    stream_1 = create_stream!(session: session)
+    create_measurement!(stream: stream_1, value: 1)
+    create_measurement!(stream: stream_1, value: 2)
+    stream_2 = create_stream!(session: session)
+    create_measurement!(stream: stream_2, value: 3)
+    create_measurement!(stream: stream_2, value: 4)
+
+    AverageStreams.new(rules: AveragingRules.add(threshold: 1, window: 2)).call
+
+    expect(stream_1.measurements.count).to eq(1)
+    expect(stream_2.measurements.count).to eq(1)
+  end
+
+  it 'averages only the streams the repository yields' do
+    session = create_mobile_session!
+    stream_1 = create_stream!(session: session)
+    create_measurement!(stream: stream_1, value: 1)
+    create_measurement!(stream: stream_1, value: 2)
+    stream_2 = create_stream!(session: session)
+    create_measurement!(stream: stream_2, value: 3)
+    create_measurement!(stream: stream_2, value: 4)
+    streams_find_each =
+      StreamsFindEach.new(streams: Stream.where(id: stream_1.id))
+
+    AverageStreams.new(
+      rules: AveragingRules.add(threshold: 1, window: 2),
+      streams_find_each: streams_find_each
+    )
+      .call
+
+    expect(stream_1.measurements.count).to eq(1)
+    expect(stream_2.measurements.count).to eq(2)
+  end
+
+  it 'does not average fixed streams' do
+    session = create_fixed_session!
+    stream = create_stream!(session: session)
+    create_measurement!(stream: stream, value: 0)
+    create_measurement!(stream: stream, value: 1)
+
+    AverageStreams.new(rules: AveragingRules.add(threshold: 1, window: 2)).call
+
+    expect(Measurement.count).to eq(2)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,6 +97,4 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
-
-  config.include TestUtils
 end

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -1,121 +1,152 @@
-module TestUtils
-  def create_session_with_streams_and_measurements!(attributes = {})
-    session =
-      create_session!(
-        id: attributes.fetch(:id, rand(1_000_000)),
-        contribute: attributes.fetch(:contribute, true),
-        start_time_local: attributes.fetch(:start_time_local, DateTime.current),
-        end_time_local: attributes.fetch(:end_time_local, DateTime.current),
-        user: attributes.fetch(:user, create_user!)
-      )
-    stream = create_stream!(session: session)
-    create_measurements!(
-      stream: stream,
-      value: attributes.fetch(:value, 1),
-      count: attributes.fetch(:count, 1)
-    )
-
-    session
-  end
-
-  def create_session!(attributes = {})
-    Session.create!(
-      id: attributes.fetch(:id, rand(1_000_000)),
-      title: attributes.fetch(:title, 'Example Session'),
-      user: attributes.fetch(:user, create_user!),
-      uuid: attributes.fetch(:uuid, "uuid#{rand}"),
-      start_time: DateTime.current,
-      start_time_local: attributes.fetch(:start_time_local, DateTime.current),
-      end_time: DateTime.current,
-      end_time_local: attributes.fetch(:end_time_local, DateTime.current),
-      type: attributes.fetch(:type, 'MobileSession'),
-      longitude: 1.0,
-      latitude: 1.0,
-      is_indoor: attributes.fetch(:is_indoor, false),
-      version: attributes.fetch(:version, 1),
+def create_session_with_streams_and_measurements!(attributes = {})
+  session =
+    create_session!(
+      id: attributes.fetch(:id, random_int),
       contribute: attributes.fetch(:contribute, true),
-      last_measurement_at:
-        attributes.fetch(:last_measurement_at, DateTime.current),
-      tag_list: attributes.fetch(:tag_list, [])
+      start_time_local: attributes.fetch(:start_time_local, DateTime.current),
+      end_time_local: attributes.fetch(:end_time_local, DateTime.current),
+      user: attributes.fetch(:user) { create_user! }
     )
-  end
+  stream = create_stream!(session: session)
+  create_measurements!(
+    stream: stream,
+    value: attributes.fetch(:value, 1),
+    count: attributes.fetch(:count, 1)
+  )
 
-  def create_stream!(attributes = {})
-    Stream.create!(
-      sensor_package_name: 'AirBeam2:00189610719F',
-      sensor_name: attributes.fetch(:sensor_name, 'AirBeam2-F'),
-      measurement_type: 'Temperature',
-      unit_name: 'Fahrenheit',
-      session: attributes.fetch(:session, create_session!),
-      measurement_short_type: 'F',
-      unit_symbol: attributes.fetch(:unit_symbol, 'F'),
-      threshold_very_low: 20,
-      threshold_low: 60,
-      threshold_medium: 70,
-      threshold_high: 80,
-      threshold_very_high: 100,
-      min_latitude: attributes.fetch(:min_latitude, 1),
-      max_latitude: attributes.fetch(:max_latitude, 1),
-      min_longitude: attributes.fetch(:min_longitude, 1),
-      max_longitude: attributes.fetch(:max_longitude, 1)
-    )
-  end
+  session
+end
 
-  def create_measurement!(attributes = {})
+def create_session!(attributes = {})
+  Session.create!(
+    id: attributes.fetch(:id, rand(1_000_000)),
+    title: attributes.fetch(:title, 'Example Session'),
+    user: attributes.fetch(:user) { create_user! },
+    uuid: attributes.fetch(:uuid, "uuid#{rand}"),
+    start_time: DateTime.current,
+    start_time_local: attributes.fetch(:start_time_local, DateTime.current),
+    end_time: DateTime.current,
+    end_time_local: attributes.fetch(:end_time_local, DateTime.current),
+    type: attributes.fetch(:type, 'MobileSession'),
+    longitude: 1.0,
+    latitude: 1.0,
+    is_indoor: attributes.fetch(:is_indoor, false),
+    version: attributes.fetch(:version, 1),
+    contribute: attributes.fetch(:contribute, true),
+    last_measurement_at:
+      attributes.fetch(:last_measurement_at, DateTime.current),
+    tag_list: attributes.fetch(:tag_list, [])
+  )
+end
+
+def create_stream!(attributes = {})
+  Stream.create!(
+    sensor_package_name: 'AirBeam2:00189610719F',
+    sensor_name: attributes.fetch(:sensor_name, 'AirBeam2-F'),
+    measurement_type: 'Temperature',
+    unit_name: 'Fahrenheit',
+    session: attributes.fetch(:session) { create_session! },
+    measurement_short_type: 'F',
+    unit_symbol: attributes.fetch(:unit_symbol, 'F'),
+    threshold_very_low: 20,
+    threshold_low: 60,
+    threshold_medium: 70,
+    threshold_high: 80,
+    threshold_very_high: 100,
+    min_latitude: attributes.fetch(:min_latitude, 1),
+    max_latitude: attributes.fetch(:max_latitude, 1),
+    min_longitude: attributes.fetch(:min_longitude, 1),
+    max_longitude: attributes.fetch(:max_longitude, 1),
+    average_value: attributes.fetch(:average_value, 1.23)
+  )
+end
+
+def create_measurement!(attributes = {})
+  Measurement.create!(
+    time: attributes.fetch(:time, DateTime.current),
+    latitude: attributes.fetch(:latitude, 1),
+    longitude: attributes.fetch(:longitude, 1),
+    value: attributes.fetch(:value, 123),
+    milliseconds: attributes.fetch(:milliseconds, 123),
+    stream: attributes.fetch(:stream) { create_stream! }
+  )
+end
+
+def create_measurements!(attributes)
+  attributes.fetch(:count, 1).times do |n|
     Measurement.create!(
-      time: attributes.fetch(:time, DateTime.current),
-      latitude: attributes.fetch(:latitude, 1),
-      longitude: attributes.fetch(:longitude, 1),
-      value: attributes.fetch(:value, 123),
-      milliseconds: attributes.fetch(:milliseconds, 123),
-      stream: attributes.fetch(:stream, create_stream!)
-    )
-  end
-
-  def create_measurements!(attributes)
-    attributes.fetch(:count, 1).times do |n|
-      Measurement.create!(
-        time: Time.current - n.minutes,
-        latitude: 1,
-        longitude: 1,
-        value: attributes.fetch(:value, 1),
-        milliseconds: 0,
-        stream: attributes.fetch(:stream)
-      )
-    end
-  end
-
-  def create_old_measurements!(attributes)
-    60.times do |n|
-      Measurement.create!(
-        time: Time.current - (61 + n).minutes,
-        latitude: 1,
-        longitude: 1,
-        value: attributes.fetch(:value),
-        milliseconds: 0,
-        stream: attributes.fetch(:stream)
-      )
-    end
-  end
-
-  def create_user!(attributes = {})
-    User.create!(
-      id: attributes.fetch(:id, rand(100_000)),
-      username: attributes.fetch(:username, "username#{rand}"),
-      email: attributes.fetch(:email, "email#{rand}@example.com"),
-      password: 'password',
-      session_stopped_alert: attributes.fetch(:session_stopped_alert, false)
+      time: Time.current - n.minutes,
+      latitude: random_float,
+      longitude: random_float,
+      value: attributes.fetch(:value, random_float),
+      milliseconds: random_int,
+      stream: attributes.fetch(:stream)
     )
   end
 end
 
+def create_old_measurements!(attributes)
+  60.times do |n|
+    Measurement.create!(
+      time: Time.current - (61 + n).minutes,
+      latitude: random_float,
+      longitude: random_float,
+      value: attributes.fetch(:value),
+      milliseconds: random_int,
+      stream: attributes.fetch(:stream)
+    )
+  end
+end
+
+def create_user!(attributes = {})
+  User.create!(
+    id: attributes.fetch(:id, random_int),
+    username: attributes.fetch(:username, random_string),
+    email: attributes.fetch(:email, random_email),
+    password: random_string,
+    session_stopped_alert: attributes.fetch(:session_stopped_alert, random_bool)
+  )
+end
+
 def create_note!(attributes = {})
   Note.create!(
-    text: 'text',
-    date: DateTime.current,
-    latitude: 123,
-    longitude: 123,
+    text: random_string,
+    date: random_date_time,
+    latitude: random_float,
+    longitude: random_float,
     session: attributes.fetch(:session),
-    number: rand(100_000)
+    number: random_int
   )
+end
+
+def create_mobile_session!
+  create_session!(type: 'MobileSession')
+end
+
+def create_fixed_session!
+  create_session!(type: 'FixedSession')
+end
+
+def random_int
+  rand(100_000)
+end
+
+def random_float
+  rand * 100
+end
+
+def random_string
+  SecureRandom.alphanumeric
+end
+
+def random_bool
+  [true, false].sample
+end
+
+def random_email
+  "#{random_string.downcase}@example.com"
+end
+
+def random_date_time
+  DateTime.current + random_int.days - random_int.days
 end


### PR DESCRIPTION
We decided to average long mobile sessions by putting together measurements whenever a stream contains a big amount of them. In particular
- for streams containing >4 hrs but <9 hrs of data (14,400 to 32,400 data points) we apply a 5-second avg. time interval;
- for streams containing >9 hrs of data (32,401 data points) we apply a 60-second avg. time interval.

The core of this PR is `AverageStreams` which performs what's described above. Tests should help understanding how it all works.

Besides that I did some cleaning in this PR. In particular, I've extracted some factories used in tests and started using random generators when creating test objects. Tests should separate noise from signal. It's much more readable to see

```
obj = Klass.new(a: 1)

expect(obj.call).to eq(10)
```

than

```
obj = Klass.new(a: 1, b: 123, c: 123, d: 123)

expect(obj.call(123, 123)).to eq(10)
```

In the second example all the `123` are just noise. Hiding them in a factory and making them random ensures 
- no noise in the tests;
- tests are not relying on values setup in the factories (all the signal is visible in the tests).

Where possible I've removed FactoryBot because I'd rather have to deal with the factories than hiding the complexity inside FactoryBot. In fact, in the former case I can feel the pain and adjust the design to fix the root cause. Plus the author of the gem warn against using it:

>My general advice, though, is to avoid Factory Girl as much as is reasonably possible. Not because it’s bad or unreliable software (Factory Girl is very reliable; we’ve used it successfully since 2008), but because its inherent persistence mechanism is calling #save! on the object, which will always take longer than not persisting data. (https://thoughtbot.com/blog/speed-up-tests-by-selectively-avoiding-factory-girl)