### PR TITLE
Autocomplete spinner

### DIFF
--- a/app/assets/stylesheets/config/jquery-ui-assets.css.scss
+++ b/app/assets/stylesheets/config/jquery-ui-assets.css.scss
@@ -26,10 +26,6 @@
 .ui-state-error-text .ui-icon {
   background-image: url("../../images/vendor/jquery-ui/ui-icons_cd0a0a_256x240.png");
 }
-.ui-autocomplete-loading {
-  background: white url("../../images/vendor/jquery-ui/ui-anim_basic_16x16.gif")
-    right center no-repeat;
-}
 .ui-widget-header,
 .ui-widget button {
   font-family: Arial, Verdana, sans-serif !important;

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -41,6 +41,7 @@
 @import "./modules/session-type-nav";
 @import "./modules/single-session";
 @import "./modules/spinner";
+@import "./modules/spinner-autocomplete";
 @import "./modules/subnav-list";
 @import "./modules/tag";
 @import "./modules/time-filter-calendar";

--- a/app/assets/stylesheets/modules/spinner-autocomplete.css.scss
+++ b/app/assets/stylesheets/modules/spinner-autocomplete.css.scss
@@ -1,0 +1,22 @@
+// Replaces JQuery autocomplete spinner
+
+.ui-autocomplete-loading ~ .autocomplete-spinner {
+  background-image: none;
+  position: absolute;
+  transform: translate(-50%, -50%);
+  right: 21px;
+  top: 32px;
+  z-index: 100000;
+
+  &:after {
+    content: " ";
+    position: absolute;
+    width: 15px;
+    height: 15px;
+    margin: 1px;
+    border-radius: 50%;
+    border: 2px solid $white;
+    border-color: $white transparent $white transparent;
+    animation: spinning 1.2s linear infinite;
+  }
+}

--- a/app/javascript/elm/src/LabelsInput.elm
+++ b/app/javascript/elm/src/LabelsInput.elm
@@ -92,6 +92,7 @@ view model text_ inputId placeholderText isDisabled tooltipText =
             []
         , label [ class "label label--filters", for inputId ] [ text text_ ]
         , Tooltip.view tooltipText
+        , div [ class "autocomplete-spinner" ] []
         ]
 
 


### PR DESCRIPTION
Replaces the ugly default jQuery autocomplete library's spinner with a more elegant, pure CSS one close to our main spinner.

![spinner](https://user-images.githubusercontent.com/457999/72436569-0ddbea80-37a1-11ea-8522-71386a66613d.gif)
