### PR TITLE
Fix Google outline style

### DIFF
--- a/app/javascript/react/assets/styles/global-styles.ts
+++ b/app/javascript/react/assets/styles/global-styles.ts
@@ -36,6 +36,10 @@ const GlobalStyles = createGlobalStyle`
     line-height: 1.2;
     color: ${gray400};
   }
+
+  body:not(.user-is-tabbing) .gm-style iframe + div {
+    border: none !important;
+  }
 `;
 
 export default GlobalStyles;

--- a/app/javascript/react/pages/MapPage/MapPage.style.tsx
+++ b/app/javascript/react/pages/MapPage/MapPage.style.tsx
@@ -1,9 +1,0 @@
-import styled from "styled-components";
-
-const StyledMapContainer = styled.div`
-  body:not(.user-is-tabbing) .gm-style iframe + div {
-    border: none !important;
-  }
-`;
-
-export { StyledMapContainer };

--- a/app/javascript/react/pages/MapPage/MapPage.tsx
+++ b/app/javascript/react/pages/MapPage/MapPage.tsx
@@ -19,10 +19,8 @@ const MapPage: React.FC<MapPageProps> = ({ children }) => {
       onLoad={() => console.log("Maps API has loaded.")}
     >
       {children}
-      <StyledMapContainer>
-        <FocusTabController />
-        <Map />
-      </StyledMapContainer>
+      <FocusTabController />
+      <Map />
     </APIProvider>
   );
 };

--- a/app/javascript/react/pages/MapPage/MapPage.tsx
+++ b/app/javascript/react/pages/MapPage/MapPage.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { APIProvider } from "@vis.gl/react-google-maps";
 
 import { Map } from "../../components/Map";
-import { StyledMapContainer } from "./MapPage.style";
 import { FocusTabController } from "../../utils/focusTabController";
 
 const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY || "";


### PR DESCRIPTION
I made a mistake in the last PR. The controller that's responsible for checking whether the user is tabbing or using the mouse should be initialized on the map level. The style related to the map itself must be used inside the global styles. Otherwise, it won't work.