### PR TITLE
Increase button sizes in notes popup

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -22,6 +22,7 @@
 @import "./modules/header";
 @import "./modules/heatmap";
 @import "./modules/heatmap-button";
+@import "./modules/gm-popup";
 @import "./modules/icons";
 @import "./modules/info-window";
 @import "./modules/input";

--- a/app/assets/stylesheets/modules/gm-popup.css.scss
+++ b/app/assets/stylesheets/modules/gm-popup.css.scss
@@ -1,0 +1,18 @@
+// gm popup overrides. gm popup is used for notes and info windows on the map.
+
+// the topmost popup container
+.gm-style-iw.gm-style-iw-c {
+  box-shadow: $basic-shadow;
+  padding-top: 15px;
+}
+
+// close button
+.gm-ui-hover-effect {
+  top: 0 !important;
+  right: 0 !important;
+
+  img {
+    height: 18px !important;
+    width: 18px !important;
+  }
+}

--- a/app/assets/stylesheets/modules/info-window.css.scss
+++ b/app/assets/stylesheets/modules/info-window.css.scss
@@ -1,14 +1,3 @@
-// gm popup overrides - the topmost container
-.gm-style-iw.gm-style-iw-c {
-  box-shadow: $basic-shadow;
-  padding-top: 15px;
-}
-
-.gm-ui-hover-effect {
-  top: 0;
-  right: 0;
-}
-
 .info-window {
   font-family: "PT Sans", sans-serif;
 

--- a/app/assets/stylesheets/modules/note.css.scss
+++ b/app/assets/stylesheets/modules/note.css.scss
@@ -1,6 +1,7 @@
 .note {
   min-width: 100px;
   max-width: 200px;
+  padding: 6px 6px 0 6px;
 }
 
 .note__date {
@@ -33,8 +34,15 @@
 }
 
 .note-pagination {
+  display: inline-block;
   line-height: 1;
   text-align: center;
+  width: 100%;
+}
+
+.note-pagination__page {
+  display: inline-block;
+  padding: 10px 0 0;
 }
 
 .note-pagination__arrow {
@@ -43,17 +51,16 @@
   border: none;
   cursor: pointer;
   color: $blue;
+  font-size: 20px;
   font-weight: $font-stack-bold;
+  line-height: 13px;
+  padding: 10px;
 }
 
 .note-pagination__arrow--prev {
   float: left;
-  padding-left: 0;
-  padding-right: 10px;
 }
 
 .note-pagination__arrow--next {
   float: right;
-  padding-right: 0;
-  padding-left: 10px;
 }


### PR DESCRIPTION
- increases close button size in gm popups = both info window and note
- increases prev/next button sizes and adds more padding around them for better tapping

before:
![Screenshot 2020-01-14 at 19 57 55](https://user-images.githubusercontent.com/457999/72373289-454a8880-3708-11ea-8cf0-ab9ff77a1064.png)

after:
![Screenshot 2020-01-14 at 19 58 02](https://user-images.githubusercontent.com/457999/72373291-454a8880-3708-11ea-824b-d1c20d8cd357.png)
