### PR TITLE
Upgrade highcharts to 9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "elm": "^0.19.1-5",
     "elm-hot-webpack-loader": "^1.1.7",
     "elm-webpack-loader": "^6.0.1",
-    "highcharts": "~8.2.0",
+    "highcharts": "~9.0.0",
     "jquery": "3.6.0",
     "jquery-ui": "^1.12.1",
     "luminous-lightbox": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3970,10 +3970,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highcharts@~8.2.0:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-8.2.2.tgz#3eb1a694cff013d3385c3ca8e58e69a27be52cab"
-  integrity sha512-F63TXO7RxsvTcpO/KOubQZWualYpCMyCTuKtoWbt7KCsfQ3Kl7Fr6HEyyJdjkYl+XlnmnKlSRi9d3HjLK9Q0wg==
+highcharts@~9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.0.1.tgz#49ec994a7897a96fc3e0880f49a0eca34adff6a2"
+  integrity sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Ref: https://trello.com/c/pJ5HOiAm

Part of security update: https://github.com/HabitatMap/AirCasting/pull/436