### PR TITLE
Fix "Profile Name" and "Tags" suggestions

### DIFF
--- a/app/assets/stylesheets/config/variables.css.scss
+++ b/app/assets/stylesheets/config/variables.css.scss
@@ -112,9 +112,6 @@ $bold-font: "Moderat-Bold", sans-serif;
 $body-font: "Muli", sans-serif;
 
 // z-index
-$header-z-index: 999;
-
-// z-index stack for elements on top of the map
 $sessions-z-index: 4;
 $heatmap-z-index: $sessions-z-index;
 
@@ -124,6 +121,9 @@ $partial-overlay-z-index: $heatmap-z-index - 1;
 $overlay-info-z-index: $full-overlay-z-index + 1;
 $filters-z-index: $overlay-info-z-index + 1;
 $popup-z-index: $filters-z-index + 1;
+
+$header-z-index: 999;
+$mobile-filters-z-index: $header-z-index + 1;
 
 // breakpoints
 $large-desktop-min: 1920px;

--- a/app/assets/stylesheets/modules/filters.css.scss
+++ b/app/assets/stylesheets/modules/filters.css.scss
@@ -17,7 +17,7 @@ $filter-actions-height: 60px;
   width: 100vw;
   top: 0;
   position: fixed;
-  z-index: $header-z-index + 1;
+  z-index: $mobile-filters-z-index;
 
   &.filters--expanded {
     @include transition(all 0.5s ease);
@@ -112,6 +112,11 @@ $filter-actions-height: 60px;
   max-width: $filters-width - 2 * $margin-default;
   overflow: auto;
   z-index: $popup-z-index;
+
+  .filters--expanded ~ & {
+    max-width: 100%;
+    z-index: $mobile-filters-z-index;
+  }
 }
 
 .ui-menu-item a.ui-state-hover {

--- a/app/javascript/elm/src/LabelsInput.elm
+++ b/app/javascript/elm/src/LabelsInput.elm
@@ -74,13 +74,13 @@ update msg model toCmd =
 -- VIEW
 
 
-view : Model -> String -> String -> String -> Bool -> TooltipText -> Html Msg
-view model text_ inputId placeholderText isDisabled tooltipText =
+view : Model -> String -> String -> String -> String -> Bool -> TooltipText -> Html Msg
+view model text_ inputId jsClass placeholderText isDisabled tooltipText =
     div [ class "filters__input-group" ]
         [ div [ class "tag-container" ] (List.map viewLabel <| asList model)
         , input
             [ id inputId
-            , class "input input--dark input--filters"
+            , class (String.append jsClass " input input--dark input--filters")
             , placeholder placeholderText
             , type_ "text"
             , name inputId

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -1416,8 +1416,8 @@ viewMobileFilters model =
         , lazy5 viewSensorFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , viewLocationFilter model.location model.isIndoor
         , TimeRange.view RefreshTimeRange model.resetIconWhite
-        , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" False Tooltip.profilesFilter
-        , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False Tooltip.tagsFilter
+        , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "js--profile-names-input" "+ add profile name" False Tooltip.profilesFilter
+        , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "js--tags-input" "+ add tag" False Tooltip.tagsFilter
         , viewCrowdMapOptions model.isCrowdMapOn model.crowdMapResolution model.selectedSession
         ]
 
@@ -1429,8 +1429,8 @@ viewFixedFilters model =
         , lazy5 viewSensorFilter model.page model.sensors model.selectedSensorId model.isPopupListExpanded model.popup
         , viewLocationFilter model.location model.isIndoor
         , TimeRange.view RefreshTimeRange model.resetIconWhite
-        , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "+ add profile name" model.isIndoor Tooltip.profilesFilter
-        , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "+ add tag" False Tooltip.tagsFilter
+        , Html.map ProfileLabels <| LabelsInput.view model.profiles "profile names:" "profile-names" "js--profile-names-input" "+ add profile name" model.isIndoor Tooltip.profilesFilter
+        , Html.map TagsLabels <| LabelsInput.view model.tags "tags:" "tags" "js--tags-input" "+ add tag" False Tooltip.tagsFilter
         , div [ class "filters__toggle-group" ]
             [ label [ class "label label--filters" ] [ text "placement:" ]
             , Tooltip.view Tooltip.typeToggleFilter

--- a/app/javascript/elm/tests/LabelsInputTests.elm
+++ b/app/javascript/elm/tests/LabelsInputTests.elm
@@ -15,18 +15,18 @@ all =
     describe "view"
         [ fuzz string "label area has a description" <|
             \description ->
-                LabelsInput.view LabelsInput.empty description "input-id" "placeholder" False Tooltip.profilesFilter
+                LabelsInput.view LabelsInput.empty description "input-id" "js--input-class" "placeholder" False Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.has [ Slc.text description ]
         , fuzz bool "label input can be disabled" <|
             \isDisabled ->
-                LabelsInput.view LabelsInput.empty "description" "input-id" "placeholder" isDisabled Tooltip.profilesFilter
+                LabelsInput.view LabelsInput.empty "description" "input-id" "js--input-class" "placeholder" isDisabled Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.find [ Slc.attribute (type_ "text") ]
                     |> Query.has [ Slc.attribute (disabled isDisabled) ]
         , fuzz string "when user types, updateLabelsSearch is triggered with the input" <|
             \input ->
-                LabelsInput.view LabelsInput.empty "description" "input-id" "placeholder" False Tooltip.profilesFilter
+                LabelsInput.view LabelsInput.empty "description" "input-id" "js--input-class" "placeholder" False Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.find [ Slc.tag "input" ]
                     |> Event.simulate (Event.input input)
@@ -37,7 +37,7 @@ all =
                     labels =
                         LabelsInput.withCandidate candidate LabelsInput.empty
                 in
-                LabelsInput.view labels "description" "input-id" "placeholder" False Tooltip.profilesFilter
+                LabelsInput.view labels "description" "input-id" "js--input-class" "placeholder" False Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.find [ Slc.tag "input" ]
                     |> Query.has [ Slc.attribute <| value candidate ]
@@ -47,7 +47,7 @@ all =
                     labels =
                         LabelsInput.fromList [ label ]
                 in
-                LabelsInput.view labels "description" "input-id" "placeholder" False Tooltip.profilesFilter
+                LabelsInput.view labels "description" "input-id" "js--input-class" "placeholder" False Tooltip.profilesFilter
                     |> Query.fromHtml
                     |> Query.find [ Slc.tag "button" ]
                     |> Event.simulate Event.click

--- a/app/javascript/javascript/filtersUtils.js
+++ b/app/javascript/javascript/filtersUtils.js
@@ -103,7 +103,7 @@ export const setupTimeRangeFilter = (
 };
 export const setupTagsAutocomplete = (callback, path, createParams) => {
   if (document.getElementById("tags")) {
-    $(`#tags`)
+    $(".js--tags-input")
       .autocomplete({
         source: function(request, response) {
           const data = {
@@ -126,7 +126,7 @@ export const setupTagsAutocomplete = (callback, path, createParams) => {
 
 export const setupProfileNamesAutocomplete = callback => {
   if (document.getElementById("profile-names")) {
-    $(`#profile-names`).autocomplete({
+    $(".js--profile-names-input").autocomplete({
       source: function(request, response) {
         const data = {
           q: { input: request.term }


### PR DESCRIPTION
With two alternative filter containers, profile name and tags autocomplete fields broke. Now the autocomplete is initiated per dedicated class + some css changes were introduced to adjust the dropdown menu for the mobile version and make it visible by changing the `z-index`.

This is the functionality that was broken:

<img width="252" alt="image" src="https://user-images.githubusercontent.com/457999/76539382-ff4c3f80-6480-11ea-85b5-2ccdcd50860d.png">
