### PR TITLE
api/fixed/sessions/:id unused endpoint deletion

### DIFF
--- a/app/controllers/api/fixed/sessions_controller.rb
+++ b/app/controllers/api/fixed/sessions_controller.rb
@@ -2,21 +2,6 @@ module Api
   class Fixed::SessionsController < BaseController
     respond_to :json
 
-    def show
-      GoogleAnalyticsWorker::RegisterEvent.async_call('Fixed Sessions#show')
-
-      if form.invalid?
-        render json: form.errors, status: :bad_request
-      else
-        hash =
-          Api::ToFixedSessionHash.new(
-            measurements_limit: form.to_h.measurements_limit,
-            stream: stream,
-          ).call
-        render json: hash, status: :ok
-      end
-    end
-
     def show_all_streams
       GoogleAnalyticsWorker::RegisterEvent.async_call(
         'Fixed Sessions#show_all_streams',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,6 @@ Rails.application.routes.draw do
     end
 
     namespace :fixed do
-      get 'sessions/:id' => 'sessions#show'
       get 'sessions/:id/streams' => 'sessions#show_all_streams'
       get 'streams/:id' => 'streams#show'
       get 'autocomplete/tags' => 'autocomplete#tags'

--- a/spec/controllers/api/fixed/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/sessions_controller_spec.rb
@@ -1,67 +1,6 @@
 require 'rails_helper'
 
 describe Api::Fixed::SessionsController do
-  describe '#show' do
-    it 'returns session json' do
-      username = 'username'
-      title = 'session title'
-      start_time_local = DateTime.new(2_000, 10, 1, 2, 3)
-      end_time_local = DateTime.new(2_001, 11, 4, 5, 6)
-      sensor_name = 'sensor-name'
-      user = create_user!(username: username)
-      session =
-        create_fixed_session!(
-          user: user,
-          title: title,
-          start_time_local: start_time_local,
-          end_time_local: end_time_local,
-        )
-      create_stream!(session: session, sensor_name: 'another-sensor-name')
-      stream = create_stream!(session: session, sensor_name: sensor_name)
-      create_stream!(session: session, sensor_name: 'yet another-sensor-name')
-      create_measurement!(stream: stream, time: start_time_local)
-
-      get :show, params: { id: session.id, sensor_name: sensor_name }
-
-      expected = {
-        'title' => title,
-        'username' => username,
-        'sensorName' => sensor_name,
-        'startTime' => 970_365_780_000,
-        'endTime' => 1_004_850_360_000,
-        'id' => session.id,
-        'streamId' => stream.id,
-        'isIndoor' => false,
-        'lastMeasurementValue' => stream.average_value,
-        'latitude' => 123.0,
-        'longitude' => 123.0,
-        'maxLatitude' => 1.0,
-        'maxLongitude' => 1.0,
-        'measurements' => [
-          {
-            'latitude' => 1.0,
-            'longitude' => 1.0,
-            'time' => start_time_local.to_i * 1_000,
-            'value' => 123.0,
-          },
-        ],
-        'minLatitude' => 1.0,
-        'minLongitude' => 1.0,
-        'notes' => [],
-        'sensorUnit' => 'F',
-        'threshold_very_low' => 20,
-        'threshold_low' => 60,
-        'threshold_medium' => 70,
-        'threshold_high' => 80,
-        'threshold_very_high' => 100,
-        'unit_name' => 'Fahrenheit',
-        'measurement_short_type' => 'F',
-        'measurement_type' => 'Temperature',
-      }
-      expect(json_response).to eq(expected)
-    end
-  end
-
   describe '#show_all_streams' do
     it 'returns session json including all streams' do
       username = 'username'


### PR DESCRIPTION
We've discovered a lot of requests to this public endpoint connected to deleted OpenAQ sessions.
We don't use this endpoint anymore in our mobile apps.
