### PR TITLE
Implement a new solution for the mobile version of filters

### DIFF
--- a/app/assets/stylesheets/modules/filters.css.scss
+++ b/app/assets/stylesheets/modules/filters.css.scss
@@ -1,32 +1,57 @@
+$filter-actions-height: 60px;
+
 .filters {
   background: $gray-dark;
   color: white;
   font-family: $bold-font;
-  height: 0;
   position: relative;
   z-index: $filters-z-index;
+}
 
-  @media screen and (max-width: $tablet-max) {
-    @include transform(translateX(100%));
-    height: 0;
-    transition: transform 200ms ease;
-    overflow: hidden;
-    width: 100vw;
+.filters--mobile {
+  @include flexbox;
+  @include flex-direction(column);
+  @include transition(all 100ms ease);
+  height: 0;
+  overflow: hidden;
+  width: 100vw;
+  top: 0;
+  position: fixed;
+  z-index: $header-z-index + 1;
 
-    &.filters--expanded {
-      @include transform(translateX(0%));
-      display: flex;
-      flex-direction: column;
-      height: calc(100vh - #{$nav-height-mobile});
-      overflow-y: auto;
-      position: absolute;
-    }
+  &.filters--expanded {
+    @include transition(all 0.5s ease);
+    overflow-y: auto;
+    height: 100%;
+    z-index: 1000;
   }
 
   @media screen and (min-width: $small-desktop-min) {
-    box-shadow: 1px 1px 6px 0 rgba(51, 51, 51, 0.5);
-    min-height: calc(100vh - #{$nav-height});
-    width: $filters-width;
+    display: none;
+  }
+}
+
+// ensures proper flex-based layout when filters are open
+.nav-icon-placeholder {
+  width: 25px;
+}
+
+.phone-filters__header {
+  @include flexbox;
+  @include justify-content(space-between);
+  @include align-items(center);
+  height: 3.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.filters--desktop {
+  box-shadow: 1px 1px 6px 0 rgba(51, 51, 51, 0.5);
+  min-height: calc(100vh - #{$nav-height});
+  width: $filters-width;
+
+  @media screen and (max-width: $tablet-max) {
+    display: none;
   }
 }
 
@@ -34,15 +59,15 @@
   @include flexbox;
   @include flex-direction(column);
   @include flex-grow(1);
-
-  .filters--expanded & {
-    height: calc(100% - #{$nav-height-mobile} - #{$session-type-nav-height});
-  }
 }
 
 .filters__form {
   @include flex-grow(1);
   padding: $margin-default;
+
+  @media screen and (min-width: $small-desktop-min) {
+    padding-bottom: $filter-actions-height;
+  }
 }
 
 .filters__actions {

--- a/app/assets/stylesheets/modules/header.scss
+++ b/app/assets/stylesheets/modules/header.scss
@@ -42,6 +42,14 @@ $header-font-size-desktop: 1.125rem;
     height: 3.5rem;
     padding-left: 1rem;
     padding-right: 1rem;
+
+    &.header__brand--filters {
+      height: auto;
+      background: $white;
+      color: $blue;
+      padding-top: 1.25em;
+      padding-bottom: 1.25em;
+    }
   }
 }
 
@@ -130,6 +138,10 @@ $header-font-size-desktop: 1.125rem;
   outline: none;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   padding: 0;
+
+  .filters--mobile & {
+    width: 27px;
+  }
 
   @media screen and (min-width: $small-desktop-min) {
     display: none;

--- a/app/assets/stylesheets/modules/icons.css.scss
+++ b/app/assets/stylesheets/modules/icons.css.scss
@@ -12,6 +12,12 @@
 
 .icon-nav-close {
   display: none;
+  stroke: $white;
+
+  .header__brand--filters & {
+    display: initial;
+    stroke: $blue;
+  }
 
   @media screen and (max-width: $tablet-max) {
     .header--nav-expanded & {

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -891,6 +891,7 @@ viewDocument model =
     { title = "AirCasting"
     , body =
         [ lazy4 viewNav model.navLogo model.sensors model.selectedSensorId model.page
+        , viewFiltersForPhone model
         , view model
         ]
     }
@@ -1038,25 +1039,64 @@ viewMain model =
                 , ( "with-filters-collapsed", not model.areFiltersExpanded )
                 ]
             ]
-            [ div
-                [ classList
-                    [ ( "filters", True )
-                    , ( "filters--expanded", model.areFiltersExpanded )
-                    ]
-                ]
-                [ viewSessionTypeNav model
-                , div [ class "filters-form-container" ]
-                    [ viewFilters model
-                    , viewFiltersButtons model.selectedSession model.sessions model.linkIcon model.popup model.emailForm
-                    , button
-                        [ class "show-results-button"
-                        , Events.onClick CloseFilters
-                        ]
-                        [ text "show results" ]
-                    ]
-                ]
+            [ viewFiltersForDesktop model
             , viewMap model
             ]
+        ]
+
+
+viewFiltersForPhone : Model -> Html Msg
+viewFiltersForPhone model =
+    div
+        [ classList
+            [ ( "filters filters--mobile", True )
+            , ( "filters--expanded", model.areFiltersExpanded )
+            ]
+        ]
+        [ div [ class "header__brand header__brand--filters" ]
+            [ div [ class "nav-icon-placeholder" ] []
+            , div
+                [ class "filters-info u--show-on-mobile"
+                , Events.onClick ToggleFiltersExpanded
+                ]
+                [ p
+                    [ class "filters-info__session-type" ]
+                    [ text (Page.toString model.page)
+                    , text " sessions"
+                    ]
+                , p [ class "filters-info__parameter-sensor" ]
+                    [ text (Sensor.parameterForId model.sensors model.selectedSensorId)
+                    , text " - "
+                    , text (Sensor.sensorLabelForId model.sensors model.selectedSensorId)
+                    ]
+                ]
+            , button
+                [ class "header__toggle-button"
+                , title "Close filters"
+                , type_ "button"
+                , ariaLabel "Close filters"
+                , Events.onClick ToggleFiltersExpanded
+                ]
+                [ Svgs.navClose ]
+            ]
+        , viewSessionTypeNav model
+        , viewFilters model
+        , viewFiltersButtons model.selectedSession model.sessions model.linkIcon model.popup model.emailForm
+        , button
+            [ class "show-results-button"
+            , Events.onClick CloseFilters
+            ]
+            [ text "show results" ]
+        ]
+
+
+viewFiltersForDesktop : Model -> Html Msg
+viewFiltersForDesktop model =
+    div
+        [ class "filters filters--desktop" ]
+        [ viewSessionTypeNav model
+        , viewFilters model
+        , viewFiltersButtons model.selectedSession model.sessions model.linkIcon model.popup model.emailForm
         ]
 
 

--- a/app/javascript/elm/src/Svgs.elm
+++ b/app/javascript/elm/src/Svgs.elm
@@ -66,7 +66,7 @@ navClose =
     Svg.svg
         [ class "icon-nav-close", height "20", viewBox "0 0 20 20", width "20" ]
         [ Svg.g
-            [ fill "none", fillRule "evenodd", stroke "#fff", strokeLinecap "square", strokeWidth "2", transform "translate(.865179 1)" ]
+            [ fill "none", fillRule "evenodd", strokeLinecap "square", strokeWidth "2", transform "translate(.865179 1)" ]
             [ Svg.node "path"
                 [ d "m21 9h-22.73035714", transform "matrix(-.70710678 .70710678 -.70710678 -.70710678 22.581475 8.646447)" ]
                 []


### PR DESCRIPTION
The new solution resembles the behavior of the expandable mobile menu.
This PR fixes a number of issues, including filters panel breaking whenever the screen height is less than the height of the filters panel, the need to double scroll to see the bottom part of mobile version of filters, issues with map peaking out from under filters etc.