### PR TITLE
feat: add more data to fixed stream jsons

### DIFF
--- a/app/services/api/to_fixed_session_hash.rb
+++ b/app/services/api/to_fixed_session_hash.rb
@@ -23,7 +23,15 @@ class Api::ToFixedSessionHash
       minLongitude: stream.min_longitude,
       notes: notes.map(&:as_json),
       isIndoor: session.is_indoor,
-      lastMeasurementValue: stream.average_value
+      lastMeasurementValue: stream.average_value,
+      threshold_high: stream.threshold_high,
+      threshold_low: stream.threshold_low,
+      threshold_medium: stream.threshold_medium,
+      threshold_very_high: stream.threshold_very_high,
+      threshold_very_low: stream.threshold_very_low,
+      unit_name: stream.unit_name,
+      measurement_short_type: stream.measurement_short_type,
+      measurement_type: stream.measurement_type,
     }
   end
 

--- a/spec/controllers/api/fixed/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/sessions_controller_spec.rb
@@ -48,7 +48,15 @@ describe Api::Fixed::SessionsController do
         'minLatitude' => 1.0,
         'minLongitude' => 1.0,
         'notes' => [],
-        'sensorUnit' => 'F'
+        'sensorUnit' => 'F',
+        'threshold_very_low' => 20,
+        'threshold_low' => 60,
+        'threshold_medium' => 70,
+        'threshold_high' => 80,
+        'threshold_very_high' => 100,
+        'unit_name' => 'Fahrenheit',
+        'measurement_short_type' => 'F',
+        'measurement_type' => 'Temperature',
       }
       expect(json_response).to eq(expected)
     end

--- a/spec/controllers/api/fixed/streams_controller_spec.rb
+++ b/spec/controllers/api/fixed/streams_controller_spec.rb
@@ -48,7 +48,15 @@ describe Api::Fixed::StreamsController do
         'minLatitude' => 1.0,
         'minLongitude' => 1.0,
         'notes' => [],
-        'sensorUnit' => 'F'
+        'sensorUnit' => 'F',
+        'threshold_very_low' => 20,
+        'threshold_low' => 60,
+        'threshold_medium' => 70,
+        'threshold_high' => 80,
+        'threshold_very_high' => 100,
+        'unit_name' => 'Fahrenheit',
+        'measurement_short_type' => 'F',
+        'measurement_type' => 'Temperature',
       }
       expect(json_response).to eq(expected)
     end


### PR DESCRIPTION
Adding following fields to the fixed streams jsons: 
```
"threshold_high": 55,
"threshold_low": 12,
 "threshold_medium": 35,
 "threshold_very_high": 150,
 "threshold_very_low": 0,
 "unit_name": "microgram per cubic meter",
 "measurement_short_type": "PM",
 "measurement_type": "Particulate Matter",
 ```