### PR TITLE
Fix threshold alert emails

### DIFF
--- a/app/models/api/threshold_alerts.rb
+++ b/app/models/api/threshold_alerts.rb
@@ -12,6 +12,7 @@ module Api::ThresholdAlerts
       required(:session_uuid).filled(:str?)
       required(:threshold_value).filled(:str?)
       required(:frequency).filled(:str?)
+      required(:timezone_offset).filled(:str?)
     end
 
   class Struct < Dry::Struct
@@ -19,5 +20,6 @@ module Api::ThresholdAlerts
     attribute :session_uuid, Types::Strict::String
     attribute :threshold_value, Types::Coercible::Float
     attribute :frequency, Types::Coercible::Integer
+    attribute :timezone_offset, Types::Coercible::Integer
   end
 end

--- a/app/services/api/create_threshold_alert.rb
+++ b/app/services/api/create_threshold_alert.rb
@@ -20,7 +20,8 @@ module Api
         session_uuid:    data[:session_uuid],
         sensor_name:     data[:sensor_name],
         threshold_value: data[:threshold_value],
-        frequency:       data[:frequency]
+        frequency:       data[:frequency],
+        timezone_offset: data[:timezone_offset]
       )
 
       Success.new(alert.id)

--- a/app/services/api/to_threshold_alerts_array.rb
+++ b/app/services/api/to_threshold_alerts_array.rb
@@ -7,17 +7,18 @@ module Api
     def call
       alerts.map do |alert|
         {
-          id:              alert.id,
-          session_uuid:    alert.session_uuid,
-          sensor_name:     alert.sensor_name,
+          id: alert.id,
+          session_uuid: alert.session_uuid,
+          sensor_name: alert.sensor_name,
           threshold_value: alert.threshold_value,
-          frequency:       alert.frequency,
-          timezone_offset: alert.timezone_offset
+          frequency: alert.frequency,
+          timezone_offset: alert.timezone_offset,
         }
       end
     end
 
     private
+
     attr_reader :alerts
   end
 end

--- a/app/services/api/to_threshold_alerts_array.rb
+++ b/app/services/api/to_threshold_alerts_array.rb
@@ -11,7 +11,8 @@ module Api
           session_uuid:    alert.session_uuid,
           sensor_name:     alert.sensor_name,
           threshold_value: alert.threshold_value,
-          frequency:       alert.frequency
+          frequency:       alert.frequency,
+          timezone_offset: alert.timezone_offset
         }
       end
     end

--- a/app/workers/threshold_alerts_worker.rb
+++ b/app/workers/threshold_alerts_worker.rb
@@ -28,8 +28,10 @@ class ThresholdAlertsWorker
       end
       # next unless stream
 
-      date_to_compare = alert.last_email_at || alert.created_at
-      measurements = stream.measurements.where('time > ?', date_to_compare).order('time ASC')
+      date_to_compare = alert.last_email_at || alert.created_at # Those are in UTC
+      date_to_compare_local = date_to_compare + alert.timezone_offset
+
+      measurements = stream.measurements.where('time > ?', date_to_compare_local).order('time ASC') # Measurement#time is local
       Sidekiq.logger.info "[TRSHLD] Found #{measurements.count} measurements since #{date_to_compare}: #{measurements.inspect} for alert ##{alert.id}."
 
       measurements_above_threshold = measurements&.select { |m| m.value > alert.threshold_value }

--- a/db/migrate/20221006162918_add_timezone_offset_to_threshold_alert.rb
+++ b/db/migrate/20221006162918_add_timezone_offset_to_threshold_alert.rb
@@ -1,0 +1,5 @@
+class AddTimezoneOffsetToThresholdAlert < ActiveRecord::Migration[6.1]
+  def change
+    add_column :threshold_alerts, :timezone_offset, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_27_100546) do
+ActiveRecord::Schema.define(version: 2022_10_06_162918) do
 
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(version: 2022_07_27_100546) do
     t.index ["name"], name: "index_tags_on_name"
   end
 
-  create_table "threshold_alerts", charset: "utf8", force: :cascade do |t|
+  create_table "threshold_alerts", charset: "utf8mb3", force: :cascade do |t|
     t.integer "user_id"
     t.string "session_uuid"
     t.string "sensor_name"
@@ -193,10 +193,11 @@ ActiveRecord::Schema.define(version: 2022_07_27_100546) do
     t.datetime "last_email_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "timezone_offset", default: 0
     t.index ["session_uuid", "sensor_name"], name: "index_threshold_alerts_on_session_uuid_and_sensor_name"
   end
 
-  create_table "users", id: :integer, charset: "utf8", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", limit: 128, default: "", null: false
     t.string "reset_password_token"

--- a/spec/controllers/api/fixed/threshold_alerts_controller_spec.rb
+++ b/spec/controllers/api/fixed/threshold_alerts_controller_spec.rb
@@ -16,7 +16,8 @@ describe Api::Fixed::ThresholdAlertsController do
           sensor_name: 'PM2.5',
           session_uuid: uuid,
           threshold_value: 15.0,
-          frequency: 1
+          frequency: 1,
+          timezone_offset: -18000
         }
       }
 
@@ -38,14 +39,15 @@ describe Api::Fixed::ThresholdAlertsController do
           sensor_name: 'PM2.5',
           session_uuid: uuid,
           threshold_value: nil,
-          frequency: nil
+          frequency: nil,
+          timezone_offset: nil
         }
       }
 
       it 'returns errors' do
         session = create_session!(uuid: uuid, type: 'FixedSession')
         stream = create_stream!(session: session, sensor_name: 'PM2.5')
-        errors = ['threshold_value must be filled', 'frequency must be filled']
+        errors = ['threshold_value must be filled', 'frequency must be filled', 'timezone_offset must be filled']
 
         post :create, params: { data: params }, format: :json
 
@@ -60,7 +62,8 @@ describe Api::Fixed::ThresholdAlertsController do
           sensor_name: "PM2.5",
           session_uuid: "123-456",
           threshold_value: 10,
-          frequency: 1
+          frequency: 1,
+          timezone_offset: -18000
         }
       }
       errors = ['alert already exists']
@@ -92,14 +95,16 @@ describe Api::Fixed::ThresholdAlertsController do
           'session_uuid' => '1',
           'sensor_name' => 'PM2.5',
           'frequency' => 1,
-          'threshold_value' => 10
+          'threshold_value' => 10,
+          'timezone_offset' => -18000
         },
         {
           'id' => alert2.id,
           'session_uuid' => '2',
           'sensor_name' => 'PM10',
           'frequency' => 1,
-          'threshold_value' => 10
+          'threshold_value' => 10,
+          'timezone_offset' => -18000
         }
       ]
     }

--- a/spec/controllers/api/fixed/threshold_alerts_controller_spec.rb
+++ b/spec/controllers/api/fixed/threshold_alerts_controller_spec.rb
@@ -3,23 +3,21 @@ require 'rails_helper'
 describe Api::Fixed::ThresholdAlertsController do
   let(:user) { FactoryBot.create(:user) }
 
-  before do
-    sign_in user
-  end
+  before { sign_in user }
 
   describe '#create' do
-    let(:uuid)   { '123-0345' }
+    let(:uuid) { '123-0345' }
 
     context 'with valid params' do
-      let(:params) {
+      let(:params) do
         {
           sensor_name: 'PM2.5',
           session_uuid: uuid,
           threshold_value: 15.0,
           frequency: 1,
-          timezone_offset: -18000
+          timezone_offset: -18_000,
         }
-      }
+      end
 
       it 'creates a record' do
         session = create_session!(uuid: uuid, type: 'FixedSession')
@@ -29,25 +27,29 @@ describe Api::Fixed::ThresholdAlertsController do
 
         alert = ThresholdAlert.last
         expect(response.status).to eq 201
-        expect(response.body).to eq({id: alert.id}.to_json)
+        expect(response.body).to eq({ id: alert.id }.to_json)
       end
     end
 
     context 'with invalid params' do
-      let(:params) {
+      let(:params) do
         {
           sensor_name: 'PM2.5',
           session_uuid: uuid,
           threshold_value: nil,
           frequency: nil,
-          timezone_offset: nil
+          timezone_offset: nil,
         }
-      }
+      end
 
       it 'returns errors' do
         session = create_session!(uuid: uuid, type: 'FixedSession')
         stream = create_stream!(session: session, sensor_name: 'PM2.5')
-        errors = ['threshold_value must be filled', 'frequency must be filled', 'timezone_offset must be filled']
+        errors = [
+          'threshold_value must be filled',
+          'frequency must be filled',
+          'timezone_offset must be filled',
+        ]
 
         post :create, params: { data: params }, format: :json
 
@@ -57,24 +59,27 @@ describe Api::Fixed::ThresholdAlertsController do
     end
 
     context 'when alert already exists for stream' do
-      let(:params) {
+      let(:params) do
         {
-          sensor_name: "PM2.5",
-          session_uuid: "123-456",
+          sensor_name: 'PM2.5',
+          session_uuid: '123-456',
           threshold_value: 10,
           frequency: 1,
-          timezone_offset: -18000
+          timezone_offset: -18_000,
         }
-      }
+      end
       errors = ['alert already exists']
 
-      before do
-        sign_in user
-      end
+      before { sign_in user }
 
       it do
-        alert = FactoryBot.create(:threshold_alert,
-          session_uuid: "123-456", sensor_name: "PM2.5", user: user)
+        alert =
+          FactoryBot.create(
+            :threshold_alert,
+            session_uuid: '123-456',
+            sensor_name: 'PM2.5',
+            user: user,
+          )
 
         post :create, params: { data: params }, format: :json
 
@@ -85,10 +90,24 @@ describe Api::Fixed::ThresholdAlertsController do
   end
 
   describe '#index' do
-    let!(:alert1) { FactoryBot.create(:threshold_alert, user: user, session_uuid: '1', sensor_name: 'PM2.5') }
-    let!(:alert2) { FactoryBot.create(:threshold_alert, user: user, session_uuid: '2', sensor_name: 'PM10') }
+    let!(:alert1) do
+      FactoryBot.create(
+        :threshold_alert,
+        user: user,
+        session_uuid: '1',
+        sensor_name: 'PM2.5',
+      )
+    end
+    let!(:alert2) do
+      FactoryBot.create(
+        :threshold_alert,
+        user: user,
+        session_uuid: '2',
+        sensor_name: 'PM10',
+      )
+    end
 
-    let(:expected_response) {
+    let(:expected_response) do
       [
         {
           'id' => alert1.id,
@@ -96,7 +115,7 @@ describe Api::Fixed::ThresholdAlertsController do
           'sensor_name' => 'PM2.5',
           'frequency' => 1,
           'threshold_value' => 10,
-          'timezone_offset' => -18000
+          'timezone_offset' => -18_000,
         },
         {
           'id' => alert2.id,
@@ -104,10 +123,10 @@ describe Api::Fixed::ThresholdAlertsController do
           'sensor_name' => 'PM10',
           'frequency' => 1,
           'threshold_value' => 10,
-          'timezone_offset' => -18000
-        }
+          'timezone_offset' => -18_000,
+        },
       ]
-    }
+    end
 
     it do
       get :index
@@ -117,16 +136,15 @@ describe Api::Fixed::ThresholdAlertsController do
   end
 
   describe '#destroy' do
-    before do
-      sign_in user
-    end
+    before { sign_in user }
 
     context 'when alert belongs to user' do
       it do
         alert = FactoryBot.create(:threshold_alert, user: user)
 
-        expect { delete :destroy, params: { id: alert.id } }
-          .to change { ThresholdAlert.count }.from(1).to 0
+        expect { delete :destroy, params: { id: alert.id } }.to change {
+          ThresholdAlert.count
+        }.from(1).to 0
       end
     end
 
@@ -136,8 +154,9 @@ describe Api::Fixed::ThresholdAlertsController do
       it do
         alert = FactoryBot.create(:threshold_alert, user: another_user)
 
-        expect { delete :destroy, params: { id: alert.id } }
-          .not_to change { ThresholdAlert.count }
+        expect { delete :destroy, params: { id: alert.id } }.not_to change {
+          ThresholdAlert.count
+        }
         expect(response.status).to eq 401
       end
     end

--- a/spec/controllers/api/fixed/threshold_alerts_controller_spec.rb
+++ b/spec/controllers/api/fixed/threshold_alerts_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Api::Fixed::ThresholdAlertsController do
   let(:user) { FactoryBot.create(:user) }
+  let(:timezone_offset) { -18_000 }
 
   before { sign_in user }
 
@@ -15,7 +16,7 @@ describe Api::Fixed::ThresholdAlertsController do
           session_uuid: uuid,
           threshold_value: 15.0,
           frequency: 1,
-          timezone_offset: -18_000,
+          timezone_offset: timezone_offset,
         }
       end
 
@@ -65,7 +66,7 @@ describe Api::Fixed::ThresholdAlertsController do
           session_uuid: '123-456',
           threshold_value: 10,
           frequency: 1,
-          timezone_offset: -18_000,
+          timezone_offset: timezone_offset,
         }
       end
       errors = ['alert already exists']
@@ -79,6 +80,7 @@ describe Api::Fixed::ThresholdAlertsController do
             session_uuid: '123-456',
             sensor_name: 'PM2.5',
             user: user,
+            timezone_offset: timezone_offset,
           )
 
         post :create, params: { data: params }, format: :json
@@ -96,6 +98,7 @@ describe Api::Fixed::ThresholdAlertsController do
         user: user,
         session_uuid: '1',
         sensor_name: 'PM2.5',
+        timezone_offset: timezone_offset,
       )
     end
     let!(:alert2) do
@@ -104,6 +107,7 @@ describe Api::Fixed::ThresholdAlertsController do
         user: user,
         session_uuid: '2',
         sensor_name: 'PM10',
+        timezone_offset: timezone_offset,
       )
     end
 

--- a/spec/factories/threshold_alerts.rb
+++ b/spec/factories/threshold_alerts.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     threshold_value { 10 }
     frequency { 1 }
     last_email_at { 1.hour.ago }
-    timezone_offset { -18000 }
+    timezone_offset { -18_000 }
   end
 end

--- a/spec/factories/threshold_alerts.rb
+++ b/spec/factories/threshold_alerts.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     threshold_value { 10 }
     frequency { 1 }
     last_email_at { 1.hour.ago }
+    timezone_offset { -18000 }
   end
 end

--- a/spec/workers/threshold_alerts_worker_spec.rb
+++ b/spec/workers/threshold_alerts_worker_spec.rb
@@ -6,6 +6,7 @@ describe ThresholdAlertsWorker do
   let(:user) { create_user!(email: 'user@ex.com') }
   let(:session) { create_session!(user: user, title: 'Session Title') }
   let(:stream) { create_stream!(session: session, sensor_name: 'PM2.5') }
+  let(:timezone_offset) { -18_000 }
 
   context 'when measurement exceeds threshold value' do
     context 'when time passed since last email > frequency' do
@@ -17,11 +18,11 @@ describe ThresholdAlertsWorker do
           threshold_value: 10,
           frequency: 1,
           last_email_at: Time.current - 70.minutes,
-          timezone_offset: -18_000,
+          timezone_offset: timezone_offset,
         )
       end
       let!(:measurement) do
-        create_measurement!(stream: stream, time: Time.current, value: 20)
+        create_measurement!(stream: stream, time: Time.current + timezone_offset, value: 20)
       end
 
       it 'sends alert email' do
@@ -45,7 +46,7 @@ describe ThresholdAlertsWorker do
         )
       end
       let!(:measurement) do
-        create_measurement!(stream: stream, time: Time.current, value: 20)
+        create_measurement!(stream: stream, time: Time.current + timezone_offset, value: 20)
       end
 
       it 'does not send alert email' do

--- a/spec/workers/threshold_alerts_worker_spec.rb
+++ b/spec/workers/threshold_alerts_worker_spec.rb
@@ -22,7 +22,11 @@ describe ThresholdAlertsWorker do
         )
       end
       let!(:measurement) do
-        create_measurement!(stream: stream, time: Time.current + timezone_offset, value: 20)
+        create_measurement!(
+          stream: stream,
+          time: Time.current + timezone_offset,
+          value: 20,
+        )
       end
 
       it 'sends alert email' do
@@ -42,11 +46,15 @@ describe ThresholdAlertsWorker do
           threshold_value: 10,
           frequency: 1,
           last_email_at: Time.current - 10.minutes,
-          timezone_offset: -18_000,
+          timezone_offset: timezone_offset,
         )
       end
       let!(:measurement) do
-        create_measurement!(stream: stream, time: Time.current + timezone_offset, value: 20)
+        create_measurement!(
+          stream: stream,
+          time: Time.current + timezone_offset,
+          value: 20,
+        )
       end
 
       it 'does not send alert email' do

--- a/spec/workers/threshold_alerts_worker_spec.rb
+++ b/spec/workers/threshold_alerts_worker_spec.rb
@@ -3,38 +3,56 @@ require 'rails_helper'
 describe ThresholdAlertsWorker do
   ActiveJob::Base.queue_adapter = :test
 
-  let(:user)    { create_user!(email: 'user@ex.com') }
-  let(:session) { create_session!( user: user, title: 'Session Title') }
-  let(:stream)  { create_stream!(session: session, sensor_name: 'PM2.5') }
+  let(:user) { create_user!(email: 'user@ex.com') }
+  let(:session) { create_session!(user: user, title: 'Session Title') }
+  let(:stream) { create_stream!(session: session, sensor_name: 'PM2.5') }
 
   context 'when measurement exceeds threshold value' do
     context 'when time passed since last email > frequency' do
-      let!(:alert) { ThresholdAlert.create(
-                        user: user,
-                        session_uuid: session.uuid,
-                        sensor_name: stream.sensor_name,
-                        threshold_value: 10,
-                        frequency: 1,
-                        last_email_at: Time.current - 70.minutes) }
-      let!(:measurement) { create_measurement!(stream: stream, time: Time.current, value: 20) }
+      let!(:alert) do
+        ThresholdAlert.create(
+          user: user,
+          session_uuid: session.uuid,
+          sensor_name: stream.sensor_name,
+          threshold_value: 10,
+          frequency: 1,
+          last_email_at: Time.current - 70.minutes,
+          timezone_offset: -18000
+        )
+      end
+      let!(:measurement) do
+        create_measurement!(stream: stream, time: Time.current, value: 20)
+      end
 
       it 'sends alert email' do
-        expect { subject.perform }.to have_enqueued_mail(UserMailer, :threshold_exceeded_email)
+        expect { subject.perform }.to have_enqueued_mail(
+          UserMailer,
+          :threshold_exceeded_email,
+        )
       end
     end
 
     context 'when time passed since last email < frequency' do
-      let!(:alert) { ThresholdAlert.create(
-                        user: user,
-                        session_uuid: session.uuid,
-                        sensor_name: stream.sensor_name,
-                        threshold_value: 10,
-                        frequency: 1,
-                        last_email_at: Time.current - 10.minutes) }
-      let!(:measurement) { create_measurement!(stream: stream, time: Time.current, value: 20) }
+      let!(:alert) do
+        ThresholdAlert.create(
+          user: user,
+          session_uuid: session.uuid,
+          sensor_name: stream.sensor_name,
+          threshold_value: 10,
+          frequency: 1,
+          last_email_at: Time.current - 10.minutes,
+          timezone_offset: -18000
+        )
+      end
+      let!(:measurement) do
+        create_measurement!(stream: stream, time: Time.current, value: 20)
+      end
 
       it 'does not send alert email' do
-        expect { subject.perform }.not_to have_enqueued_mail(UserMailer, :threshold_exceeded_email)
+        expect { subject.perform }.not_to have_enqueued_mail(
+          UserMailer,
+          :threshold_exceeded_email,
+        )
       end
     end
   end

--- a/spec/workers/threshold_alerts_worker_spec.rb
+++ b/spec/workers/threshold_alerts_worker_spec.rb
@@ -17,7 +17,7 @@ describe ThresholdAlertsWorker do
           threshold_value: 10,
           frequency: 1,
           last_email_at: Time.current - 70.minutes,
-          timezone_offset: -18000
+          timezone_offset: -18_000,
         )
       end
       let!(:measurement) do
@@ -41,7 +41,7 @@ describe ThresholdAlertsWorker do
           threshold_value: 10,
           frequency: 1,
           last_email_at: Time.current - 10.minutes,
-          timezone_offset: -18000
+          timezone_offset: -18_000,
         )
       end
       let!(:measurement) do


### PR DESCRIPTION
This PR contains a simpler fix for threshold alerts, which assumes that we'll be getting a `timezone_offset` value along with the threshold alert data.

Trello: https://trello.com/c/IbLe2TfC/1607-fixed-following-threshold-alert

TODO: 

- [x] change all nil to 0 after the migration is run on production
- [x] update controller, api model, factory, CreateThresholdAlert service
- [ ] clean up all the logging in threshold alert worker code