### PR TITLE
Calendar controls - improvements

### DIFF
--- a/app/javascript/react/components/molecules/Calendar/Calendar.style.tsx
+++ b/app/javascript/react/components/molecules/Calendar/Calendar.style.tsx
@@ -71,20 +71,11 @@ const CalendarContainer = styled.div`
   }
 `;
 
-const RedErrorMessage = styled.span`
-  color: red;
-  padding: 0 0 1rem 0;
-  min-height: 2rem;
-  display: block;
-  visibility: hidden;
-`;
-
 export {
   DateField,
   ThreeMonths,
   CalendarContainer,
   MobileSwipeContainer,
   DesktopSwipeLeftContainer,
-  DesktopSwipeRightContainer,
-  RedErrorMessage
+  DesktopSwipeRightContainer
 };

--- a/app/javascript/react/components/molecules/Calendar/Calendar.tsx
+++ b/app/javascript/react/components/molecules/Calendar/Calendar.tsx
@@ -29,8 +29,7 @@ const Calendar: React.FC<CalendarProps> = ({
   } = useCalendarHook({ streamId, minCalendarDate, maxCalendarDate });
 
   const { t } = useTranslation();
-  const showError = isLeftButtonDisabled || isRightButtonDisabled;
-
+  
   return (
     threeMonthsData && (
       <S.CalendarContainer>
@@ -58,11 +57,6 @@ const Calendar: React.FC<CalendarProps> = ({
                   handleClick={handleRightClick}
                 />
               </S.MobileSwipeContainer>
-              <S.RedErrorMessage
-                style={{ visibility: showError ? "visible" : "hidden" }}
-              >
-                {showError && t("calendarPage.noDataMessage")}
-              </S.RedErrorMessage>
               <S.ThreeMonths>
                 <S.DesktopSwipeLeftContainer>
                   <ScrollCalendarButton

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import moment from "moment";
 
 import { ValueLabel } from "./atoms/ValueLabel";
 import { StationName } from "./atoms/StationName";
@@ -22,8 +23,10 @@ const FixedStreamStationHeader = () => {
     active,
     sessionId,
     startTime,
-    endTime
+    endTime,
   } = useSelector(selectFixedStreamShortInfo);
+
+  const streamEndTime: string = endTime ?? lastUpdate ?? moment().format("YYYY-MM-DD");
 
   return (
     <S.GridContainer>
@@ -39,7 +42,7 @@ const FixedStreamStationHeader = () => {
         lastUpdate={lastUpdate}
         updateFrequency={updateFrequency}
         startTime={startTime}
-        endTime={endTime}
+        endTime={streamEndTime}
       />
       <StationActionButtons sessionId={sessionId} />
     </S.GridContainer>

--- a/app/javascript/react/locales/en/translation.json
+++ b/app/javascript/react/locales/en/translation.json
@@ -80,8 +80,7 @@
   },
   "calendarPage": {
     "forwardScrollButton": "Move calendar page one step forward",
-    "backScrollButton": "Move calendar page one step back",
-    "noDataMessage": "There is no more data available at the moment"
+    "backScrollButton": "Move calendar page one step back"
   },
   "map": {
     "mapLabel": "Map",

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -37,8 +37,12 @@ const CalendarPage = () => {
   const calendarIsVisible =
     movingCalendarData.data.length &&
     streamId &&
-    fixedStreamData.stream.startTime &&
-    fixedStreamData.stream.endTime;
+    fixedStreamData.stream.startTime;
+
+  const streamEndTime: string =
+    fixedStreamData.stream.endTime ??
+    fixedStreamData.stream.lastUpdate ??
+    moment().format("YYYY-MM-DD");
 
   useEffect(() => {
     streamId && dispatch(fetchFixedStreamById(streamId));
@@ -57,15 +61,7 @@ const CalendarPage = () => {
   }, []);
 
   useEffect(() => {
-    if (!fixedStreamData?.streamDailyAverages?.length) {
-      console.log("No daily averages to process.");
-      return;
-    }
-
-    const formattedEndMoment = moment(
-      fixedStreamData.stream.endTime,
-      "YYYY-MM-DD"
-    );
+    const formattedEndMoment = moment(streamEndTime, "YYYY-MM-DD");
     const formattedEndDate = formattedEndMoment.format("YYYY-MM-DD");
     const newStartDate = formattedEndMoment
       .date(1)
@@ -92,7 +88,7 @@ const CalendarPage = () => {
           <Calendar
             streamId={streamId}
             minCalendarDate={fixedStreamData.stream.startTime}
-            maxCalendarDate={fixedStreamData.stream.endTime}
+            maxCalendarDate={streamEndTime}
           />
         ) : (
           <EmptyCalendar />

--- a/app/javascript/react/types/fixedStream.ts
+++ b/app/javascript/react/types/fixedStream.ts
@@ -1,8 +1,8 @@
 interface StreamUpdate {
-  lastUpdate: string;
+  lastUpdate: string | null;
   updateFrequency: string;
   startTime: string;
-  endTime: string;
+  endTime: string | null;
 }
 
 interface DataSource {
@@ -15,8 +15,6 @@ interface FixedStreamStationInfo extends StreamUpdate, DataSource {
   title: string;
   unitSymbol: string;
   active: boolean;
-  startTime: string;
-  endTime: string;
   min: number,
   low: number;
   middle: number;


### PR DESCRIPTION
Relates to both - Michaels comments:
- https://trello.com/c/Oht690FY/1795-controls-for-viewing-earlier-months
- https://trello.com/c/9kFI8CsY/1874-calendar-navbar-data-range

We need end time to handle disabling and enabling calendar control in well manner. It can be different for both mobile and fixed so we need to make sure to make it as best as possible.
1. For FIXED there is no end_time so we have to use last_update.
2. For MOBILE there is no last_update so we have to use end_time.
3. In case we're missing something, let's assume that the current date is the one we can't pass because there can be no data from the future