### PR TITLE
(chore) hide map controls when screen width < 580

### DIFF
--- a/app/javascript/javascript/googleMapsInit.js
+++ b/app/javascript/javascript/googleMapsInit.js
@@ -47,5 +47,16 @@ export const init = () => {
     zoom: parseInt(zoom, 10),
     zoomControl: false,
   };
+
+  removeMapTypeControlOnMobile(options)
+
   map.init(element, options);
 };
+
+const removeMapTypeControlOnMobile = (options) => {
+  const width = window.innerWidth;
+  if(width < 580) {
+    options.mapTypeControl = false;
+    delete options.mapTypeControlOptions;
+  }
+}


### PR DESCRIPTION
https://trello.com/c/7UViimrA/1532-mobile-phone-remove-map-type-selection-map-satellite