### PR TITLE
Graph fixes

### DIFF
--- a/app/javascript/react/components/Graph/Graph.style.tsx
+++ b/app/javascript/react/components/Graph/Graph.style.tsx
@@ -38,10 +38,6 @@ const Container = styled.div`
       transform: translate(3px, 0px) scale(2);
       stroke-width: 3px;
     }
-
-    .hide-tooltip .highcharts-tooltip {
-      display: none !important;
-    }
 `;
 
 export { Container };

--- a/app/javascript/react/components/Graph/Graph.style.tsx
+++ b/app/javascript/react/components/Graph/Graph.style.tsx
@@ -1,11 +1,7 @@
 import styled from "styled-components";
 import { media } from "../../utils/media";
 
-interface ContainerProps {
-  $tooltipVisible: boolean;
-}
-
-const Container = styled.div<ContainerProps>`
+const Container = styled.div`
   width: 100%;
   position: relative;
   font-family: "Roboto", sans-serif;
@@ -43,8 +39,8 @@ const Container = styled.div<ContainerProps>`
       stroke-width: 3px;
     }
 
-    .highcharts-point {
-      display:${(props) => (props.$tooltipVisible ? "auto" : "none")};
+    .hide-tooltip .highcharts-tooltip {
+      display: none !important;
     }
 `;
 

--- a/app/javascript/react/components/Graph/Graph.style.tsx
+++ b/app/javascript/react/components/Graph/Graph.style.tsx
@@ -1,7 +1,11 @@
 import styled from "styled-components";
 import { media } from "../../utils/media";
 
-const Container = styled.div`
+interface ContainerProps {
+  $tooltipVisible: boolean;
+}
+
+const Container = styled.div<ContainerProps>`
   width: 100%;
   position: relative;
   font-family: "Roboto", sans-serif;
@@ -37,6 +41,10 @@ const Container = styled.div`
     .highcharts-scrollbar-arrow {
       transform: translate(3px, 0px) scale(2);
       stroke-width: 3px;
+    }
+
+    .highcharts-point {
+      display:${(props) => (props.$tooltipVisible ? "auto" : "none")};
     }
 `;
 

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -40,8 +40,6 @@ interface GraphProps {
   streamId: number | null;
 }
 
-const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
-
 const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
   const thresholdsState = useSelector(selectThreshold);
   const fixedSessionTypeSelected: boolean = sessionType === SessionTypes.FIXED;

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -25,16 +25,13 @@ import { updateMobileMeasurementExtremes } from "../../store/mobileStreamSlice";
 import { selectThreshold } from "../../store/thresholdSlice";
 import { SessionType, SessionTypes } from "../../types/filters";
 import { MobileStreamShortInfo as StreamShortInfo } from "../../types/mobileStream";
-import {
-  selectFixedExtremes,
-  selectFixedStreamShortInfo,
-} from "../../store/fixedStreamSelectors";
+import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
 import { selectMobileStreamData } from "../../store/mobileStreamSelectors";
 import { selectMobileStreamShortInfo } from "../../store/mobileStreamSelectors";
 import { useAppDispatch } from "../../store/hooks";
 import { handleLoad } from "./chartEvents";
-import { min } from "lodash";
 
+const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
 interface GraphProps {
   sessionType: SessionType;
   streamId: number | null;
@@ -72,7 +69,6 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
   const plotOptions = getPlotOptions();
 
   const dispatch = useAppDispatch();
-  const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
 
   useEffect(() => {
     if (seriesData.length > 0 && !isLoading) {

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -29,7 +29,7 @@ import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
 import { selectMobileStreamData } from "../../store/mobileStreamSelectors";
 import { selectMobileStreamShortInfo } from "../../store/mobileStreamSelectors";
 import { useAppDispatch } from "../../store/hooks";
-import { handleLoad, handleRedraw } from "./chartEvents";
+import { handleLoad } from "./chartEvents";
 
 interface GraphProps {
   sessionType: SessionType;
@@ -127,9 +127,6 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
       events: {
         load: function () {
           handleLoad.call(this, setTooltipVisible);
-        },
-        redraw: function () {
-          handleRedraw.call(this, setTooltipVisible);
         },
       },
     },

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import Highcharts from "highcharts/highstock";
 import HighchartsReact from "highcharts-react-official";
 import { useSelector } from "react-redux";
@@ -29,7 +29,7 @@ import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
 import { selectMobileStreamData } from "../../store/mobileStreamSelectors";
 import { selectMobileStreamShortInfo } from "../../store/mobileStreamSelectors";
 import { useAppDispatch } from "../../store/hooks";
-import { handleLoad } from "./chartEvents";
+import { handleLoad } from "./chartEvents"; // Import handleLoad
 
 interface GraphProps {
   sessionType: SessionType;
@@ -39,8 +39,6 @@ interface GraphProps {
 const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
 
 const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
-  const [tooltipVisible, setTooltipVisible] = useState(true);
-
   const thresholdsState = useSelector(selectThreshold);
   const fixedSessionTypeSelected: boolean = sessionType === SessionTypes.FIXED;
 
@@ -58,7 +56,7 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
 
   const measurements = graphData?.measurements || [];
   const unitSymbol = streamShortInfo?.unitSymbol || "";
-  const measurementType = "Particulate Matter"; // take this parameter from filters in the future
+  const measurementType = "Particulate Matter";
 
   const seriesData = measurements.map(
     (measurement: { time: number; value: number }) => [
@@ -67,20 +65,13 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
     ]
   );
 
-  const xAxisOptions = getXAxisOptions(
-    fixedSessionTypeSelected,
-    tooltipVisible
-  );
+  const xAxisOptions = getXAxisOptions(fixedSessionTypeSelected);
   const yAxisOption = getYAxisOptions(thresholdsState);
-  const tooltipOptions = getTooltipOptions(
-    measurementType,
-    unitSymbol,
-    tooltipVisible
-  );
+  const tooltipOptions = getTooltipOptions(measurementType, unitSymbol);
   const rangeSelectorOptions = getRangeSelectorOptions(
     fixedSessionTypeSelected
   );
-  const plotOptions = getPlotOptions(tooltipVisible);
+  const plotOptions = getPlotOptions();
 
   const dispatch = useAppDispatch();
 
@@ -126,7 +117,7 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
       },
       events: {
         load: function () {
-          handleLoad.call(this, setTooltipVisible);
+          handleLoad.call(this);
         },
       },
     },
@@ -141,7 +132,7 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
   };
 
   return (
-    <S.Container $tooltipVisible={tooltipVisible}>
+    <S.Container>
       <HighchartsReact
         highcharts={Highcharts}
         constructorType={"stockChart"}

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -25,11 +25,15 @@ import { updateMobileMeasurementExtremes } from "../../store/mobileStreamSlice";
 import { selectThreshold } from "../../store/thresholdSlice";
 import { SessionType, SessionTypes } from "../../types/filters";
 import { MobileStreamShortInfo as StreamShortInfo } from "../../types/mobileStream";
-import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
+import {
+  selectFixedExtremes,
+  selectFixedStreamShortInfo,
+} from "../../store/fixedStreamSelectors";
 import { selectMobileStreamData } from "../../store/mobileStreamSelectors";
 import { selectMobileStreamShortInfo } from "../../store/mobileStreamSelectors";
 import { useAppDispatch } from "../../store/hooks";
 import { handleLoad } from "./chartEvents"; // Import handleLoad
+import { last } from "lodash";
 
 interface GraphProps {
   sessionType: SessionType;
@@ -54,6 +58,9 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
       : selectMobileStreamShortInfo
   );
 
+  const { minMeasurementValue, maxMeasurementValue } =
+    useSelector(selectFixedExtremes);
+
   const measurements = graphData?.measurements || [];
   const unitSymbol = streamShortInfo?.unitSymbol || "";
   const measurementType = "Particulate Matter";
@@ -77,18 +84,17 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
 
   useEffect(() => {
     if (measurements.length > 0 && !isLoading) {
-      if (fixedSessionTypeSelected) {
-        const now = Date.now();
-        const last24Hours = measurements.filter(
-          (m) => now - m.time <= MILLISECONDS_IN_A_DAY
+      if (
+        fixedSessionTypeSelected &&
+        minMeasurementValue !== null &&
+        maxMeasurementValue !== null
+      ) {
+        dispatch(
+          updateFixedMeasurementExtremes({
+            min: minMeasurementValue,
+            max: maxMeasurementValue,
+          })
         );
-        if (last24Hours.length > 0) {
-          const minTime = Math.min(...last24Hours.map((m) => m.time));
-          const maxTime = Math.max(...last24Hours.map((m) => m.time));
-          dispatch(
-            updateFixedMeasurementExtremes({ min: minTime, max: maxTime })
-          );
-        }
       } else {
         const minTime = Math.min(...measurements.map((m) => m.time));
         const maxTime = Math.max(...measurements.map((m) => m.time));

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -6,7 +6,7 @@ import { useSelector } from "react-redux";
 import * as S from "./Graph.style";
 import {
   getXAxisOptions,
-  plotOptions,
+  getPlotOptions,
   legendOption,
   seriesOptions,
   getYAxisOptions,
@@ -67,7 +67,10 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
     ]
   );
 
-  const xAxisOptions = getXAxisOptions(fixedSessionTypeSelected);
+  const xAxisOptions = getXAxisOptions(
+    fixedSessionTypeSelected,
+    tooltipVisible
+  );
   const yAxisOption = getYAxisOptions(thresholdsState);
   const tooltipOptions = getTooltipOptions(
     measurementType,
@@ -77,6 +80,7 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
   const rangeSelectorOptions = getRangeSelectorOptions(
     fixedSessionTypeSelected
   );
+  const plotOptions = getPlotOptions(tooltipVisible);
 
   const dispatch = useAppDispatch();
 
@@ -115,6 +119,7 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
       zooming: { type: "x" },
       height: 300,
       margin: [40, 30, 0, 10],
+      animation: false,
       scrollablePlotArea: {
         minWidth: 100,
         scrollPositionX: 1,
@@ -139,7 +144,7 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
   };
 
   return (
-    <S.Container>
+    <S.Container $tooltipVisible={tooltipVisible}>
       <HighchartsReact
         highcharts={Highcharts}
         constructorType={"stockChart"}

--- a/app/javascript/react/components/Graph/chartEvents.ts
+++ b/app/javascript/react/components/Graph/chartEvents.ts
@@ -2,85 +2,55 @@ import Highcharts from "highcharts/highstock";
 import graphChevronLeft from "../../assets/icons/graphChevronLeft.svg";
 import graphChevronRight from "../../assets/icons/graphChevronRight.svg";
 
-const addNavigationArrows = (
-  chart: Highcharts.Chart,
-  setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>
-) => {
-  let leftArrow: Highcharts.SVGElement;
-  let rightArrow: Highcharts.SVGElement;
+const addNavigationArrows = (chart: Highcharts.Chart) => {
+  const chartWidth = chart.chartWidth;
+  const chartHeight = chart.chartHeight;
 
   // Remove existing arrows if any
   chart.renderer.boxWrapper.element
     .querySelectorAll('.custom-arrow')
     .forEach((el) => el.remove());
 
-  const chartWidth = chart.chartWidth;
-  const chartHeight = chart.chartHeight;
-
-  leftArrow = chart.renderer
+  const leftArrow = chart.renderer
     .image(graphChevronLeft, 30, chartHeight / 2, 30, 30)
     .attr({ zIndex: 10, class: 'custom-arrow' })
     .css({ cursor: 'pointer' })
     .add();
 
-  rightArrow = chart.renderer
+  const rightArrow = chart.renderer
     .image(graphChevronRight, chartWidth - 80, chartHeight / 2, 30, 30)
     .attr({ zIndex: 10, class: 'custom-arrow' })
     .css({ cursor: 'pointer' })
     .add();
 
-  const moveLeft = () => {
+  const move = (direction: 'left' | 'right') => {
     const axis = chart.xAxis[0];
-    const { min, max, dataMin } = axis.getExtremes();
+    const { min, max, dataMin, dataMax } = axis.getExtremes();
     const range = max - min;
-    const newMin = Math.max(dataMin, min - range * 0.1);
-    const newMax = Math.max(dataMin + range, max - range * 0.1);
+    const newMin = direction === 'left' ? Math.max(dataMin, min - range * 0.1) : Math.min(dataMax - range, min + range * 0.1);
+    const newMax = direction === 'left' ? Math.max(dataMin + range, max - range * 0.1) : Math.min(dataMax, max + range * 0.1);
     axis.setExtremes(newMin, newMax);
   };
 
-  const moveRight = () => {
-    const axis = chart.xAxis[0];
-    const { min, max, dataMax } = axis.getExtremes();
-    const range = max - min;
-    const newMin = Math.min(dataMax - range, min + range * 0.1);
-    const newMax = Math.min(dataMax, max + range * 0.1);
-    axis.setExtremes(newMin, newMax);
+  const toggleElements = (display: 'none' | 'block') => {
+    const elements = ['.highcharts-tooltip', '.highcharts-point', '.highcharts-crosshair', '.highcharts-halo'];
+    elements.forEach(selector => {
+      const element = chart.container.querySelector(selector) as HTMLElement;
+      if (element) element.style.display = display;
+    });
   };
 
-  leftArrow.on('click', moveLeft);
-  rightArrow.on('click', moveRight);
+  leftArrow.on('click', () => move('left'));
+  rightArrow.on('click', () => move('right'));
 
-  // Handle tooltip visibility on arrow hover
-  const handleArrowHover = (arrow: Highcharts.SVGElement, visible: boolean) => {
-    if (!visible) {
-      setTooltipVisible(false);
-    } else {
-      setTimeout(() => {
-        const chartOffset = chart.container.getBoundingClientRect();
-        const arrowBBox = arrow.getBBox();
-        const arrowX = arrowBBox.x + arrowBBox.width / 2;
-        const arrowY = arrowBBox.y + arrowBBox.height / 2;
-        const mouseX = chartOffset.left + arrowX;
-        const mouseY = chartOffset.top + arrowY;
-        if (!chart.isInsidePlot(mouseX, mouseY)) {
-          setTooltipVisible(true);
-        }
-      }, 200);
-    }
-  };
+  leftArrow.on('mouseover', () => toggleElements('none'));
+  leftArrow.on('mouseout', () => toggleElements('block'));
+  rightArrow.on('mouseover', () => toggleElements('none'));
+  rightArrow.on('mouseout', () => toggleElements('block'));
+}
 
-  leftArrow.on('mouseover', () => handleArrowHover(leftArrow, false));
-  leftArrow.on('mouseout', () => handleArrowHover(leftArrow, true));
-
-  rightArrow.on('mouseover', () => handleArrowHover(rightArrow, false));
-  rightArrow.on('mouseout', () => handleArrowHover(rightArrow, true));
-};
-
-const handleLoad = function (
-  this: Highcharts.Chart,
-  setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>
-) {
-  addNavigationArrows(this, setTooltipVisible);
+const handleLoad = function (this: Highcharts.Chart) {
+  addNavigationArrows(this);
 };
 
 export { handleLoad };

--- a/app/javascript/react/components/Graph/chartEvents.ts
+++ b/app/javascript/react/components/Graph/chartEvents.ts
@@ -1,26 +1,35 @@
 import Highcharts from "highcharts/highstock";
+
 import graphChevronLeft from "../../assets/icons/graphChevronLeft.svg";
 import graphChevronRight from "../../assets/icons/graphChevronRight.svg";
 
-const addNavigationArrows = (chart: Highcharts.Chart, setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>) => {
+const addNavigationArrows = (
+  chart: Highcharts.Chart,
+  setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>
+) => {
   // Remove existing arrows if any
-  chart.renderer.boxWrapper.element.querySelectorAll('.custom-arrow').forEach(el => el.remove());
+  chart.renderer.boxWrapper.element
+    .querySelectorAll('.custom-arrow')
+    .forEach((el) => el.remove());
 
   const chartWidth = chart.chartWidth;
   const chartHeight = chart.chartHeight;
 
   const leftArrow = chart.renderer
-    .image(graphChevronLeft, 30, chartHeight / 2, 30, 30)
+    .image(graphChevronLeft, 30, chartHeight / 2 - 15, 30, 30)
     .attr({ zIndex: 10, class: 'custom-arrow' })
+    .css({ cursor: 'pointer' }) // Set cursor to pointer
     .add();
+
   const rightArrow = chart.renderer
-    .image(graphChevronRight, chartWidth - 80, chartHeight / 2, 30, 30)
+    .image(graphChevronRight, chartWidth - 60, chartHeight / 2 - 15, 30, 30)
     .attr({ zIndex: 10, class: 'custom-arrow' })
+    .css({ cursor: 'pointer' }) // Set cursor to pointer
     .add();
 
   const moveLeft = () => {
     const axis = chart.xAxis[0];
-    const { min, max, dataMin, dataMax } = axis.getExtremes();
+    const { min, max, dataMin } = axis.getExtremes();
     const range = max - min;
     const newMin = Math.max(dataMin, min - range * 0.1);
     const newMax = Math.max(dataMin + range, max - range * 0.1);
@@ -30,7 +39,7 @@ const addNavigationArrows = (chart: Highcharts.Chart, setTooltipVisible: React.D
 
   const moveRight = () => {
     const axis = chart.xAxis[0];
-    const { min, max, dataMin, dataMax } = axis.getExtremes();
+    const { min, max, dataMax } = axis.getExtremes();
     const range = max - min;
     const newMin = Math.min(dataMax - range, min + range * 0.1);
     const newMax = Math.min(dataMax, max + range * 0.1);
@@ -61,17 +70,45 @@ const addNavigationArrows = (chart: Highcharts.Chart, setTooltipVisible: React.D
 
   updateArrowState();
 
-  leftArrow.on('mouseover', () => setTooltipVisible(false));
-  leftArrow.on('mouseout', () => setTooltipVisible(true));
-  rightArrow.on('mouseover', () => setTooltipVisible(false));
-  rightArrow.on('mouseout', () => setTooltipVisible(true));
+  // Adjust hover events to ignore arrows
+  leftArrow.on('mouseover', () => {
+    setTooltipVisible(false);
+  });
+
+  leftArrow.on('mouseout', () => {
+    setTooltipVisible(true);
+  });
+
+  rightArrow.on('mouseover', () => {
+    setTooltipVisible(false);
+  });
+
+  rightArrow.on('mouseout', () => {
+    setTooltipVisible(true);
+  });
+
+  // Prevent propagation of mouse events to the chart to avoid unintended interactions
+  [leftArrow, rightArrow].forEach((arrow) => {
+    arrow.element.addEventListener('mouseenter', (event) => {
+      event.stopPropagation();
+    });
+    arrow.element.addEventListener('mouseleave', (event) => {
+      event.stopPropagation();
+    });
+  });
 };
 
-const handleLoad = function (this: Highcharts.Chart, setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>) {
+const handleLoad = function (
+  this: Highcharts.Chart,
+  setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>
+) {
   addNavigationArrows(this, setTooltipVisible);
 };
 
-const handleRedraw = function (this: Highcharts.Chart, setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>) {
+const handleRedraw = function (
+  this: Highcharts.Chart,
+  setTooltipVisible: React.Dispatch<React.SetStateAction<boolean>>
+) {
   addNavigationArrows(this, setTooltipVisible);
 };
 

--- a/app/javascript/react/components/Graph/chartEvents.ts
+++ b/app/javascript/react/components/Graph/chartEvents.ts
@@ -2,6 +2,9 @@ import Highcharts from "highcharts/highstock";
 import graphChevronLeft from "../../assets/icons/graphChevronLeft.svg";
 import graphChevronRight from "../../assets/icons/graphChevronRight.svg";
 
+const DIRECTION_LEFT = 'left';
+const DIRECTION_RIGHT = 'right';
+
 const addNavigationArrows = (chart: Highcharts.Chart) => {
   const chartWidth = chart.chartWidth;
   const chartHeight = chart.chartHeight;
@@ -23,12 +26,12 @@ const addNavigationArrows = (chart: Highcharts.Chart) => {
     .css({ cursor: 'pointer' })
     .add();
 
-  const move = (direction: 'left' | 'right') => {
+    const move = (direction: typeof DIRECTION_LEFT | typeof DIRECTION_RIGHT) => {
     const axis = chart.xAxis[0];
     const { min, max, dataMin, dataMax } = axis.getExtremes();
     const range = max - min;
-    const newMin = direction === 'left' ? Math.max(dataMin, min - range * 0.1) : Math.min(dataMax - range, min + range * 0.1);
-    const newMax = direction === 'left' ? Math.max(dataMin + range, max - range * 0.1) : Math.min(dataMax, max + range * 0.1);
+    const newMin = direction === DIRECTION_LEFT ? Math.max(dataMin, min - range * 0.1) : Math.min(dataMax - range, min + range * 0.1);
+    const newMax = direction === DIRECTION_LEFT ? Math.max(dataMin + range, max - range * 0.1) : Math.min(dataMax, max + range * 0.1);
     axis.setExtremes(newMin, newMax);
   };
 
@@ -40,8 +43,8 @@ const addNavigationArrows = (chart: Highcharts.Chart) => {
     });
   };
 
-  leftArrow.on('click', () => move('left'));
-  rightArrow.on('click', () => move('right'));
+  leftArrow.on('click', () => move(DIRECTION_LEFT));
+  rightArrow.on('click', () => move(DIRECTION_RIGHT));
 
   leftArrow.on('mouseover', () => toggleElements('none'));
   leftArrow.on('mouseout', () => toggleElements('block'));

--- a/app/javascript/react/components/Graph/chartEvents.ts
+++ b/app/javascript/react/components/Graph/chartEvents.ts
@@ -16,15 +16,15 @@ const addNavigationArrows = (
   const chartHeight = chart.chartHeight;
 
   const leftArrow = chart.renderer
-    .image(graphChevronLeft, 30, chartHeight / 2 - 15, 30, 30)
+    .image(graphChevronLeft, 30, chartHeight / 2, 30, 30)
     .attr({ zIndex: 10, class: 'custom-arrow' })
-    .css({ cursor: 'pointer' }) // Set cursor to pointer
+    .css({ cursor: 'pointer' })
     .add();
 
   const rightArrow = chart.renderer
-    .image(graphChevronRight, chartWidth - 60, chartHeight / 2 - 15, 30, 30)
+    .image(graphChevronRight, chartWidth - 80, chartHeight / 2, 30, 30)
     .attr({ zIndex: 10, class: 'custom-arrow' })
-    .css({ cursor: 'pointer' }) // Set cursor to pointer
+    .css({ cursor: 'pointer' })
     .add();
 
   const moveLeft = () => {
@@ -70,7 +70,6 @@ const addNavigationArrows = (
 
   updateArrowState();
 
-  // Adjust hover events to ignore arrows
   leftArrow.on('mouseover', () => {
     setTooltipVisible(false);
   });
@@ -87,7 +86,6 @@ const addNavigationArrows = (
     setTooltipVisible(true);
   });
 
-  // Prevent propagation of mouse events to the chart to avoid unintended interactions
   [leftArrow, rightArrow].forEach((arrow) => {
     arrow.element.addEventListener('mouseenter', (event) => {
       event.stopPropagation();

--- a/app/javascript/react/components/Graph/graphConfig.ts
+++ b/app/javascript/react/components/Graph/graphConfig.ts
@@ -32,7 +32,7 @@ const scrollbarOptions = {
 
 };
 
-const getXAxisOptions = (fixedSessionTypeSelected: boolean, tooltipVisible: boolean): XAxisOptions => {
+const getXAxisOptions = (fixedSessionTypeSelected: boolean): XAxisOptions => {
   const dispatch = useAppDispatch();
   const isLoading = useAppSelector(selectIsLoading);
 
@@ -62,7 +62,7 @@ const getXAxisOptions = (fixedSessionTypeSelected: boolean, tooltipVisible: bool
     },
     crosshair: {
       color: white,
-      width: tooltipVisible ? 2 : 0,
+      width:  2,
     },
     visible: true,
     minRange: 1000,
@@ -148,7 +148,7 @@ const credits: CreditsOptions = {
   position: { align: 'right', verticalAlign: 'top', x: -50, y: 55 },
 };
 
-const getPlotOptions = (tooltipVisible: boolean): PlotOptions => {
+const getPlotOptions = (): PlotOptions => {
 
   return {
     series: {
@@ -163,7 +163,6 @@ const getPlotOptions = (tooltipVisible: boolean): PlotOptions => {
       states: {
         hover: {
           halo: {
-            size: tooltipVisible ? 10 : 0,
             attributes: {
               fill: blue,
               'stroke-width': 2,
@@ -246,8 +245,8 @@ const responsive = {
 
 
 
-const getTooltipOptions = (measurementType: string, unitSymbol: string, tooltipVisible: boolean) => ({
-  enabled: tooltipVisible,
+const getTooltipOptions = (measurementType: string, unitSymbol: string) => ({
+  enabled: true,
   formatter: function (this: Highcharts.TooltipFormatterContextObject): string {
     const date = Highcharts.dateFormat('%m/%d/%Y', Number(this.x));
     const time = Highcharts.dateFormat('%H:%M:%S', Number(this.x));

--- a/app/javascript/react/components/Graph/graphConfig.ts
+++ b/app/javascript/react/components/Graph/graphConfig.ts
@@ -62,7 +62,7 @@ const getXAxisOptions = (fixedSessionTypeSelected: boolean): XAxisOptions => {
     },
     crosshair: {
       color: white,
-      width:  2,
+      width: 2,
     },
     visible: true,
     minRange: 1000,

--- a/app/javascript/react/components/Graph/graphConfig.ts
+++ b/app/javascript/react/components/Graph/graphConfig.ts
@@ -37,7 +37,7 @@ const getXAxisOptions = (fixedSessionTypeSelected: boolean): XAxisOptions => {
   const isLoading = useAppSelector(selectIsLoading);
 
   const handleSetExtremes = (e: Highcharts.AxisSetExtremesEventObject) => {
-    if (!isLoading) {
+    if (!isLoading && e.min && e.max) {
       const min = e.min;
       const max = e.max;
       dispatch(fixedSessionTypeSelected ? updateFixedMeasurementExtremes({ min, max }) : updateMobileMeasurementExtremes({ min, max }));
@@ -189,7 +189,7 @@ const seriesOptions = (data: number[][]): SeriesOptionsType => (
   {
     type: 'spline',
     color: white,
-    data: data.sort((a, b) => a[0] - b[0]),
+    data: data,
     tooltip: {
       valueDecimals: 2,
     },

--- a/app/javascript/react/components/Graph/graphConfig.ts
+++ b/app/javascript/react/components/Graph/graphConfig.ts
@@ -32,7 +32,7 @@ const scrollbarOptions = {
 
 };
 
-const getXAxisOptions = (fixedSessionTypeSelected: boolean): XAxisOptions => {
+const getXAxisOptions = (fixedSessionTypeSelected: boolean, tooltipVisible: boolean): XAxisOptions => {
   const dispatch = useAppDispatch();
   const isLoading = useAppSelector(selectIsLoading);
 
@@ -62,7 +62,7 @@ const getXAxisOptions = (fixedSessionTypeSelected: boolean): XAxisOptions => {
     },
     crosshair: {
       color: white,
-      width: 2,
+      width: tooltipVisible ? 2 : 0,
     },
     visible: true,
     minRange: 1000,
@@ -75,7 +75,7 @@ const getXAxisOptions = (fixedSessionTypeSelected: boolean): XAxisOptions => {
 };
 
 const buildTicks = (low: number, high: number) => {
-  const tick =  Math.round((high - low) / 4);
+  const tick = Math.round((high - low) / 4);
   return [low, low + tick, low + 2 * tick, high - tick, high];
 }
 
@@ -87,8 +87,8 @@ const getYAxisOptions = (thresholdsState: ThresholdState): YAxisOptions => {
   const high = Number(thresholdsState.high);
 
   ;
-const ticks = buildTicks(min, max);
-const tickInterval = ticks[1] - ticks[0];
+  const ticks = buildTicks(min, max);
+  const tickInterval = ticks[1] - ticks[0];
 
   return {
     title: {
@@ -148,38 +148,42 @@ const credits: CreditsOptions = {
   position: { align: 'right', verticalAlign: 'top', x: -50, y: 55 },
 };
 
-const plotOptions: PlotOptions = {
-  series: {
-    lineWidth: 2,
-    color: blue,
-    marker: {
-      fillColor: blue,
-      lineWidth: 0,
-      lineColor: blue,
-      radius: 3,
-    },
-    states: {
-      hover: {
-        halo: {
-          attributes: {
-            fill: blue,
-            'stroke-width': 2,
+const getPlotOptions = (tooltipVisible: boolean): PlotOptions => {
+
+  return {
+    series: {
+      lineWidth: 2,
+      color: blue,
+      marker: {
+        fillColor: blue,
+        lineWidth: 0,
+        lineColor: blue,
+        radius: 3,
+      },
+      states: {
+        hover: {
+          halo: {
+            size: tooltipVisible ? 10 : 0,
+            attributes: {
+              fill: blue,
+              'stroke-width': 2,
+            },
           },
         },
       },
+      dataGrouping: {
+        enabled: true,
+        units: [
+          ["millisecond", []],
+          ["second", [2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 50]],
+          ["minute", [1, 2, 3, 4, 5]],
+        ],
+      },
+      dataLabels: {
+        allowOverlap: true,
+      },
     },
-    dataGrouping: {
-      enabled: true,
-      units: [
-        ["millisecond", []],
-        ["second", [2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 50]],
-        ["minute", [1, 2, 3, 4, 5]],
-      ],
-    },
-    dataLabels: {
-      allowOverlap: true,
-    },
-  },
+  }
 };
 
 const seriesOptions = (data: number[][]): SeriesOptionsType => (
@@ -280,53 +284,53 @@ const getRangeSelectorOptions = (fixedSessionTypeSelected: boolean): RangeSelect
   fixedSessionTypeSelected ? {
     labelStyle: {
       display: 'none'
-   },
-  buttonSpacing: 15,
-  buttons: [
-    {
-      type: 'hour',
-      count: 24,
-      text: '24 HOURS',
     },
-    {
-      type: 'day',
-      count: 7,
-      text: '1 WEEK',
-    },
-    {
-      type: 'month',
-      count: 1,
-      text: '1 MONTH',
-    },
-  ],
-  selected: 0,
-  inputEnabled: false,
-} : {
+    buttonSpacing: 15,
+    buttons: [
+      {
+        type: 'hour',
+        count: 24,
+        text: '24 HOURS',
+      },
+      {
+        type: 'day',
+        count: 7,
+        text: '1 WEEK',
+      },
+      {
+        type: 'month',
+        count: 1,
+        text: '1 MONTH',
+      },
+    ],
+    selected: 0,
+    inputEnabled: false,
+  } : {
 
-  buttonSpacing: 15,
-  labelStyle: {
-    display: 'none'
- },
-  buttons: [
-    {
-      type: 'minute',
-      count: 5,
-      text: '5 MINUTES',
+    buttonSpacing: 15,
+    labelStyle: {
+      display: 'none'
     },
-    {
-      type: 'hour',
-      count: 1,
-      text: '1 HOUR',
-    },
-    { type: 'all', text: 'ALL' },
-  ],
-  selected: 2,
-  inputEnabled: false,
-});
+    buttons: [
+      {
+        type: 'minute',
+        count: 5,
+        text: '5 MINUTES',
+      },
+      {
+        type: 'hour',
+        count: 1,
+        text: '1 HOUR',
+      },
+      { type: 'all', text: 'ALL' },
+    ],
+    selected: 2,
+    inputEnabled: false,
+  });
 
 export {
   getXAxisOptions,
-  plotOptions,
+  getPlotOptions,
   titleOption,
   legendOption,
   responsive,

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 import { Map as GoogleMap, MapEvent } from "@vis.gl/react-google-maps";
 
@@ -21,6 +22,9 @@ import * as S from "./Map.style";
 import { FixedMarkers } from "./Markers/FixedMarkers";
 import { MobileMarkers } from "./Markers/MobileMarkers";
 import { StreamMarkers } from "./Markers/StreamMarkers";
+import { screenSizes } from "../../utils/media";
+
+const IS_MOBILE = window.innerWidth <= screenSizes.mobile;
 
 const Map = () => {
   // const
@@ -35,6 +39,7 @@ const Map = () => {
 
   // Hooks
   const dispatch = useAppDispatch();
+  const navigate = useNavigate(); // Initialize useNavigate
 
   // State
   const [mapBounds, setMapBounds] = useState({
@@ -123,6 +128,11 @@ const Map = () => {
 
   // Handlers
   const handleMarkerClick = (streamId: number | null, id: number | null) => {
+    if (IS_MOBILE) {
+      navigate(`/fixed_stream?streamId=${streamId}`);
+      return;
+    }
+
     if (streamId) {
       fixedSessionTypeSelected
         ? dispatch(fetchFixedStreamById(streamId))

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -40,7 +40,7 @@ const Map = () => {
 
   // Hooks
   const dispatch = useAppDispatch();
-  const navigate = useNavigate(); // Initialize useNavigate
+  const navigate = useNavigate();
 
   // State
   const [mapBounds, setMapBounds] = useState({

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -1,17 +1,20 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-
 import { Map as GoogleMap, MapEvent } from "@vis.gl/react-google-maps";
-
-import { DEFAULT_MAP_BOUNDS, DEFAULT_MAP_CENTER, DEFAULT_ZOOM } from "../../const/coordinates";
+import {
+  DEFAULT_MAP_BOUNDS,
+  DEFAULT_MAP_CENTER,
+  DEFAULT_ZOOM,
+} from "../../const/coordinates";
 import { RootState } from "../../store";
 import { selectFixedSessionsPoints } from "../../store/fixedSessionsSelectors";
 import { fetchFixedSessions } from "../../store/fixedSessionsSlice";
 import { fetchFixedStreamById } from "../../store/fixedStreamSlice";
 import { useAppDispatch } from "../../store/hooks";
 import {
-    selectMobileSessionPointsBySessionId, selectMobileSessionsPoints
+  selectMobileSessionPointsBySessionId,
+  selectMobileSessionsPoints,
 } from "../../store/mobileSessionsSelectors";
 import { fetchMobileSessions } from "../../store/mobileSessionsSlice";
 import { selectMobileStreamPoints } from "../../store/mobileStreamSelectors";
@@ -23,8 +26,6 @@ import { FixedMarkers } from "./Markers/FixedMarkers";
 import { MobileMarkers } from "./Markers/MobileMarkers";
 import { StreamMarkers } from "./Markers/StreamMarkers";
 import { screenSizes } from "../../utils/media";
-
-const IS_MOBILE = window.innerWidth <= screenSizes.mobile;
 
 const Map = () => {
   // const
@@ -60,6 +61,10 @@ const Map = () => {
   );
   const [selectedStreamId, setSelectedStreamId] = useState<number | null>(null);
   const [shouldFetchSessions, setShouldFetchSessions] = useState(true);
+  const [isMobile, setIsMobile] = useState(
+    window.innerWidth <= screenSizes.mobile
+  );
+
   const fixedSessionTypeSelected: boolean =
     selectedSessionType === SessionTypes.FIXED;
 
@@ -105,6 +110,16 @@ const Map = () => {
     }
   }, [dispatch, filters, shouldFetchSessions]);
 
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= screenSizes.mobile);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
   // Callbacks
   const onIdle = useCallback(
     (event: MapEvent) => {
@@ -128,7 +143,7 @@ const Map = () => {
 
   // Handlers
   const handleMarkerClick = (streamId: number | null, id: number | null) => {
-    if (IS_MOBILE) {
+    if (isMobile) {
       navigate(`/fixed_stream?streamId=${streamId}`);
       return;
     }

--- a/app/javascript/react/components/Navbar/MobileHeader.tsx
+++ b/app/javascript/react/components/Navbar/MobileHeader.tsx
@@ -50,7 +50,7 @@ export const MobileHeader = ({
 
 export const MobileCalendarHeader = ({ t }: { t: Function }) => (
   <S.MobileContainer>
-    <S.GoBack href={urls.map} aria-label={t("navbar.mapPage")}>
+    <S.GoBack href={urls.reactMap} aria-label={t("navbar.mapPage")}>
       <img
         src={goBackIcon}
         alt={t("navbar.altGoBackIcon")}

--- a/app/javascript/react/components/Navbar/Navbar.style.tsx
+++ b/app/javascript/react/components/Navbar/Navbar.style.tsx
@@ -32,7 +32,7 @@ const Header = styled.header`
 
 const MobileContainer = styled.div`
   display: flex;
-
+  padding: 1rem;
   @media ${media.smallDesktop} {
     display: none;
   }

--- a/app/javascript/react/components/Navbar/Navbar.style.tsx
+++ b/app/javascript/react/components/Navbar/Navbar.style.tsx
@@ -32,7 +32,7 @@ const Header = styled.header`
 
 const MobileContainer = styled.div`
   display: flex;
-  padding: 1rem;
+  padding: 1.5rem;
   @media ${media.smallDesktop} {
     display: none;
   }

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.style.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.style.tsx
@@ -36,7 +36,7 @@ const Subtitle = styled(H5)`
 
 const GridContainer = styled.div`
   background: ${gray100};
-  padding: 3.5rem 2rem;
+  padding: 4.5rem 2rem;
   display: grid;
   width: 100%;
   grid-gap: 10px;

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.style.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.style.tsx
@@ -36,7 +36,7 @@ const Subtitle = styled(H5)`
 
 const GridContainer = styled.div`
   background: ${gray100};
-  padding: 4.5rem 2rem;
+  padding: 5.5rem 2rem;
   display: grid;
   width: 100%;
   grid-gap: 10px;
@@ -69,6 +69,7 @@ const GridContainer = styled.div`
   }
 
   @media ${media.desktop} {
+    padding: 4.5rem 10rem;
     grid-template-columns: 0.2fr 1fr 1fr;
     align-items: center;
     column-gap: 70px;

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
@@ -26,7 +26,8 @@ const FixedStreamStationHeader = () => {
     endTime,
   } = useSelector(selectFixedStreamShortInfo);
 
-  const streamEndTime: string = endTime ?? lastUpdate ?? moment().format("YYYY-MM-DD");
+  const streamEndTime: string =
+    endTime ?? lastUpdate ?? moment().format("YYYY-MM-DD");
 
   return (
     <S.GridContainer>

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
@@ -9,6 +9,7 @@ import { StreamUpdate } from "./atoms/StreamUpdate";
 import { StationActionButtons } from "./atoms/StationActionButtons";
 import { selectFixedStreamShortInfo } from "../../../store/fixedStreamSelectors";
 import * as S from "./FixedStreamStationHeader.style";
+import { DateFormat } from "../../../types/dateFormat";
 
 const FixedStreamStationHeader = () => {
   const {
@@ -27,7 +28,7 @@ const FixedStreamStationHeader = () => {
   } = useSelector(selectFixedStreamShortInfo);
 
   const streamEndTime: string =
-    endTime ?? lastUpdate ?? moment().format("YYYY-MM-DD");
+    endTime ?? lastUpdate ?? moment().format(DateFormat.default);
 
   return (
     <S.GridContainer>

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -16,7 +16,7 @@ interface FixedStreamState {
   averageMeasurementValue: number | null;
   isLoading: boolean;
 }
-const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
+
 const initialState: FixedStreamState = {
   data: {
     stream: {

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -16,7 +16,7 @@ interface FixedStreamState {
   averageMeasurementValue: number | null;
   isLoading: boolean;
 }
-
+const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
 const initialState: FixedStreamState = {
   data: {
     stream: {
@@ -40,11 +40,13 @@ const initialState: FixedStreamState = {
     streamDailyAverages: [],
   },
   status: StatusEnum.Idle,
-  minMeasurementValue: 0,
-  maxMeasurementValue: 0,
+  minMeasurementValue: Date.now() - MILLISECONDS_IN_A_DAY,
+  maxMeasurementValue: Date.now(),
   averageMeasurementValue: 0,
   isLoading: false,
 };
+
+
 
 export const fetchFixedStreamById = createAsyncThunk<
   FixedStream,

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -40,8 +40,8 @@ const initialState: FixedStreamState = {
     streamDailyAverages: [],
   },
   status: StatusEnum.Idle,
-  minMeasurementValue: Date.now() - MILLISECONDS_IN_A_DAY,
-  maxMeasurementValue: Date.now(),
+  minMeasurementValue: Date.now() - MILLISECONDS_IN_A_DAY || 0,
+  maxMeasurementValue: Date.now() || 0,
   averageMeasurementValue: 0,
   isLoading: false,
 };

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -40,8 +40,8 @@ const initialState: FixedStreamState = {
     streamDailyAverages: [],
   },
   status: StatusEnum.Idle,
-  minMeasurementValue: Date.now() - MILLISECONDS_IN_A_DAY || 0,
-  maxMeasurementValue: Date.now() || 0,
+  minMeasurementValue: 0,
+  maxMeasurementValue: 0,
   averageMeasurementValue: 0,
   isLoading: false,
 };

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-i18next": "^13.5.0",
     "react-is": "^18.3.1",
     "react-redux": "^9.0.4",
-    "react-router-dom": "^6.22.3",
+    "react-router-dom": "^6.23.1",
     "reactjs-popup": "^2.0.6",
     "resolve-url-loader": "^5.0.0",
     "sass": "^1.63.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,10 +1899,10 @@
     redux-thunk "^3.1.0"
     reselect "^5.0.1"
 
-"@remix-run/router@1.15.3":
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.3.tgz#d2509048d69dbb72d5389a14945339f1430b2d3c"
-  integrity sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==
+"@remix-run/router@1.16.1":
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.16.1.tgz#73db3c48b975eeb06d0006481bde4f5f2d17d1cd"
+  integrity sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==
 
 "@sentry-internal/browser-utils@8.5.0":
   version "8.5.0"
@@ -7407,20 +7407,20 @@ react-redux@^9.0.4:
     "@types/use-sync-external-store" "^0.0.3"
     use-sync-external-store "^1.0.0"
 
-react-router-dom@^6.22.3:
-  version "6.22.3"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.22.3.tgz#9781415667fd1361a475146c5826d9f16752a691"
-  integrity sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==
+react-router-dom@^6.23.1:
+  version "6.23.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.23.1.tgz#30cbf266669693e9492aa4fc0dde2541ab02322f"
+  integrity sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==
   dependencies:
-    "@remix-run/router" "1.15.3"
-    react-router "6.22.3"
+    "@remix-run/router" "1.16.1"
+    react-router "6.23.1"
 
-react-router@6.22.3:
-  version "6.22.3"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.22.3.tgz#9d9142f35e08be08c736a2082db5f0c9540a885e"
-  integrity sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==
+react-router@6.23.1:
+  version "6.23.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.23.1.tgz#d08cbdbd9d6aedc13eea6e94bc6d9b29cb1c4be9"
+  integrity sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==
   dependencies:
-    "@remix-run/router" "1.15.3"
+    "@remix-run/router" "1.16.1"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Fixed the bugs listed below:

- fixed markers: should directly navigate to the calendar view (we are not showing modal for this sessions"

- click on a fixed marker > click "24 HOURS": sometimes the stats update even though the timeframe and graph do not update after clicking "24 HOURS" .  if you can't reproduce on your first try, click on a different marker and try again until it's reproduced; you shouldn't have to try more than 10 times before the bug is reproduced.

- click on a fixed marker > click "1 WEEK" > hover your mouse over one of the graph chevrons: the timeframe changes even tough no action has been taken to change the timeframe.  this bug also impacts the mobile graph, click "5 MINUTES" then hover hover the graph chevron

- hover over the graph chevron: timeframe buttons should not collapse and expand.  the below two items may be related to this bug

- fixed > click left hand side chevron: vertical line and blue dot should not be visible when clicking the chevron

- drag the TC thresholds: timeframe buttons should not collapse and expand

[Trello card](https://trello.com/c/dvX1cq18/1828-session-details-graph)