### PR TITLE
Timerange: make fixed+active timerange same as mobile

### DIFF
--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -1373,7 +1373,7 @@ viewMobileFilters model =
         [ lazy4 viewParameterFilter model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , lazy4 viewSensorFilter model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , viewLocationFilter model.location model.isIndoor
-        , TimeRange.view RefreshTimeRange Dormant model.resetIconWhite
+        , TimeRange.view RefreshTimeRange model.resetIconWhite
         , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" False Tooltip.profilesFilter
         , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False Tooltip.tagsFilter
         , viewCrowdMapOptions model.isCrowdMapOn model.crowdMapResolution model.selectedSession
@@ -1386,7 +1386,7 @@ viewFixedFilters model =
         [ lazy4 viewParameterFilter model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , lazy4 viewSensorFilter model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , viewLocationFilter model.location model.isIndoor
-        , TimeRange.view RefreshTimeRange model.status model.resetIconWhite
+        , TimeRange.view RefreshTimeRange model.resetIconWhite
         , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" model.isIndoor Tooltip.profilesFilter
         , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False Tooltip.tagsFilter
         , div [ class "filters__toggle-group" ]

--- a/app/javascript/elm/src/TimeRange.elm
+++ b/app/javascript/elm/src/TimeRange.elm
@@ -1,9 +1,8 @@
 module TimeRange exposing (TimeRange(..), defaultTimeRange, update, view)
 
 import Data.Path as Path exposing (Path)
-import Data.Status exposing (Status(..))
 import Html exposing (Html, button, div, img, input, label, text)
-import Html.Attributes exposing (alt, attribute, class, disabled, for, id, name, src)
+import Html.Attributes exposing (alt, attribute, class, for, id, name, src)
 import Html.Attributes.Aria exposing (ariaLabel)
 import Html.Events as Events
 import Json.Decode as Decode
@@ -53,15 +52,14 @@ timeRangeDecoder =
         (Decode.field "timeTo" Decode.int)
 
 
-view : msg -> Status -> Path -> Html msg
-view refreshTimeRange status resetIcon =
+view : msg -> Path -> Html msg
+view refreshTimeRange resetIcon =
     div [ class "filters__input-group" ]
         [ input
             [ id "time-range"
             , attribute "autocomplete" "off"
             , class "input input--dark input--filters input--time"
             , name "time-range"
-            , disabled (status == Active)
             ]
             []
         , button
@@ -69,7 +67,6 @@ view refreshTimeRange status resetIcon =
             , attribute "autocomplete" "off"
             , class "input input--dark input--filters input--time button--input"
             , name "time-range-button"
-            , disabled (status == Active)
             ]
             []
         , label

--- a/app/javascript/elm/tests/MainTests.elm
+++ b/app/javascript/elm/tests/MainTests.elm
@@ -146,27 +146,6 @@ timeFilter =
                     |> update (UpdateTimeRange value)
                     |> Tuple.first
                     |> Expect.equal expected
-        , test "disabled for active fixed sessions" <|
-            \_ ->
-                { defaultModel | status = Active, page = Fixed }
-                    |> view
-                    |> Query.fromHtml
-                    |> Query.find [ Slc.id "time-range" ]
-                    |> Query.has [ Slc.attribute <| disabled True ]
-        , test "is enabled for dormant fixed sessions" <|
-            \_ ->
-                { defaultModel | status = Dormant, page = Fixed }
-                    |> view
-                    |> Query.fromHtml
-                    |> Query.find [ Slc.id "time-range" ]
-                    |> Query.has [ Slc.attribute <| disabled False ]
-        , test "is always enabled for mobile sessions" <|
-            \_ ->
-                { defaultModel | status = Active, page = Mobile }
-                    |> view
-                    |> Query.fromHtml
-                    |> Query.find [ Slc.id "time-range" ]
-                    |> Query.has [ Slc.attribute <| disabled False ]
         ]
 
 

--- a/app/javascript/elm/tests/TimeRangeTests.elm
+++ b/app/javascript/elm/tests/TimeRangeTests.elm
@@ -23,7 +23,7 @@ all =
     describe "TimeRange"
         [ test ".view has an input field" <|
             \_ ->
-                TimeRange.view (\_ -> ()) Active defaultIcon
+                TimeRange.view (\_ -> ()) defaultIcon
                     |> Query.fromHtml
                     |> Query.has [ tag "input" ]
         , fuzz2 int int ".update returns updated TimeRange if value has correct format" <|
@@ -53,7 +53,7 @@ all =
                     |> Expect.equal expected
         , test "viewTimeFilter has a reset time frame button" <|
             \_ ->
-                TimeRange.view Msg Active defaultIcon
+                TimeRange.view Msg defaultIcon
                     |> Query.fromHtml
                     |> Query.find [ attribute <| ariaLabel "Reset time frame" ]
                     |> Event.simulate Event.click

--- a/app/javascript/javascript/filtersUtils.js
+++ b/app/javascript/javascript/filtersUtils.js
@@ -15,17 +15,6 @@ export const oneYearAgo = () =>
     .subtract(1, "year")
     .format("X");
 
-export const presentMoment = () =>
-  moment()
-    .utc()
-    .format("X");
-
-export const oneHourAgo = () =>
-  moment
-    .utc()
-    .subtract(1, "hour")
-    .format("X");
-
 const humanTime = time =>
   moment
     .unix(time)

--- a/app/javascript/javascript/sessionsMap.js
+++ b/app/javascript/javascript/sessionsMap.js
@@ -270,40 +270,20 @@ export default (() => {
     }
   };
 
-  if (params.get("data").isActive) {
-    // fixed tab
-    setupActiveTimeRangeFilter(
-      FiltersUtils.oneHourAgo(),
-      FiltersUtils.presentMoment()
-    );
-  } else {
-    // fixed or mobile tab
+  FiltersUtils.setupTimeRangeFilter(
+    onTimeRangeChanged,
+    params.get("data").timeFrom,
+    params.get("data").timeTo,
+    elmApp.ports.isShowingTimeRangeFilter.send
+  );
+
+  const resetTimeRangeFilter = () => {
     FiltersUtils.setupTimeRangeFilter(
       onTimeRangeChanged,
-      params.get("data").timeFrom,
-      params.get("data").timeTo,
+      FiltersUtils.oneYearAgo(),
+      FiltersUtils.endOfToday(),
       elmApp.ports.isShowingTimeRangeFilter.send
     );
-  }
-
-  // fixed or mobile tab
-  const resetTimeRangeFilter = () => {
-    if (params.get("data").isActive) {
-      // fixed tab
-      setupActiveTimeRangeFilter(
-        FiltersUtils.oneHourAgo(),
-        FiltersUtils.presentMoment()
-      );
-      sessions.fetch();
-    } else {
-      // fixed or mobile tab
-      FiltersUtils.setupTimeRangeFilter(
-        onTimeRangeChanged,
-        FiltersUtils.oneYearAgo(),
-        FiltersUtils.endOfToday(),
-        elmApp.ports.isShowingTimeRangeFilter.send
-      );
-    }
     onTimeRangeChanged(FiltersUtils.oneYearAgo(), FiltersUtils.endOfToday());
   };
 


### PR DESCRIPTION
The diff reads really badly. This changes the timerange for the fixed tab with active enabled.

Previously it was greyed out and shown the last hour in the disabled field. Now it behaves exactly like in fixed+dormant or mobile tab. In other words, it's not disabled and initially set to the "one_year_ago..end_of_today" range. The circular arrow can be used to update the range without opening the time picker.