### PR TITLE
Time zone translation script fix

### DIFF
--- a/lib/tasks/populate_time_with_timezone.rake
+++ b/lib/tasks/populate_time_with_timezone.rake
@@ -24,7 +24,7 @@ namespace :measurements do
         break
       end
 
-      Streams.where(id: stream_ids_to_update).find_each(batch_size: 100) do |stream|
+      Stream.where(id: stream_ids_to_update).find_each(batch_size: 100) do |stream|
         time_zone_name = Session.find(stream.session_id).time_zone
 
         Measurement.where(stream_id: stream.id, time_with_time_zone: nil).find_in_batches(batch_size: batch_size) do |batch|

--- a/lib/tasks/populate_time_with_timezone.rake
+++ b/lib/tasks/populate_time_with_timezone.rake
@@ -1,5 +1,6 @@
 namespace :measurements do
   task populate_time_with_time_zone: :environment do
+    batch_size = 50_000
     sleep_time = 0.5
     total_processed = 0
     last_maintenance_at = 0
@@ -12,35 +13,48 @@ namespace :measurements do
     total_to_update = ActiveRecord::Base.connection.execute(total_to_update_sql).first['count'].to_i
     puts "Total measurements to update: #{total_to_update}"
 
-    Stream
-      .distinct
-      .joins(:session, :measurements)
-      .where(measurements: {time_with_time_zone: nil})
-      .pluck('streams.id, sessions.time_zone, streams.measurements_count')
-      .each do |stream_id, time_zone_name, measurements_count|
-
-      sql = <<-SQL
-        UPDATE measurements
-        SET time_with_time_zone = time AT TIME ZONE '#{time_zone_name}'
-        WHERE stream_id = '#{stream_id}' AND time_with_time_zone IS NULL
+    while true
+      stream_ids_to_update_sql = <<-SQL
+        SELECT DISTINCT stream_id FROM measurements WHERE time_with_time_zone IS NULL LIMIT #{batch_size}
       SQL
 
-      ActiveRecord::Base.connection.execute(sql)
+      stream_ids_to_update = ActiveRecord::Base.connection.execute(stream_ids_to_update_sql).map { |row| row['stream_id'] }
 
-      total_processed += measurements_count
-      progress_percentage = (total_processed.to_f / total_to_update * 100).round(2)
-      puts "Processed #{total_processed} measurements so far (#{progress_percentage}% of total to update)."
+      if stream_ids_to_update.empty?
+        break
+      end
 
-      sleep(sleep_time)
+      Streams.where(id: stream_ids_to_update).find_each(batch_size: 100) do |stream|
+        time_zone_name = Session.find(stream.session_id).time_zone
 
-      if total_processed - last_maintenance_at >= maintenance_interval
-        puts "Performing database maintenance (VACUUM ANALYZE measurements)..."
-        ActiveRecord::Base.connection.execute("VACUUM ANALYZE measurements")
-        puts "Database maintenance completed."
-        last_maintenance_at = total_processed
+        Measurement.where(stream_id: stream.id, time_with_time_zone: nil).find_in_batches(batch_size: batch_size) do |batch|
+          measurement_ids = batch.map(&:id)
+
+          unless measurement_ids.empty?
+            sql = <<-SQL
+              UPDATE measurements
+              SET time_with_time_zone = time at time zone '#{time_zone_name}'
+              WHERE id IN (#{measurement_ids.join(',')})
+            SQL
+
+            ActiveRecord::Base.connection.execute(sql)
+          end
+
+          total_processed += batch.size
+          progress_percentage = (total_processed.to_f / total_to_update * 100).round(2)
+          puts "Processed #{total_processed} measurements so far (#{progress_percentage}% of total to update)."
+
+          sleep(sleep_time)
+
+          if total_processed - last_maintenance_at >= maintenance_interval
+            puts "Performing database maintenance (VACUUM ANALYZE measurements)..."
+            ActiveRecord::Base.connection.execute("VACUUM ANALYZE measurements")
+            puts "Database maintenance completed."
+            last_maintenance_at = total_processed
+          end
+        end
       end
     end
-
 
     puts "Finished populating time_with_time_zone for measurements."
   end

--- a/lib/tasks/populate_time_with_timezone.rake
+++ b/lib/tasks/populate_time_with_timezone.rake
@@ -42,6 +42,7 @@ namespace :measurements do
             puts "Database maintenance completed."
             last_maintenance_at = total_processed
           end
+        end
     end
 
     puts "Finished populating time_with_time_zone for measurements."

--- a/lib/tasks/populate_time_with_timezone.rake
+++ b/lib/tasks/populate_time_with_timezone.rake
@@ -4,12 +4,14 @@ namespace :measurements do
     sleep_time = 0.5
     total_processed = 0
     last_maintenance_at = 0
-    maintenance_interval = 200_000_000
+    maintenance_interval = 50_000_000
 
+    stream_ids_to_update = Measurement.where(time_with_time_zone: nil).select(:stream_id).distinct
+    session_ids_to_update = Stream.where(id: stream_ids_to_update).select(:session_id).distinct.pluck(:session_id)
     total_to_update = Measurement.where(time_with_time_zone: nil).count
     puts "Total measurements to update: #{total_to_update}"
 
-    Session.find_each(batch_size: 100) do |session|
+    Session.where(id: session_ids_to_update).find_each(batch_size: 100) do |session|
       time_zone_name = session.time_zone
       next if time_zone_name.blank?
 

--- a/lib/tasks/populate_time_with_timezone.rake
+++ b/lib/tasks/populate_time_with_timezone.rake
@@ -20,9 +20,6 @@ namespace :measurements do
         time_zone_name = session.time_zone
         next if time_zone_name.blank?
 
-        Measurement.where(stream_id: Stream.select(:id).where(session_id: session.id), time_with_time_zone: nil).find_in_batches(batch_size: batch_size) do |batch|
-          measurement_ids = batch.map(&:id)
-
         session.streams.each do |stream|
           sql = <<-SQL
             UPDATE measurements
@@ -45,7 +42,6 @@ namespace :measurements do
             puts "Database maintenance completed."
             last_maintenance_at = total_processed
           end
-      end
     end
 
     puts "Finished populating time_with_time_zone for measurements."

--- a/lib/tasks/populate_time_with_timezone.rake
+++ b/lib/tasks/populate_time_with_timezone.rake
@@ -15,12 +15,11 @@ namespace :measurements do
     Session.select('streams.id, sessions.time_zone')
       .distinct
       .joins(streams: :measurements)
-      .where(measurements: { time_with_time_zone:  nil }) do |session|
+      .where(measurements: { time_with_time_zone: nil }).each do |stream|
 
-        time_zone_name = session.time_zone
+        time_zone_name = stream.time_zone
         next if time_zone_name.blank?
 
-        session.streams.each do |stream|
           sql = <<-SQL
             UPDATE measurements
             SET time_with_time_zone = time AT TIME ZONE '#{time_zone_name}'
@@ -42,7 +41,6 @@ namespace :measurements do
             puts "Database maintenance completed."
             last_maintenance_at = total_processed
           end
-        end
     end
 
     puts "Finished populating time_with_time_zone for measurements."


### PR DESCRIPTION
The maintenance interval changed from 200mln to 50mln measurements. 
Only looping through not-processed sessions.