### PR TITLE
Tweak filter popup buttons

### DIFF
--- a/app/assets/stylesheets/config/variables.css.scss
+++ b/app/assets/stylesheets/config/variables.css.scss
@@ -51,7 +51,6 @@ $indigo: #19237e; // rgb(25, 35, 126)
 // ui colors
 $brand-primary: $blue;
 $brand-secondary: $dark-blue;
-$input-bg: $dark-grey;
 $navy-font: #3e4970;
 
 $shadow-color: rgba(149, 149, 149, 0.5);

--- a/app/assets/stylesheets/config/variables.css.scss
+++ b/app/assets/stylesheets/config/variables.css.scss
@@ -62,7 +62,6 @@ $shadow-color-darker: rgba(166, 166, 166, 0.5);
 $shadow-color-delicate: rgba(215, 215, 215, 0.5);
 
 $basic-shadow: 0px 2px 4px 0px $shadow-color;
-$blue-shadow: 1px 1px 4px 0 $shadow-color-blue;
 $darker-shadow: 0px 2px 4px 0px $shadow-color-darker;
 $lighter-shadow: 0px 2px 4px 0px $shadow-color-lighter;
 $delicate-shadow: 1px 1px 8px 0 $shadow-color-delicate;

--- a/app/assets/stylesheets/modules/filters-popups.css.scss
+++ b/app/assets/stylesheets/modules/filters-popups.css.scss
@@ -5,7 +5,6 @@ $popup-background-color: #f7f7f7;
   background: $popup-background-color;
   border-radius: $basic-radius;
   box-shadow: $basic-shadow;
-  color: $text-color;
   max-height: 80vh;
   overflow: auto;
   padding: $margin-default;
@@ -43,6 +42,7 @@ $popup-background-color: #f7f7f7;
   background: $popup-background-color;
   border: none;
   border-top: 1px solid $separator-color;
+  color: $gray-dark;
   cursor: pointer;
   font-size: $tiny-font;
   margin-top: 8px;
@@ -61,19 +61,19 @@ $popup-background-color: #f7f7f7;
 
 .filter-popup-button {
   background: white;
-  box-shadow: $blue-shadow;
+  box-shadow: $lighter-shadow;
   border: none;
-  color: $dark-blue;
+  border-radius: 0;
+  color: $gray-dark;
   flex: 1 0 48%;
+  font-family: $bold-font;
   font-size: $tiny-font;
-  font-weight: $font-stack-regular;
   padding: 8px 12px;
   margin-bottom: $margin-default;
 
   &.active {
     background: $blue;
     color: white;
-    font-weight: $font-stack-bold;
   }
 
   &:nth-child(2n) {
@@ -85,6 +85,7 @@ $popup-background-color: #f7f7f7;
   @include appearance(none);
   background: none;
   border: none;
+  color: $gray-dark;
   flex: 1 0 50%;
   font-size: $tiny-font;
   padding: $margin-default;

--- a/app/assets/stylesheets/modules/filters-popups.css.scss
+++ b/app/assets/stylesheets/modules/filters-popups.css.scss
@@ -1,8 +1,6 @@
-$popup-background-color: #f7f7f7;
-
 .filter-popup {
   animation: show-up 0.4s ease;
-  background: $popup-background-color;
+  background: $white;
   border-radius: $basic-radius;
   box-shadow: $basic-shadow;
   max-height: 80vh;
@@ -39,7 +37,7 @@ $popup-background-color: #f7f7f7;
 
 .filter-popup__toggle-more-button {
   @include appearance(none);
-  background: $popup-background-color;
+  background: none;
   border: none;
   border-top: 1px solid $separator-color;
   color: $gray-dark;
@@ -61,7 +59,7 @@ $popup-background-color: #f7f7f7;
 
 .filter-popup-button {
   background: white;
-  box-shadow: $lighter-shadow;
+  box-shadow: $basic-shadow;
   border: none;
   border-radius: 0;
   color: $gray-dark;

--- a/app/assets/stylesheets/modules/filters-popups.css.scss
+++ b/app/assets/stylesheets/modules/filters-popups.css.scss
@@ -91,4 +91,8 @@
   word-break: break-word;
   word-wrap: break-word;
   hyphens: auto;
+
+  &.active {
+    color: $blue;
+  }
 }


### PR DESCRIPTION
Before:
![Screenshot 2020-01-20 at 17 51 54](https://user-images.githubusercontent.com/457999/72744581-1f146500-3bae-11ea-89e1-3eb40f2e5b74.png)


After:
![Screenshot 2020-01-20 at 17 51 36](https://user-images.githubusercontent.com/457999/72744579-1f146500-3bae-11ea-8ed0-8526c2faabca.png)

I also changed the secondary parameter/sensor buttons (the ones you need to expand) so that they're blue when selected. before there was no indication that a secondary parameter/sensor is selected.

![Screenshot 2020-01-20 at 18 08 43](https://user-images.githubusercontent.com/457999/72745544-44a26e00-3bb0-11ea-9e43-0247c735c01d.png)

