### PR TITLE
Show a bigger, gray spinner when loading initial data

### DIFF
--- a/app/assets/stylesheets/modules/spinner.css.scss
+++ b/app/assets/stylesheets/modules/spinner.css.scss
@@ -20,3 +20,17 @@
   border-color: $brand-primary transparent $brand-primary transparent;
   animation: spinning 1.2s linear infinite;
 }
+
+.spinner-big {
+  width: 92px;
+  height: 92px;
+  top: 40%;
+}
+
+.spinner-big:after {
+  width: 92px;
+  height: 92px;
+  border: 8px solid $gray-dark;
+  border-color: $gray-dark transparent $gray-dark transparent;
+  animation: spinning 1.2s linear infinite;
+}

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,1 +1,1 @@
-<div class="spinner"></div>
+<div class="spinner spinner-big"></div>


### PR DESCRIPTION
This PR changes the way the initial spinner looks, the one that's later replaced by the elm app.
This way it doesn't look as the spinner jumps from its position onto the map after the elm app loads but before the sessions load.

![Screenshot 2020-01-20 at 16 13 48](https://user-images.githubusercontent.com/457999/72737635-36e4ec80-3ba0-11ea-9065-52f33043deec.png)
