### PR TITLE
Set smaller max height of filter popup on mobile

### DIFF
--- a/app/assets/stylesheets/modules/filters-popups.css.scss
+++ b/app/assets/stylesheets/modules/filters-popups.css.scss
@@ -16,6 +16,7 @@
     border-radius: $input-radius;
     left: 0;
     top: 3.4rem;
+    max-height: 60vh;
     width: calc(100vw - 2 * #{$margin-default});
   }
 }


### PR DESCRIPTION
This solves issues with scrolling on mobile when "more sensors" or "more parameters" are shown and the list is long.

Before:
<img width="375" alt="Screenshot 2020-02-10 at 17 56 57" src="https://user-images.githubusercontent.com/457999/74171393-c9702d00-4c2e-11ea-812c-b287f08dee3c.png">

After:
<img width="395" alt="image" src="https://user-images.githubusercontent.com/457999/74171512-fcb2bc00-4c2e-11ea-92ec-26d54be62e64.png">




