### PR TITLE
Update frequency changed for AirNow streams

### DIFF
--- a/app/serializers/fixed_stream_serializer.rb
+++ b/app/serializers/fixed_stream_serializer.rb
@@ -12,6 +12,7 @@ class FixedStreamSerializer
 
   def serialized_stream(stream)
     thresolds = Stream.thresholds(stream.sensor_name, stream.unit_symbol)
+    update_frequency = stream.session.user.username == 'US EPA AirNow' ? '1 hour' : '1 minute'
 
     {
       id: stream.id,
@@ -21,7 +22,7 @@ class FixedStreamSerializer
       profile: stream.session.username,
       sensor_name: stream.sensor_name,
       unit_symbol: stream.unit_symbol,
-      update_frequency: '1 minute',
+      update_frequency: update_frequency,
       last_update: stream.session.last_measurement_at,
       start_time: stream.session.start_time_local,
       end_time: stream.session.end_time_local,

--- a/app/serializers/fixed_stream_serializer.rb
+++ b/app/serializers/fixed_stream_serializer.rb
@@ -12,7 +12,7 @@ class FixedStreamSerializer
 
   def serialized_stream(stream)
     thresolds = Stream.thresholds(stream.sensor_name, stream.unit_symbol)
-    update_frequency = stream.session.user.username == 'US EPA AirNow' ? '1 hour' : '1 minute'
+    update_frequency = stream.session.username == 'US EPA AirNow' ? '1 hour' : '1 minute'
 
     {
       id: stream.id,

--- a/spec/requests/fixed_streams_spec.rb
+++ b/spec/requests/fixed_streams_spec.rb
@@ -58,41 +58,6 @@ describe 'GET api/v3/fixed_streams/:id' do
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)).to eq(expected_response.as_json)
     end
-
-    it 'returns 1h update frequency for US EPA AirNow user' do
-      session = create_fixed_session!({ username: 'US EPA AirNow' })
-      stream = create_stream!({ session: session })
-
-      expected_response = {
-        stream: {
-          id: stream.id,
-          session_id: session.id,
-          active: session.is_active,
-          title: session.title,
-          profile: session.username,
-          sensor_name: stream.sensor_name,
-          unit_symbol: stream.unit_symbol,
-          update_frequency: '1 hour',
-          last_update: stream.session.last_measurement_at,
-          start_time: session.end_time_local,
-          end_time: session.start_time_local,
-          min: stream.threshold_very_low.to_s,
-          low: stream.threshold_low.to_s,
-          middle: stream.threshold_medium.to_s,
-          high: stream.threshold_high.to_s,
-          max: stream.threshold_very_high.to_s,
-        },
-        measurements: [],
-        stream_daily_averages: [],
-      }
-
-      expect(Flipper).to receive(:enabled?).with(:calendar).and_return(true)
-
-      get "/api/v3/fixed_streams/#{stream.id}"
-
-      expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)).to eq(expected_response.as_json)
-    end
   end
 
   context 'calendar feature disabled' do

--- a/spec/requests/fixed_streams_spec.rb
+++ b/spec/requests/fixed_streams_spec.rb
@@ -58,6 +58,41 @@ describe 'GET api/v3/fixed_streams/:id' do
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)).to eq(expected_response.as_json)
     end
+
+    it 'returns 1h update frequency for US EPA AirNow user' do
+      session = create_fixed_session!({ username: 'US EPA AirNow' })
+      stream = create_stream!({ session: session })
+
+      expected_response = {
+        stream: {
+          id: stream.id,
+          session_id: session.id,
+          active: session.is_active,
+          title: session.title,
+          profile: session.username,
+          sensor_name: stream.sensor_name,
+          unit_symbol: stream.unit_symbol,
+          update_frequency: '1 hour',
+          last_update: stream.session.last_measurement_at,
+          start_time: session.end_time_local,
+          end_time: session.start_time_local,
+          min: stream.threshold_very_low.to_s,
+          low: stream.threshold_low.to_s,
+          middle: stream.threshold_medium.to_s,
+          high: stream.threshold_high.to_s,
+          max: stream.threshold_very_high.to_s,
+        },
+        measurements: [],
+        stream_daily_averages: [],
+      }
+
+      expect(Flipper).to receive(:enabled?).with(:calendar).and_return(true)
+
+      get "/api/v3/fixed_streams/#{stream.id}"
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(expected_response.as_json)
+    end
   end
 
   context 'calendar feature disabled' do

--- a/spec/serializers/fixed_stream_serializer_spec.rb
+++ b/spec/serializers/fixed_stream_serializer_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe FixedStreamSerializer do
+  describe '#call' do
+    session = create_fixed_session!
+    stream = create_stream!({ session: session })
+    measurement_1 = create_measurement!({ stream: stream })
+    measurement_2 = create_measurement!({ stream: stream })
+    stream_daily_average_1 =
+      create_stream_daily_average!(
+        { stream: stream, date: Date.current, value: 10 },
+      )
+    stream_daily_average_2 =
+      create_stream_daily_average!(
+        { stream: stream, date: Date.current.prev_day, value: 9 },
+      )
+
+    it 'returns fixed stream data' do
+      expected_response = {
+        stream: {
+          id: stream.id,
+          session_id: session.id,
+          active: session.is_active,
+          title: session.title,
+          profile: session.username,
+          sensor_name: stream.sensor_name,
+          unit_symbol: stream.unit_symbol,
+          update_frequency: '1 minute',
+          last_update: stream.session.last_measurement_at,
+          start_time: session.end_time_local,
+          end_time: session.start_time_local,
+          min: stream.threshold_very_low.to_s,
+          low: stream.threshold_low.to_s,
+          middle: stream.threshold_medium.to_s,
+          high: stream.threshold_high.to_s,
+          max: stream.threshold_very_high.to_s,
+        },
+        measurements: [
+          { time: measurement_1.time.to_i * 1_000, value: measurement_1.value },
+          { time: measurement_2.time.to_i * 1_000, value: measurement_2.value },
+        ],
+        stream_daily_averages: [
+          {
+            date: stream_daily_average_1.date.strftime('%Y-%m-%d'),
+            value: stream_daily_average_1.value.round,
+          },
+          {
+            date: stream_daily_average_2.date.strftime('%Y-%m-%d'),
+            value: stream_daily_average_2.value.round,
+          },
+        ],
+      }
+
+      expect(described_class.new.call(
+        stream: stream,
+        measurements: [measurement_1, measurement_2],
+        stream_daily_averages: [stream_daily_average_1, stream_daily_average_2],
+      )).to eq(expected_response)
+    end
+
+    it 'returns data with correct update frequency for AirNow streams' do
+      session.user.update!(username: 'US EPA AirNow')
+      expected_response = {
+        stream: {
+          id: stream.id,
+          session_id: session.id,
+          active: session.is_active,
+          title: session.title,
+          profile: session.username,
+          sensor_name: stream.sensor_name,
+          unit_symbol: stream.unit_symbol,
+          update_frequency: '1 hour',
+          last_update: stream.session.last_measurement_at,
+          start_time: session.end_time_local,
+          end_time: session.start_time_local,
+          min: stream.threshold_very_low.to_s,
+          low: stream.threshold_low.to_s,
+          middle: stream.threshold_medium.to_s,
+          high: stream.threshold_high.to_s,
+          max: stream.threshold_very_high.to_s,
+        },
+        measurements: [
+          { time: measurement_1.time.to_i * 1_000, value: measurement_1.value },
+          { time: measurement_2.time.to_i * 1_000, value: measurement_2.value },
+        ],
+        stream_daily_averages: [
+          {
+            date: stream_daily_average_1.date.strftime('%Y-%m-%d'),
+            value: stream_daily_average_1.value.round,
+          },
+          {
+            date: stream_daily_average_2.date.strftime('%Y-%m-%d'),
+            value: stream_daily_average_2.value.round,
+          },
+        ],
+      }
+
+      expect(described_class.new.call(
+        stream: stream,
+        measurements: [measurement_1, measurement_2],
+        stream_daily_averages: [stream_daily_average_1, stream_daily_average_2],
+      )).to eq(expected_response)
+    end
+  end
+end

--- a/spec/serializers/fixed_stream_serializer_spec.rb
+++ b/spec/serializers/fixed_stream_serializer_spec.rb
@@ -15,91 +15,95 @@ RSpec.describe FixedStreamSerializer do
         { stream: stream, date: Date.current.prev_day, value: 9 },
       )
 
-    it 'returns fixed stream data' do
-      expected_response = {
-        stream: {
-          id: stream.id,
-          session_id: session.id,
-          active: session.is_active,
-          title: session.title,
-          profile: session.username,
-          sensor_name: stream.sensor_name,
-          unit_symbol: stream.unit_symbol,
-          update_frequency: '1 minute',
-          last_update: stream.session.last_measurement_at,
-          start_time: session.end_time_local,
-          end_time: session.start_time_local,
-          min: stream.threshold_very_low.to_s,
-          low: stream.threshold_low.to_s,
-          middle: stream.threshold_medium.to_s,
-          high: stream.threshold_high.to_s,
-          max: stream.threshold_very_high.to_s,
-        },
-        measurements: [
-          { time: measurement_1.time.to_i * 1_000, value: measurement_1.value },
-          { time: measurement_2.time.to_i * 1_000, value: measurement_2.value },
-        ],
-        stream_daily_averages: [
-          {
-            date: stream_daily_average_1.date.strftime('%Y-%m-%d'),
-            value: stream_daily_average_1.value.round,
+    context 'username is not US EPA AirNow' do
+      it 'returns fixed stream data' do
+        expected_response = {
+          stream: {
+            id: stream.id,
+            session_id: session.id,
+            active: session.is_active,
+            title: session.title,
+            profile: session.username,
+            sensor_name: stream.sensor_name,
+            unit_symbol: stream.unit_symbol,
+            update_frequency: '1 minute',
+            last_update: stream.session.last_measurement_at,
+            start_time: session.end_time_local,
+            end_time: session.start_time_local,
+            min: stream.threshold_very_low.to_s,
+            low: stream.threshold_low.to_s,
+            middle: stream.threshold_medium.to_s,
+            high: stream.threshold_high.to_s,
+            max: stream.threshold_very_high.to_s,
           },
-          {
-            date: stream_daily_average_2.date.strftime('%Y-%m-%d'),
-            value: stream_daily_average_2.value.round,
-          },
-        ],
-      }
+          measurements: [
+            { time: measurement_1.time.to_i * 1_000, value: measurement_1.value },
+            { time: measurement_2.time.to_i * 1_000, value: measurement_2.value },
+          ],
+          stream_daily_averages: [
+            {
+              date: stream_daily_average_1.date.strftime('%Y-%m-%d'),
+              value: stream_daily_average_1.value.round,
+            },
+            {
+              date: stream_daily_average_2.date.strftime('%Y-%m-%d'),
+              value: stream_daily_average_2.value.round,
+            },
+          ],
+        }
 
-      expect(described_class.new.call(
-        stream: stream,
-        measurements: [measurement_1, measurement_2],
-        stream_daily_averages: [stream_daily_average_1, stream_daily_average_2],
-      )).to eq(expected_response)
+        expect(described_class.new.call(
+          stream: stream,
+          measurements: [measurement_1, measurement_2],
+          stream_daily_averages: [stream_daily_average_1, stream_daily_average_2],
+        )).to eq(expected_response)
+      end
     end
 
-    it 'returns data with correct update frequency for AirNow streams' do
-      session.user.update!(username: 'US EPA AirNow')
-      expected_response = {
-        stream: {
-          id: stream.id,
-          session_id: session.id,
-          active: session.is_active,
-          title: session.title,
-          profile: session.username,
-          sensor_name: stream.sensor_name,
-          unit_symbol: stream.unit_symbol,
-          update_frequency: '1 hour',
-          last_update: stream.session.last_measurement_at,
-          start_time: session.end_time_local,
-          end_time: session.start_time_local,
-          min: stream.threshold_very_low.to_s,
-          low: stream.threshold_low.to_s,
-          middle: stream.threshold_medium.to_s,
-          high: stream.threshold_high.to_s,
-          max: stream.threshold_very_high.to_s,
-        },
-        measurements: [
-          { time: measurement_1.time.to_i * 1_000, value: measurement_1.value },
-          { time: measurement_2.time.to_i * 1_000, value: measurement_2.value },
-        ],
-        stream_daily_averages: [
-          {
-            date: stream_daily_average_1.date.strftime('%Y-%m-%d'),
-            value: stream_daily_average_1.value.round,
+    context 'username is US EPA AirNow' do
+      it 'returns data with correct update frequency for AirNow streams' do
+        session.user.update!(username: 'US EPA AirNow')
+        expected_response = {
+          stream: {
+            id: stream.id,
+            session_id: session.id,
+            active: session.is_active,
+            title: session.title,
+            profile: session.username,
+            sensor_name: stream.sensor_name,
+            unit_symbol: stream.unit_symbol,
+            update_frequency: '1 hour',
+            last_update: stream.session.last_measurement_at,
+            start_time: session.end_time_local,
+            end_time: session.start_time_local,
+            min: stream.threshold_very_low.to_s,
+            low: stream.threshold_low.to_s,
+            middle: stream.threshold_medium.to_s,
+            high: stream.threshold_high.to_s,
+            max: stream.threshold_very_high.to_s,
           },
-          {
-            date: stream_daily_average_2.date.strftime('%Y-%m-%d'),
-            value: stream_daily_average_2.value.round,
-          },
-        ],
-      }
+          measurements: [
+            { time: measurement_1.time.to_i * 1_000, value: measurement_1.value },
+            { time: measurement_2.time.to_i * 1_000, value: measurement_2.value },
+          ],
+          stream_daily_averages: [
+            {
+              date: stream_daily_average_1.date.strftime('%Y-%m-%d'),
+              value: stream_daily_average_1.value.round,
+            },
+            {
+              date: stream_daily_average_2.date.strftime('%Y-%m-%d'),
+              value: stream_daily_average_2.value.round,
+            },
+          ],
+        }
 
-      expect(described_class.new.call(
-        stream: stream,
-        measurements: [measurement_1, measurement_2],
-        stream_daily_averages: [stream_daily_average_1, stream_daily_average_2],
-      )).to eq(expected_response)
+        expect(described_class.new.call(
+          stream: stream,
+          measurements: [measurement_1, measurement_2],
+          stream_daily_averages: [stream_daily_average_1, stream_daily_average_2],
+        )).to eq(expected_response)
+      end
     end
   end
 end

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -21,7 +21,7 @@ def create_session!(attributes = {})
   Session.create!(
     id: attributes.fetch(:id, rand(1_000_000)),
     title: attributes.fetch(:title, 'Example Session'),
-    user: attributes.fetch(:user) { create_user! },
+    user: attributes.fetch(:user) { create_user!(attributes) },
     uuid: attributes.fetch(:uuid, "uuid#{rand}"),
     start_time_local: attributes.fetch(:start_time_local, DateTime.current),
     end_time_local: attributes.fetch(:end_time_local, DateTime.current),
@@ -128,8 +128,9 @@ def create_mobile_session!
   create_session!(type: 'MobileSession')
 end
 
-def create_fixed_session!
-  create_session!(type: 'FixedSession')
+def create_fixed_session!(attributes = {})
+  fixed_attributes = attributes.merge(type: 'FixedSession')
+  create_session!(fixed_attributes)
 end
 
 def create_stream_daily_average!(attributes = {})


### PR DESCRIPTION
For now, I don't have a better idea of how to adjust this logic. 
I did not want to change the db schema (adding update frequency to sessions) for this small change as it would be more complex and we don't have a guarantee of updates in this time interval, so it would not be true always.