### PR TITLE
fix: draw session graph with predefined thresholds if none are fetched yet

### DIFF
--- a/app/javascript/elm/src/Main.elm
+++ b/app/javascript/elm/src/Main.elm
@@ -221,7 +221,7 @@ fetchSelectedStream maybeId page =
             Cmd.none
 
         Just id ->
-            Process.sleep 1000
+            Process.sleep 1500
                 |> Task.perform
                     (\_ ->
                         ExecCmd (SelectedSession.fetch page id (RemoteData.fromResult >> GotSession))


### PR DESCRIPTION
https://trello.com/c/MR153W6c/1576-links-to-shared-sessions-dont-always-work

The issue was that at the page load both session data and heatmap thresholds are fetched from API simultaneously. Most of the time session data arrives first and the graph is attempted to be drawn immediately after that but it can't be without the thresholds. A workaround was implemented which delayed fetching the session for 1 second but that was not enough anymore.