### PR TITLE
Station dormant

### DIFF
--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
@@ -19,6 +19,7 @@ const FixedStreamStationHeader = () => {
     updateFrequency,
     lastMeasurementValue,
     lastMeasurementDateLabel,
+    active,
   } = useSelector(selectFixedStreamShortInfo);
 
   return (
@@ -27,6 +28,7 @@ const FixedStreamStationHeader = () => {
         date={lastMeasurementDateLabel}
         value={lastMeasurementValue}
         unitSymbol={unitSymbol}
+        isActive={active}
       />
       <StationName stationName={title} />
       <DataSource profile={profile} sensorName={sensorName} />

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.style.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.style.tsx
@@ -3,7 +3,7 @@ import {
   blue,
   green,
   gray100,
-  gray400,
+  gray300,
 } from "../../../../../assets/styles/colors";
 import hexToRGBA from "../../../../../utils/hexToRGB";
 import { media } from "../../../../../utils/media";
@@ -17,14 +17,14 @@ const Container = styled.div<ContainerProps>`
     props.isActive
       ? `linear-gradient(
       241deg,
-      ${hexToRGBA(gray100, 0.4)} -2.4%,
-      ${hexToRGBA(gray100, 0.0)} 94.94%
-    ), ${gray400}`
+      ${hexToRGBA(blue, 0.4)} -2.4%,
+      ${hexToRGBA(blue, 0.0)} 94.94%
+    ), ${green}`
       : `linear-gradient(
         241deg,
-        ${hexToRGBA(blue, 0.4)} -2.4%,
-        ${hexToRGBA(blue, 0.0)} 94.94%
-      ), ${green}`};
+        ${hexToRGBA(gray100, 0.4)} -2.4%,
+        ${hexToRGBA(gray100, 0.0)} 94.94%
+      ), ${gray300}`};
   display: flex;
   flex-direction: column;
   align-self: stretch;

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.style.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.style.tsx
@@ -1,15 +1,30 @@
 import styled from "styled-components";
-import { blue, green } from "../../../../../assets/styles/colors";
+import {
+  blue,
+  green,
+  gray100,
+  gray400,
+} from "../../../../../assets/styles/colors";
 import hexToRGBA from "../../../../../utils/hexToRGB";
 import { media } from "../../../../../utils/media";
 
-const Container = styled.div`
-  background: linear-gradient(
+interface ContainerProps {
+  isActive?: boolean;
+}
+
+const Container = styled.div<ContainerProps>`
+  background: ${(props) =>
+    props.isActive
+      ? `linear-gradient(
       241deg,
-      ${hexToRGBA(blue, 0.4)} -2.4%,
-      ${hexToRGBA(blue, 0.0)} 94.94%
-    ),
-    ${green};
+      ${hexToRGBA(gray100, 0.4)} -2.4%,
+      ${hexToRGBA(gray100, 0.0)} 94.94%
+    ), ${gray400}`
+      : `linear-gradient(
+        241deg,
+        ${hexToRGBA(blue, 0.4)} -2.4%,
+        ${hexToRGBA(blue, 0.0)} 94.94%
+      ), ${green}`};
   display: flex;
   flex-direction: column;
   align-self: stretch;

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.tsx
@@ -8,13 +8,14 @@ interface StationValues {
   unitSymbol: string;
   date?: string;
   value?: number;
+  isActive?: boolean;
 }
 
-const ValueLabel = ({ date, value, unitSymbol }: StationValues) => {
+const ValueLabel = ({ date, value, unitSymbol, isActive }: StationValues) => {
   const { t } = useTranslation();
 
   return (
-    <S.Container>
+    <S.Container isActive={isActive}>
       <S.ImageContainer
         src={BroadCastLogo}
         alt={t("stationValue.altLogo")}

--- a/app/javascript/react/store/fixedStreamSelectors.ts
+++ b/app/javascript/react/store/fixedStreamSelectors.ts
@@ -138,7 +138,7 @@ const selectFixedStreamShortInfo = createSelector(
     const { value: lastMeasurementValue, date } = lastDailyAverage || {};
     const lastMeasurementDateLabel = moment(date).format("MMM D");
     const lastUpdate = moment(fixedStreamData.stream.lastUpdate).local().format("HH:mm, MMM D YYYY");
-    const active = true; //to be changed ?
+    const active = fixedStreamData.stream.active;
 
     return {
       ...fixedStreamData.stream,

--- a/app/javascript/react/store/fixedStreamSelectors.ts
+++ b/app/javascript/react/store/fixedStreamSelectors.ts
@@ -138,12 +138,14 @@ const selectFixedStreamShortInfo = createSelector(
     const { value: lastMeasurementValue, date } = lastDailyAverage || {};
     const lastMeasurementDateLabel = moment(date).format("MMM D");
     const lastUpdate = moment(fixedStreamData.stream.lastUpdate).local().format("HH:mm, MMM D YYYY");
+    const active = true; //to be changed ?
 
     return {
       ...fixedStreamData.stream,
       lastMeasurementValue,
       lastMeasurementDateLabel,
       lastUpdate,
+      active,
     };
   }
 );

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -22,6 +22,7 @@ const initialState: FixedStreamState = {
       sensorName: "",
       unitSymbol: "",
       updateFrequency: "",
+      active: true,
     },
     measurements: [],
     streamDailyAverages: [],

--- a/app/javascript/react/types/fixedStream.ts
+++ b/app/javascript/react/types/fixedStream.ts
@@ -11,6 +11,7 @@ interface DataSource {
 interface FixedStreamStationInfo extends StreamUpdate, DataSource {
   title: string;
   unitSymbol: string;
+  active: boolean; 
 }
 
 interface Measurement {


### PR DESCRIPTION
The station header should be gray when the session is dormant. The data is mocked for now. 
https://trello.com/c/4x8bo7wF/1796-add-indication-for-dormant-station-in-calendar-page