### PR TITLE
Show PurpleAir link when PurpleAir is the selected sensor

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -35,6 +35,7 @@
 @import "./modules/note";
 @import "./modules/overlay";
 @import "./modules/overlay-info";
+@import "./modules/purpleair-link";
 @import "./modules/refresh-timerange-button";
 @import "./modules/sessions";
 @import "./modules/session-card";

--- a/app/assets/stylesheets/modules/purpleair-link.scss
+++ b/app/assets/stylesheets/modules/purpleair-link.scss
@@ -1,0 +1,12 @@
+.purpleair-link {
+  margin-bottom: 24px;
+  order: -1;
+
+  & + input {
+    margin-bottom: 4px;
+  }
+
+  a {
+    color: $white;
+  }
+}

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -1501,7 +1501,14 @@ viewParameterFilter page sensors selectedSensorId isPopupListExpanded popup =
 viewSensorFilter : Page -> List Sensor -> String -> Bool -> Popup -> Html Msg
 viewSensorFilter page sensors selectedSensorId isPopupListExpanded popup =
     div [ class "filters__input-group" ]
-        [ input
+        [ case Sensor.sensorLabelForId sensors selectedSensorId of
+            "PurpleAir-PM2.5 (µg/m³)" ->
+                div [ class "purpleair-link" ]
+                    [ a [ href "https://www.purpleair.com", target "_blank" ] [ text "www.purpleair.com" ] ]
+
+            _ ->
+                text ""
+        , input
             [ id "sensor"
             , class "input input--dark input--filters"
             , placeholder "sensor"

--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -1500,8 +1500,13 @@ viewParameterFilter page sensors selectedSensorId isPopupListExpanded popup =
 
 viewSensorFilter : Page -> List Sensor -> String -> Bool -> Popup -> Html Msg
 viewSensorFilter page sensors selectedSensorId isPopupListExpanded popup =
+    let
+        sensorLabel : String
+        sensorLabel =
+            Sensor.sensorLabelForId sensors selectedSensorId
+    in
     div [ class "filters__input-group" ]
-        [ case Sensor.sensorLabelForId sensors selectedSensorId of
+        [ case sensorLabel of
             "PurpleAir-PM2.5 (µg/m³)" ->
                 div [ class "purpleair-link" ]
                     [ a [ href "https://www.purpleair.com", target "_blank" ] [ text "www.purpleair.com" ] ]
@@ -1515,14 +1520,14 @@ viewSensorFilter page sensors selectedSensorId isPopupListExpanded popup =
             , type_ "text"
             , name "sensor"
             , Popup.clickWithoutDefault (ShowListPopup Popup.SensorList)
-            , value (Sensor.sensorLabelForId sensors selectedSensorId)
+            , value sensorLabel
             , autocomplete False
             , readonly True
             ]
             []
         , label [ class "label label--filters", for "sensor" ] [ text "sensor:" ]
         , Tooltip.view Tooltip.sensorFilter
-        , viewListPopup Popup.isSensorPopupShown isPopupListExpanded popup (Sensor.labelsForParameter page sensors selectedSensorId) "sensors" (Sensor.sensorLabelForId sensors selectedSensorId)
+        , viewListPopup Popup.isSensorPopupShown isPopupListExpanded popup (Sensor.labelsForParameter page sensors selectedSensorId) "sensors" sensorLabel
         ]
 
 


### PR DESCRIPTION
Trello: https://trello.com/c/jDtJEwms/1606-maps-fixed-purpleair-when-purpleair-is-the-selected-sensor-display-the-link-wwwpurpleaircom-directly-under-the-sensor-text-field