### PR TITLE
Fix mobile layout map issue when filters are expanded and scrolled down

### DIFF
--- a/app/assets/stylesheets/config/variables.css.scss
+++ b/app/assets/stylesheets/config/variables.css.scss
@@ -77,6 +77,7 @@ $logo-width: 110px;
 $sessions-list-width: 238px;
 $sessions-list-height: 160px;
 $action-container-height: 60px;
+$session-type-nav-height: 45px;
 
 // spacing
 $input-padding: 7px;

--- a/app/assets/stylesheets/modules/buttons.css.scss
+++ b/app/assets/stylesheets/modules/buttons.css.scss
@@ -65,6 +65,7 @@
 
   @media screen and (max-width: $tablet-max) {
     @include appearance(none);
+    @include flex(0 0 auto);
     background-color: $brand-primary;
     border: none;
     color: white;
@@ -73,8 +74,6 @@
     font-size: $medium-font;
     height: 50px;
     width: 100%;
-    position: fixed;
-    bottom: 0;
     text-transform: capitalize;
   }
 }

--- a/app/assets/stylesheets/modules/filters.css.scss
+++ b/app/assets/stylesheets/modules/filters.css.scss
@@ -2,29 +2,44 @@
   background: $gray-dark;
   color: white;
   font-family: $bold-font;
-  min-height: calc(100vh - #{$nav-height});
+  height: 0;
   position: relative;
   z-index: $filters-z-index;
 
   @media screen and (max-width: $tablet-max) {
-    min-height: calc(100vh - #{$nav-height-mobile});
-    position: absolute;
+    @include transform(translateX(100%));
+    height: 0;
     transition: transform 200ms ease;
+    overflow: hidden;
     width: 100vw;
 
-    &.filters--collapsed {
-      @include transform(translateX(100%));
+    &.filters--expanded {
+      @include transform(translateX(0%));
+      height: calc(100vh - #{$nav-height-mobile});
+      overflow-y: auto;
+      position: absolute;
     }
   }
 
   @media screen and (min-width: $small-desktop-min) {
     box-shadow: 1px 1px 6px 0 rgba(51, 51, 51, 0.5);
+    min-height: calc(100vh - #{$nav-height});
     width: $filters-width;
   }
 }
 
-.filters-container {
-  padding: $margin-default $margin-default 50px $margin-default;
+.filters-form-container {
+  @include flexbox;
+  @include flex-direction(column);
+
+  .filters--expanded & {
+    height: calc(100% - #{$nav-height-mobile} - #{$session-type-nav-height});
+  }
+}
+
+.filters__form {
+  @include flex-grow(1);
+  padding: $margin-default;
 }
 
 .filters__actions {

--- a/app/assets/stylesheets/modules/filters.css.scss
+++ b/app/assets/stylesheets/modules/filters.css.scss
@@ -15,6 +15,8 @@
 
     &.filters--expanded {
       @include transform(translateX(0%));
+      display: flex;
+      flex-direction: column;
       height: calc(100vh - #{$nav-height-mobile});
       overflow-y: auto;
       position: absolute;
@@ -31,6 +33,7 @@
 .filters-form-container {
   @include flexbox;
   @include flex-direction(column);
+  @include flex-grow(1);
 
   .filters--expanded & {
     height: calc(100% - #{$nav-height-mobile} - #{$session-type-nav-height});

--- a/app/assets/stylesheets/modules/session-type-nav.css.scss
+++ b/app/assets/stylesheets/modules/session-type-nav.css.scss
@@ -1,6 +1,7 @@
 .session-type-nav {
   @include flexbox();
   @include justify-content(space-between);
+  height: $session-type-nav-height;
   list-style-type: none;
   margin: 0;
   padding-left: 0;

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -1041,17 +1041,19 @@ viewMain model =
             [ div
                 [ classList
                     [ ( "filters", True )
-                    , ( "filters--collapsed", not model.areFiltersExpanded )
+                    , ( "filters--expanded", model.areFiltersExpanded )
                     ]
                 ]
                 [ viewSessionTypeNav model
-                , viewFilters model
-                , viewFiltersButtons model.selectedSession model.sessions model.linkIcon model.popup model.emailForm
-                , button
-                    [ class "show-results-button"
-                    , Events.onClick CloseFilters
+                , div [ class "filters-form-container" ]
+                    [ viewFilters model
+                    , viewFiltersButtons model.selectedSession model.sessions model.linkIcon model.popup model.emailForm
+                    , button
+                        [ class "show-results-button"
+                        , Events.onClick CloseFilters
+                        ]
+                        [ text "show results" ]
                     ]
-                    [ text "show results" ]
                 ]
             , viewMap model
             ]
@@ -1369,7 +1371,7 @@ viewFilters model =
 
 viewMobileFilters : Model -> Html Msg
 viewMobileFilters model =
-    div [ class "filters-container" ]
+    div [ class "filters__form" ]
         [ lazy5 viewParameterFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , lazy5 viewSensorFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , viewLocationFilter model.location model.isIndoor
@@ -1382,7 +1384,7 @@ viewMobileFilters model =
 
 viewFixedFilters : Model -> Html Msg
 viewFixedFilters model =
-    div [ class "filters-container" ]
+    div [ class "filters__form" ]
         [ lazy5 viewParameterFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , lazy5 viewSensorFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , viewLocationFilter model.location model.isIndoor


### PR DESCRIPTION
After expanding filters and scrolling down the "Redo search" button was disappearing under the header and the part of the map that contained it was cut off. It also hid part of the zoom buttons. This PR fixes that but not without some costs.

![Screenshot_20200206-221056](https://user-images.githubusercontent.com/457999/75563379-8bef0a80-5a4a-11ea-8ee5-9c25876e2efe.jpg)


See this thread for more: https://trello.com/c/00QrZMOc/1489-maps-redo-search-in-map-hidden-after-scrolling-down-filters-on-mobile