### PR TITLE
TimeZoneBuilder switched for singleton class

### DIFF
--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -193,6 +193,6 @@ class Stream < ApplicationRecord
     latitude = data.first[:latitude].to_f
     longitude = data.first[:longitude].to_f
 
-    TimeZoneBuilder.new.call(latitude, longitude)
+    TimeZoneFinderWrapper.instance.time_zone_at(lat: latitude, lng: longitude)
   end
 end

--- a/app/services/air_now/process_measurements.rb
+++ b/app/services/air_now/process_measurements.rb
@@ -33,7 +33,7 @@ class AirNow::ProcessMeasurements
 
   def create_saveable_object(measurement)
     time_with_time_zone = time_with_time_zone(measurement[:time], measurement[:date])
-    time_zone = time_zone_finder.time_zone_at(lng: measurement[:longitude], lat: measurement[:latitude])
+    time_zone = time_zone_finder.time_zone_at(lat: measurement[:latitude], lng: measurement[:longitude])
     utc_offset = time_with_time_zone.in_time_zone(time_zone).utc_offset
     time_local = time_with_time_zone + utc_offset
 

--- a/app/services/air_now/process_measurements.rb
+++ b/app/services/air_now/process_measurements.rb
@@ -33,7 +33,7 @@ class AirNow::ProcessMeasurements
 
   def create_saveable_object(measurement)
     time_with_time_zone = time_with_time_zone(measurement[:time], measurement[:date])
-    time_zone = time_zone_finder.timezone_at(lng: measurement[:longitude], lat: measurement[:latitude])
+    time_zone = time_zone_finder.time_zone_at(lng: measurement[:longitude], lat: measurement[:latitude])
     utc_offset = time_with_time_zone.in_time_zone(time_zone).utc_offset
     time_local = time_with_time_zone + utc_offset
 

--- a/app/services/time_zone_finder_wrapper.rb
+++ b/app/services/time_zone_finder_wrapper.rb
@@ -5,7 +5,12 @@ class TimeZoneFinderWrapper
     @time_zone_finder = TimezoneFinder.create
   end
 
-  def timezone_at(lat:, lng:)
+  def time_zone_at(lat:, lng:)
+    if lat.nil? || lng.nil? || lat.zero? || lng.zero? || lat > 90 ||
+         lat < -90 || lng > 180 || lng < -180
+      return 'UTC'
+    end
+
     @time_zone_finder.timezone_at(lat: lat, lng: lng)
   end
 end

--- a/lib/session_builder.rb
+++ b/lib/session_builder.rb
@@ -19,7 +19,7 @@ class SessionBuilder
     stream_data = data.delete(:streams)
 
     data = build_local_start_and_end_time(data)
-    data[:time_zone] = TimeZoneFinderWrapper.instance.time_zone_at(data[:latitude], data[:longitude])
+    data[:time_zone] = TimeZoneFinderWrapper.instance.time_zone_at(lat: data[:latitude], lng: data[:longitude])
 
     allowed = Session.attribute_names + %w[notes_attributes tag_list user]
     filtered = data.select { |k, _| allowed.include?(k.to_s) }

--- a/lib/session_builder.rb
+++ b/lib/session_builder.rb
@@ -19,7 +19,7 @@ class SessionBuilder
     stream_data = data.delete(:streams)
 
     data = build_local_start_and_end_time(data)
-    data[:time_zone] = TimeZoneBuilder.new.call(data[:latitude], data[:longitude])
+    data[:time_zone] = TimeZoneFinderWrapper.instance.time_zone_at(data[:latitude], data[:longitude])
 
     allowed = Session.attribute_names + %w[notes_attributes tag_list user]
     filtered = data.select { |k, _| allowed.include?(k.to_s) }

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -225,7 +225,7 @@ end
 def latitude_longitude_time_zone(opts = {})
   lat = opts.fetch(:latitude, 13.705488)
   lon = opts.fetch(:longitude, 100.315622)
-  time_zone = TimeZoneBuilder.new.call(lat, lon)
+  time_zone = TimeZoneFinderWrapper.instance.time_zone_at(lng: lon, lat: lat)
 
   [lat, lon, time_zone]
 end

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -225,7 +225,7 @@ end
 def latitude_longitude_time_zone(opts = {})
   lat = opts.fetch(:latitude, 13.705488)
   lon = opts.fetch(:longitude, 100.315622)
-  time_zone = TimeZoneFinderWrapper.instance.time_zone_at(lng: lon, lat: lat)
+  time_zone = TimeZoneFinderWrapper.instance.time_zone_at(lat: lat, lng: lon)
 
   [lat, lon, time_zone]
 end


### PR DESCRIPTION
This is an experimental solution for frequent downtimes of the server.
When downtime occurs there are >40000 files open (check 'lsof | wc -l').
Many of those files are connected to the TimezoneFinder module.