### PR TITLE
Add threshold data to /api/fixed_stream/:id response

### DIFF
--- a/app/serializers/fixed_stream_serializer.rb
+++ b/app/serializers/fixed_stream_serializer.rb
@@ -11,6 +11,8 @@ class FixedStreamSerializer
   private
 
   def serialized_stream(stream)
+    thresolds = Stream.thresholds(stream.sensor_name, stream.unit_symbol)
+
     {
       id: stream.id,
       session_id: stream.session.id,
@@ -23,6 +25,11 @@ class FixedStreamSerializer
       last_update: stream.session.last_measurement_at,
       start_time: stream.session.start_time_local,
       end_time: stream.session.end_time_local,
+      min: thresolds[0],
+      low: thresolds[1],
+      middle: thresolds[2],
+      high: thresolds[3],
+      max: thresolds[4],
     }
   end
 

--- a/spec/requests/fixed_streams_spec.rb
+++ b/spec/requests/fixed_streams_spec.rb
@@ -29,6 +29,11 @@ describe 'GET api/v3/fixed_streams/:id' do
           last_update: stream.session.last_measurement_at,
           start_time: session.end_time_local,
           end_time: session.start_time_local,
+          min: stream.threshold_very_low.to_s,
+          low: stream.threshold_low.to_s,
+          middle: stream.threshold_medium.to_s,
+          high: stream.threshold_high.to_s,
+          max: stream.threshold_very_high.to_s,
         },
         measurements: [
           { time: measurement_1.time.to_i * 1_000, value: measurement_1.value },


### PR DESCRIPTION
It's a temporary solution using existing implementation.