### PR TITLE
Fix ugly extra bolding of filter labels and tab titles

### DIFF
--- a/app/assets/stylesheets/modules/label.css.scss
+++ b/app/assets/stylesheets/modules/label.css.scss
@@ -1,6 +1,5 @@
 .label {
   font-size: $tiny-font;
-  font-weight: bold;
   margin-bottom: 4px;
   text-transform: capitalize;
   transition: opacity 0.5s;

--- a/app/assets/stylesheets/modules/session-type-nav.css.scss
+++ b/app/assets/stylesheets/modules/session-type-nav.css.scss
@@ -20,7 +20,6 @@
   a {
     color: white;
     display: inline-block;
-    font-weight: $font-stack-bold;
     font-size: $small-font;
     margin: -$margin-default 0 -1 * $margin-default -1 * $margin-default;
     width: 94px;


### PR DESCRIPTION
Removes leftover unnecessary bolding.

Before:
![Screenshot 2020-01-15 at 11 22 07](https://user-images.githubusercontent.com/457999/72426603-53d98400-378a-11ea-8704-d3fac8eef189.png)

After:
![Screenshot 2020-01-15 at 11 22 15](https://user-images.githubusercontent.com/457999/72426604-53d98400-378a-11ea-8183-01e84b990d56.png)
