### PR TITLE
Use until_expired lock for OpenAQ worker to avoid deadlocks

### DIFF
--- a/app/workers/open_aq_import_measurements_worker.rb
+++ b/app/workers/open_aq_import_measurements_worker.rb
@@ -18,13 +18,94 @@ class OpenAqImportMeasurementsWorker
   # in the database will not be processed anymore from that point on (because they would always
   # raise). But duplicates should not happen because OpenAqImportMeasurementsWorker runs serially.
   #
-  # We could have solved the concurrent inserts with a different architecture (e.g. unique
-  # indexes in the database) but this seemed to be a simple and good enough solution.
-  sidekiq_options lock: :until_executed, on_conflict: :log
+  # Unfortunately, we can't use the `:until_executed` lock from sidekiq_unique_jobs because when the
+  # Sidekiq server is unexpectedly shut down while this worker is working, the lock will stay in
+  # Redis until someone manually removes it.
+  #
+  # Typically this problem is solved by making sure the lock stays either until the worker finishes
+  # or until a certain amount of time passes. [1]
+  #
+  # Unfortunately again, sidekiq_unique_jobs, unlike the enterprise version of Sidekiq, doesn't
+  # support such locking strategy. Instead, we have to hack it ourselves by using the
+  # `:until_expired` lock and Sidekiq's API to remove the lock when the worker finishes.
+  #
+  # `:until_expired` ensures that the lock expires after the time specified through
+  # `lock_expiration`. In case Sidekiq is shut down unexpectedly, the lock will eventually expire
+  # and Sidekiq will be able to enqueue this worker again.
+  #
+  # As [1] explains, this method doesn't guarantee uniqueness, but the alternative is having a
+  # system that requires a manual intervention after an unexpected restart/shutdown. [2] goes in
+  # detail as to why the timeout is required.
+  #
+  # Another unfortunate side effect of using `:until_expired` is that locks created by it aren't
+  # visible through the "Unique Digests" panel in Sidekiq dashboard as well as through
+  # `SidekiqUniqueJobs::Digests.all`. But the logs should still show info about skipping the worker
+  # because the unique digest being present. Attempting to enqueue the worker from console will
+  # return the error as well.
+  #
+  # One way to guarantee uniqueness for the concurrent inserts would be to use a different
+  # architecture (e.g. unique indexes in the database).
+  #
+  # [1] https://github.com/mperham/sidekiq/wiki/Ent-Unique-Jobs#use
+  # [2] https://redis.io/topics/distlock#why-failover-based-implementations-are-not-enough
+  sidekiq_options lock: :until_expired,
+                  on_conflict: :log,
+                  lock_expiration: 30.minutes
 
   def perform
+    started_at = Time.now
+
     return unless A9n.sidekiq_open_aq_import_measurements_enabled
 
     OpenAq::ImportMeasurements.new.call
+  ensure
+    remove_lock(started_at)
+  end
+
+  def remove_lock(started_at)
+    if !jid
+      # Skip lock removal logic in case the worker was executed synchronously (and thus has no jid).
+      logger.info "#{
+                    self.class.name
+                  } was executed synchronously. Skipping lock removal."
+      return
+    end
+
+    if Time.now - started_at < 5.seconds
+      # Sidekiq::Workers data is updated every 5 seconds.
+      # https://github.com/mperham/sidekiq/wiki/API#workers
+      logger.info 'Sleeping for 5 seconds to wait for Sidekiq workers data to refresh.'
+      sleep 5
+    end
+
+    current_workers =
+      Sidekiq::Workers.new.select do |_, _, work|
+        work.fetch('payload').fetch('class') == self.class.name
+      end.map { |_, _, work| work }
+
+    if current_workers.size == 1
+      # This is the happy path. Only one worker is at work, as it should be.
+      digest = current_workers.first.fetch('payload').fetch('unique_digest')
+      SidekiqUniqueJobs::Digests.delete_by_digest(digest)
+    elsif current_workers.size == 2
+      # This can happen if the first worker was enqueued or working for so long that the lock
+      # expired and another worker started working. We shouldn't remove the lock here, as the second
+      # worker acquired the lock again and should prevent any further workers from being enqueued.
+      logger.warn "Detected two active #{
+                    self.class.name
+                  } workers. Skipping lock removal."
+    else
+      # Here we deal with either zero workers or more than two workers.
+      #
+      # We shouldn't ever have zero workers since this code should be called from within an
+      # asynchronous Sidekiq worker. So either we had wrong assumptions or Sidekiq's API has
+      # changed.
+      #
+      # Having more than two workers means there's something wrong with our locking logic or it
+      # takes workers too much time to go from being enqueued to being finished.
+      logger.error "Detected an anomaly: there is #{
+                     current_workers.size
+                   } active #{self.class.name} workers. Skipping lock removal."
+    end
   end
 end


### PR DESCRIPTION
I'm sparing an extended description here as I believe I explained the cause of the problem in the comment in code. Please read it first!

## Future recommendations

### `OpenAqImportMeasurementsWorker` queue priority

In the logs I seen scenarios where `OpenAqImportMeasurementsWorker` got enqueued but it took Sidekiq over 10 minutes to actually get around to starting the worker. The longest elapsed time for the worker I found was at 3.7 minutes.

Given that the lock is created when the worker gets enqueued, I think we should increase the priority for `OpenAqImportMeasurementsWorker` to ensure Sidekiq starts the worker before the lock expires. Since we should be running only one of these workers at a time and there are 15 Sidekiq threads, I think this worker could be put on the `critical` queue. Unless I'm missing something and it's really important for other workers to be fetched first.

### Guaranteeing uniqueness through other means

In short, Sidekiq (or rather Redis) can't do it without risking deadlocks that require manual intervention. sidekiq_unique_jobs should mention this in the README, just as [Sidekiq does for enterprise Unique Jobs](https://github.com/mperham/sidekiq/wiki/Ent-Unique-Jobs#use):

> This means that a second job can be pushed to Redis after 10 minutes or after the first job has successfully processed. If your job retries for a while, 10 minutes can pass, thus allowing another copy of the same job to be pushed to Redis. Design your jobs so that uniqueness is considered best effort, not a 100% guarantee. A time limit is mandatory so that if a process crashes, any locks it is holding won't last forever.

More in-depth explanation is available in [Redis docs](https://redis.io/topics/distlock#why-failover-based-implementations-are-not-enough).

As it was suggested in the comment in `OpenAqImportMeasurementsWorker` before, the most reliable solution to guarantee this would be to implement this on the database level. However, I'm not particurarly knowledgable when it comes to Mysql so I figured out it'll take me less time to create this lock workaround rather than refactoring database stuff.

However I'm open to suggestions as I'm not particularly fond of the solution I implemented. It'd be much more straightforward if sidekiq_unique_jobs supported the same locking mechanism that Sidekiq Enterprise offers.