### PR TITLE
OpenAQ: import O3 measurements (besides PM2.5)

### DIFF
--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -24,7 +24,7 @@ import Html exposing (Html, a, button, div, h2, h3, header, img, input, label, l
 import Html.Attributes exposing (alt, attribute, autocomplete, checked, class, classList, disabled, for, href, id, max, min, name, placeholder, readonly, src, target, title, type_, value)
 import Html.Attributes.Aria exposing (ariaLabel)
 import Html.Events as Events
-import Html.Lazy exposing (lazy4, lazy7, lazy8)
+import Html.Lazy exposing (lazy4, lazy5, lazy7, lazy8)
 import Http
 import Json.Decode as Decode exposing (Decoder(..))
 import Json.Encode as Encode
@@ -427,7 +427,7 @@ update msg model =
                     deselectSession model
 
                 selectedSensorId =
-                    Sensor.idForParameterOrLabel value subModel.selectedSensorId subModel.sensors
+                    Sensor.idForParameterOrLabel subModel.page value subModel.selectedSensorId subModel.sensors
             in
             ( { subModel | selectedSensorId = selectedSensorId }
             , Cmd.batch
@@ -1370,8 +1370,8 @@ viewFilters model =
 viewMobileFilters : Model -> Html Msg
 viewMobileFilters model =
     div [ class "filters-container" ]
-        [ lazy4 viewParameterFilter model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
-        , lazy4 viewSensorFilter model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
+        [ lazy5 viewParameterFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
+        , lazy5 viewSensorFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , viewLocationFilter model.location model.isIndoor
         , TimeRange.view RefreshTimeRange model.resetIconWhite
         , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" False Tooltip.profilesFilter
@@ -1383,8 +1383,8 @@ viewMobileFilters model =
 viewFixedFilters : Model -> Html Msg
 viewFixedFilters model =
     div [ class "filters-container" ]
-        [ lazy4 viewParameterFilter model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
-        , lazy4 viewSensorFilter model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
+        [ lazy5 viewParameterFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
+        , lazy5 viewSensorFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , viewLocationFilter model.location model.isIndoor
         , TimeRange.view RefreshTimeRange model.resetIconWhite
         , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" model.isIndoor Tooltip.profilesFilter
@@ -1420,8 +1420,8 @@ viewToggleButton label isPressed callback =
         [ text label ]
 
 
-viewParameterFilter : List Sensor -> String -> Bool -> Popup -> Html Msg
-viewParameterFilter sensors selectedSensorId isPopupListExpanded popup =
+viewParameterFilter : Page -> List Sensor -> String -> Bool -> Popup -> Html Msg
+viewParameterFilter page sensors selectedSensorId isPopupListExpanded popup =
     div [ class "filters__input-group" ]
         [ input
             [ id "parameter"
@@ -1437,12 +1437,12 @@ viewParameterFilter sensors selectedSensorId isPopupListExpanded popup =
             []
         , label [ class "label label--filters", for "parameter" ] [ text "parameter:" ]
         , Tooltip.view Tooltip.parameterFilter
-        , viewListPopup Popup.isParameterPopupShown isPopupListExpanded popup (Sensor.parameters sensors) "parameters" (Sensor.parameterForId sensors selectedSensorId)
+        , viewListPopup Popup.isParameterPopupShown isPopupListExpanded popup (Sensor.parameters page sensors) "parameters" (Sensor.parameterForId sensors selectedSensorId)
         ]
 
 
-viewSensorFilter : List Sensor -> String -> Bool -> Popup -> Html Msg
-viewSensorFilter sensors selectedSensorId isPopupListExpanded popup =
+viewSensorFilter : Page -> List Sensor -> String -> Bool -> Popup -> Html Msg
+viewSensorFilter page sensors selectedSensorId isPopupListExpanded popup =
     div [ class "filters__input-group" ]
         [ input
             [ id "sensor"
@@ -1458,7 +1458,7 @@ viewSensorFilter sensors selectedSensorId isPopupListExpanded popup =
             []
         , label [ class "label label--filters", for "sensor" ] [ text "sensor:" ]
         , Tooltip.view Tooltip.sensorFilter
-        , viewListPopup Popup.isSensorPopupShown isPopupListExpanded popup (Sensor.labelsForParameter sensors selectedSensorId) "sensors" (Sensor.sensorLabelForId sensors selectedSensorId)
+        , viewListPopup Popup.isSensorPopupShown isPopupListExpanded popup (Sensor.labelsForParameter page sensors selectedSensorId) "sensors" (Sensor.sensorLabelForId sensors selectedSensorId)
         ]
 
 

--- a/app/javascript/elm/src/Sensor.elm
+++ b/app/javascript/elm/src/Sensor.elm
@@ -29,6 +29,7 @@ defaultSensorIdByParameter =
         , ( "Humidity", "Humidity-airbeam2-rh (%)" )
         , ( "Sound Level", "Sound Level-phone microphone (dB)" )
         , ( "Temperature", "Temperature-airbeam2-f (F)" )
+        , ( "Ozone", "Ozone-openaq-o3 (ppb)" )
         ]
 
 
@@ -46,6 +47,7 @@ mainSensors =
         , ( "Humidity", [ "AirBeam2-RH (%)", "AirBeam-RH (%)" ] )
         , ( "Temperature", [ "AirBeam2-F (F)", "AirBeam-F (F)" ] )
         , ( "Sound Level", [ "Phone Microphone (dB)" ] )
+        , ( "Ozone", [ "OpenAQ-O3 (ppb)" ] )
         ]
 
 

--- a/app/javascript/elm/src/Sensor.elm
+++ b/app/javascript/elm/src/Sensor.elm
@@ -11,44 +11,69 @@ module Sensor exposing
     , unitForSensorId
     )
 
+import Data.Page exposing (Page(..))
 import Dict
 import Json.Decode as Decode exposing (Decoder(..))
 import NaturalOrdering
 import Set
 
 
-defaultSensorId : String
-defaultSensorId =
+mobileDefaultSensorId : String
+mobileDefaultSensorId =
     "Particulate Matter-airbeam2-pm2.5 (µg/m³)"
 
 
-defaultSensorIdByParameter : Dict.Dict String String
-defaultSensorIdByParameter =
-    Dict.fromList
-        [ ( "Particulate Matter", defaultSensorId )
-        , ( "Humidity", "Humidity-airbeam2-rh (%)" )
-        , ( "Sound Level", "Sound Level-phone microphone (dB)" )
-        , ( "Temperature", "Temperature-airbeam2-f (F)" )
-        , ( "Ozone", "Ozone-openaq-o3 (ppb)" )
-        ]
+fixedDefaultSensorId : String
+fixedDefaultSensorId =
+    "Particulate Matter-openaq-pm2.5 (µg/m³)"
 
 
-mainSensors : Dict.Dict String (List String)
-mainSensors =
-    Dict.fromList
-        [ ( "Particulate Matter"
-          , [ "AirBeam2-PM2.5 (µg/m³)"
-            , "AirBeam2-PM1 (µg/m³)"
-            , "AirBeam2-PM10 (µg/m³)"
-            , "AirBeam-PM (µg/m³)"
-            , "OpenAQ-PM2.5 (µg/m³)"
-            ]
-          )
-        , ( "Humidity", [ "AirBeam2-RH (%)", "AirBeam-RH (%)" ] )
-        , ( "Temperature", [ "AirBeam2-F (F)", "AirBeam-F (F)" ] )
-        , ( "Sound Level", [ "Phone Microphone (dB)" ] )
-        , ( "Ozone", [ "OpenAQ-O3 (ppb)" ] )
-        ]
+defaultSensorIdByParameter : Page -> Dict.Dict String String
+defaultSensorIdByParameter page =
+    let
+        common =
+            Dict.fromList
+                [ ( "Humidity", "Humidity-airbeam2-rh (%)" )
+                , ( "Sound Level", "Sound Level-phone microphone (dB)" )
+                , ( "Temperature", "Temperature-airbeam2-f (F)" )
+                ]
+    in
+    case page of
+        Mobile ->
+            common
+                |> Dict.insert "Particulate Matter" mobileDefaultSensorId
+
+        Fixed ->
+            common
+                |> Dict.insert "Particulate Matter" fixedDefaultSensorId
+                |> Dict.insert "Ozone" "Ozone-openaq-o3 (ppb)"
+
+
+mainSensors : Page -> Dict.Dict String (List String)
+mainSensors page =
+    let
+        common =
+            Dict.fromList
+                [ ( "Particulate Matter"
+                  , [ "AirBeam2-PM2.5 (µg/m³)"
+                    , "AirBeam2-PM1 (µg/m³)"
+                    , "AirBeam2-PM10 (µg/m³)"
+                    , "AirBeam-PM (µg/m³)"
+                    ]
+                  )
+                , ( "Humidity", [ "AirBeam2-RH (%)", "AirBeam-RH (%)" ] )
+                , ( "Temperature", [ "AirBeam2-F (F)", "AirBeam-F (F)" ] )
+                , ( "Sound Level", [ "Phone Microphone (dB)" ] )
+                ]
+    in
+    case page of
+        Mobile ->
+            common
+
+        Fixed ->
+            common
+                |> Dict.insert "Ozone" [ "OpenAQ-O3 (ppb)" ]
+                |> Dict.update "Particulate Matter" (Maybe.map (\labels -> labels ++ [ "OpenAQ-PM2.5 (µg/m³)" ]))
 
 
 type alias Sensor =
@@ -96,22 +121,22 @@ parameterForId sensors sensorId =
         |> Maybe.withDefault ""
 
 
-parameters : List Sensor -> ( List String, List String )
-parameters sensors =
+parameters : Page -> List Sensor -> ( List String, List String )
+parameters page sensors =
     let
         othersParameters =
             sensors
                 |> List.map (String.trim << .parameter)
                 |> Set.fromList
                 |> Set.toList
-                |> List.filter (\sensor -> not (List.member sensor (Dict.keys mainSensors)))
+                |> List.filter (\sensor -> not (List.member sensor (Dict.keys <| mainSensors page)))
                 |> List.sortWith NaturalOrdering.compare
     in
-    ( Dict.keys mainSensors, othersParameters )
+    ( Dict.keys <| mainSensors page, othersParameters )
 
 
-labelsForParameter : List Sensor -> String -> ( List String, List String )
-labelsForParameter sensors sensorId =
+labelsForParameter : Page -> List Sensor -> String -> ( List String, List String )
+labelsForParameter page sensors sensorId =
     let
         allLabels =
             sensors
@@ -120,17 +145,9 @@ labelsForParameter sensors sensorId =
                 |> List.sortWith NaturalOrdering.compare
 
         mainLabels_ =
-            let
-                allLabelsWithSessions =
-                    sensors |> List.filter (\s -> s.sessionCount > 0) |> List.map toLabel
-
-                labelHasSessions label =
-                    List.member label allLabelsWithSessions
-            in
-            mainSensors
+            mainSensors page
                 |> Dict.get (parameterForId sensors sensorId)
                 |> Maybe.withDefault []
-                |> List.filter labelHasSessions
 
         othersLabels_ =
             List.filter (\label -> not (List.member label mainLabels_)) allLabels
@@ -138,8 +155,8 @@ labelsForParameter sensors sensorId =
     ( mainLabels_, othersLabels_ )
 
 
-idForParameterOrLabel : String -> String -> List Sensor -> String
-idForParameterOrLabel parameterOrLabel oldSensorId sensors =
+idForParameterOrLabel : Page -> String -> String -> List Sensor -> String
+idForParameterOrLabel page parameterOrLabel oldSensorId sensors =
     let
         byId id =
             sensors
@@ -148,7 +165,8 @@ idForParameterOrLabel parameterOrLabel oldSensorId sensors =
                 |> Maybe.map toId
 
         maybeDefault =
-            Dict.get parameterOrLabel defaultSensorIdByParameter
+            defaultSensorIdByParameter page
+                |> Dict.get parameterOrLabel
                 |> Maybe.andThen byId
 
         maybeByParameter =
@@ -175,8 +193,13 @@ idForParameterOrLabel parameterOrLabel oldSensorId sensors =
         ( _, _, Just byLabel ) ->
             byLabel
 
-        _ ->
-            defaultSensorId
+        ( _, _, _ ) ->
+            case page of
+                Mobile ->
+                    mobileDefaultSensorId
+
+                Fixed ->
+                    fixedDefaultSensorId
 
 
 nameForSensorId : String -> List Sensor -> Maybe String

--- a/app/javascript/javascript/sensors.js
+++ b/app/javascript/javascript/sensors.js
@@ -1,5 +1,6 @@
 import _ from "underscore";
 import { getParams } from "./params";
+import constants from "./constants";
 
 const buildSensorId = sensor =>
   sensor.measurement_type +
@@ -9,19 +10,26 @@ const buildSensorId = sensor =>
   sensor.unit_symbol +
   ")";
 
-const DEFAULT_SENSOR_ID = buildSensorId({
-  measurement_type: "Particulate Matter",
-  sensor_name: "AirBeam2-PM2.5",
-  unit_symbol: "µg/m³"
-});
-
 export const sensors = params => {
   var Sensors = function() {
     this.sensors = {};
-    this.defaultSensorId = DEFAULT_SENSOR_ID;
   };
 
   Sensors.prototype = {
+    defaultSensorId: function() {
+      return window.location.pathname === constants.mobileMapRoute
+        ? buildSensorId({
+            measurement_type: "Particulate Matter",
+            sensor_name: "AirBeam2-PM2.5",
+            unit_symbol: "µg/m³"
+          })
+        : buildSensorId({
+            measurement_type: "Particulate Matter",
+            sensor_name: "OpenAQ-PM2.5",
+            unit_symbol: "µg/m³"
+          });
+    },
+
     setSensors: function(data) {
       var sensors = {};
       _(data).each(function(sensor) {
@@ -35,11 +43,11 @@ export const sensors = params => {
     },
 
     selected: function() {
-      return this.sensors[params().data.sensorId || DEFAULT_SENSOR_ID];
+      return this.sensors[params().data.sensorId || defaultSensorId()];
     },
 
     selectedId: function() {
-      return params().data.sensorId || DEFAULT_SENSOR_ID;
+      return params().data.sensorId || defaultSensorId();
     },
 
     selectedSensorName: function() {

--- a/app/javascript/javascript/sessionsMap.js
+++ b/app/javascript/javascript/sessionsMap.js
@@ -22,7 +22,7 @@ export default (() => {
     clearMap();
     map.unregisterAll();
 
-    const sensorId = params.get("data", { sensorId: sensors.defaultSensorId })
+    const sensorId = params.get("data", { sensorId: sensors.defaultSensorId() })
       .sensorId;
 
     const defaults = {

--- a/app/javascript/packs/elm.js
+++ b/app/javascript/packs/elm.js
@@ -25,6 +25,7 @@ import { get } from "../javascript/http";
 import constants from "../javascript/constants";
 import { init } from "../javascript/googleMapsInit";
 init();
+import sensors from "../javascript/sensors";
 
 import pubsub from "../javascript/pubsub";
 pubsub.subscribe("googleMapsReady", function() {
@@ -60,8 +61,8 @@ document.addEventListener("DOMContentLoaded", () => {
   // The best way to handle this would be to have the application load the sensors at the
   // same time it is loading the ui.
   // That way the user would not see a blank page until the sensors are loaded.
-  get("/api/sensors", { session_type: session_type }).then(sensors => {
-    window.__sensors = sensors;
+  get("/api/sensors", { session_type: session_type }).then(sensors_ => {
+    window.__sensors = sensors_;
 
     const defaultParams = {
       keepFiltersExpanded: false,
@@ -79,7 +80,7 @@ document.addEventListener("DOMContentLoaded", () => {
       gridResolution: 31, // this translates to grid cell size: 20; formula: f(x) = 51 - x
       isIndoor: false,
       isActive: true,
-      sensorId: "Particulate Matter-airbeam2-pm2.5 (µg/m³)",
+      sensorId: sensors.defaultSensorId(),
       isSearchAsIMoveOn: false
     };
 

--- a/app/models/open_aq/measurement.rb
+++ b/app/models/open_aq/measurement.rb
@@ -12,5 +12,17 @@ module OpenAq
       :country,
       :unit,
       keyword_init: true
-    )
+    ) do
+      def initialize(**kwargs)
+        super
+        convert_ppm_to_ppb(kwargs[:value]) if kwargs[:unit] == 'ppm'
+      end
+
+      private
+
+      def convert_ppm_to_ppb(value)
+        self.unit = 'ppb'
+        self.value = value * 1_000
+      end
+    end
 end

--- a/app/models/open_aq/stream.rb
+++ b/app/models/open_aq/stream.rb
@@ -12,6 +12,19 @@ module OpenAq
       threshold_high: 55,
       threshold_very_high: 150,
       sensor_package_name: 'OpenAQ-PM2.5'
+    },
+    'o3' => {
+      sensor_name: 'OpenAQ-O3',
+      unit_name: 'parts per billion',
+      measurement_type: 'Ozone',
+      measurement_short_type: 'O3',
+      unit_symbol: 'ppb',
+      threshold_very_low: 0,
+      threshold_low: 59,
+      threshold_medium: 75,
+      threshold_high: 95,
+      threshold_very_high: 115,
+      sensor_package_name: 'OpenAQ-O3'
     }
   }
 

--- a/app/services/open_aq/filter_measurements.rb
+++ b/app/services/open_aq/filter_measurements.rb
@@ -1,7 +1,9 @@
 class OpenAq::FilterMeasurements
-  SENSOR_NAME = 'pm25'
+  SENSOR_NAMES = %w[pm25 o3]
 
   def call(measurements:)
-    measurements.filter { |measurement| measurement.sensor_name == SENSOR_NAME }
+    measurements.filter do |measurement|
+      SENSOR_NAMES.include?(measurement.sensor_name)
+    end
   end
 end

--- a/spec/models/open_aq/measurement_spec.rb
+++ b/spec/models/open_aq/measurement_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe OpenAq::Stream do
+  it 'converts ppm to ppb' do
+    stream = build_open_aq_measurement(unit: 'ppm', value: 1)
+
+    expect(stream.unit).to eq('ppb')
+    expect(stream.value).to eq(1_000)
+  end
+
+  it 'does not convert µg/m³' do
+    stream = build_open_aq_measurement(unit: 'µg/m³', value: 1)
+
+    expect(stream.unit).to eq('µg/m³')
+    expect(stream.value).to eq(1)
+  end
+end

--- a/spec/models/open_aq/stream_spec.rb
+++ b/spec/models/open_aq/stream_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe OpenAq::Stream do
-  it 'assigns defaults depending on sensor name' do
+  it 'assigns defaults for pm25' do
     stream = build_open_aq_stream(sensor_name: 'pm25')
 
     expected = {
@@ -16,6 +16,25 @@ describe OpenAq::Stream do
       threshold_high: 55,
       threshold_very_high: 150,
       sensor_package_name: 'OpenAQ-PM2.5'
+    }
+    expect(stream.to_h).to include(expected)
+  end
+
+  it 'assigns defaults for o3' do
+    stream = build_open_aq_stream(sensor_name: 'o3')
+
+    expected = {
+      sensor_name: 'OpenAQ-O3',
+      unit_name: 'parts per billion',
+      measurement_type: 'Ozone',
+      measurement_short_type: 'O3',
+      unit_symbol: 'ppb',
+      threshold_very_low: 0,
+      threshold_low: 59,
+      threshold_medium: 75,
+      threshold_high: 95,
+      threshold_very_high: 115,
+      sensor_package_name: 'OpenAQ-O3'
     }
     expect(stream.to_h).to include(expected)
   end

--- a/spec/services/open_aq/filter_measurements_spec.rb
+++ b/spec/services/open_aq/filter_measurements_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 describe OpenAq::FilterMeasurements do
-  it 'keeps only pm2.5 measurements' do
+  it 'keeps only pm2.5 and no3 measurements' do
     non_pm25 = build_open_aq_measurement(sensor_name: random_string)
-    to_keep = build_open_aq_measurement(sensor_name: 'pm25')
+    pm25 = build_open_aq_measurement(sensor_name: 'pm25')
+    o3 = build_open_aq_measurement(sensor_name: 'o3')
 
-    actual = subject.call(measurements: [non_pm25, to_keep])
+    actual = subject.call(measurements: [non_pm25, pm25, o3])
 
-    expect(actual).to eq([to_keep])
+    expect(actual).to eq([pm25, o3])
   end
 end

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -160,7 +160,7 @@ end
 def build_open_aq_measurement(opts = {})
   OpenAq::Measurement.new(
     sensor_name: opts.fetch(:sensor_name, 'pm25'),
-    value: random_float,
+    value: opts.fetch(:value, random_float),
     latitude: opts.fetch(:latitude, random_big_decimal),
     longitude: opts.fetch(:longitude, random_big_decimal),
     time_local: random_date_time.change(usec: 0),


### PR DESCRIPTION
Review commit by commit.

* Import O3 measurements from OpenAQ (besides pm2.5 which we are already importing);
* use airbeam2 pm2.5 as a default for mobile and openaq pm2.5 as a default for fixed;
* show ozone parameter as a main parameter only in fixed;
* show openaq pm2.5 only in fixed.

![Screenshot 2020-02-24 at 16 46 30](https://user-images.githubusercontent.com/5238698/75167145-3bfc0500-5725-11ea-9e57-52b4afaf4cef.png)
![Screenshot 2020-02-24 at 16 46 25](https://user-images.githubusercontent.com/5238698/75167149-3c949b80-5725-11ea-8055-b5edb8b8e48e.png)
