### PR TITLE
Change zoom while searching by the city

### DIFF
--- a/app/javascript/react/utils/determineZoomLevel.ts
+++ b/app/javascript/react/utils/determineZoomLevel.ts
@@ -146,7 +146,7 @@ const determineZoomLevel = (results: google.maps.GeocoderResult[]) => {
     case "postal_code":
     case "postal_code_prefix":
     case "postal_code_suffix":
-      return 13;
+      return 11;
 
     // Regional level zoom
     case "administrative_area_level_3":


### PR DESCRIPTION
When searching by city, zoom out a bit.

[Trello card](https://trello.com/c/0KdFAvrR/1888-maps-search-for-location-zoom-is-too-close-when-the-search-entry-is-a-city)