### PR TITLE
[DO NOT MERGE] Create test_worker.rb

### DIFF
--- a/app/workers/test_worker.rb
+++ b/app/workers/test_worker.rb
@@ -1,11 +1,19 @@
 class TestWorker
   include Sidekiq::Worker
 
-  sidekiq_options lock: :until_executed, on_conflict: :log
+  #sidekiq_options lock: :until_executed,
+    #log_duplicate: true,
+    #on_conflict: :replace
+
+  # this won't help us
+  # when sidekiq killed then we can schedule unlimited jobs and they run in parallel ;(
+  sidekiq_options lock: :until_and_while_executing,
+    log_duplicate: true,
+    on_conflict: :log
 
   def perform
-    #t = 60*10
-    t = 10
+    t = 60*10
+    #t = 10
     t.times do |i|
       puts i
       sleep 1

--- a/app/workers/test_worker.rb
+++ b/app/workers/test_worker.rb
@@ -1,0 +1,14 @@
+class TestWorker
+  include Sidekiq::Worker
+
+  sidekiq_options lock: :until_executed, on_conflict: :log
+
+  def perform
+    #t = 60*10
+    t = 10
+    t.times do |i|
+      puts i
+      sleep 1
+    end
+  end
+end


### PR DESCRIPTION
This is experimental code to debug issue with sidekiq-unique-jobs gem and remaining lock in Redis DB that sometimes stops `OpenAqImportMeasurementsWorker` jobs from processing. 

More in story: https://trello.com/c/pOvN6w05