### PR TITLE
Performance improvements

### DIFF
--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -5,14 +5,11 @@ import { useSelector } from "react-redux";
 
 import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
 import {
-  selectFixedData,
-  selectIsLoading,
-  updateFixedMeasurementExtremes,
+    selectFixedData, selectIsLoading, updateFixedMeasurementExtremes
 } from "../../store/fixedStreamSlice";
 import { useAppDispatch } from "../../store/hooks";
 import {
-  selectMobileStreamPoints,
-  selectMobileStreamShortInfo,
+    selectMobileStreamPoints, selectMobileStreamShortInfo
 } from "../../store/mobileStreamSelectors";
 import { updateMobileMeasurementExtremes } from "../../store/mobileStreamSlice";
 import { selectThresholds } from "../../store/thresholdSlice";
@@ -24,15 +21,8 @@ import useMobileDetection from "../../utils/useScreenSizeDetection";
 import { handleLoad } from "./chartEvents";
 import * as S from "./Graph.style";
 import {
-  getPlotOptions,
-  getRangeSelectorOptions,
-  getResponsiveOptions,
-  getTooltipOptions,
-  getXAxisOptions,
-  getYAxisOptions,
-  legendOption,
-  scrollbarOptions,
-  seriesOptions,
+    getPlotOptions, getRangeSelectorOptions, getResponsiveOptions, getTooltipOptions,
+    getXAxisOptions, getYAxisOptions, legendOption, scrollbarOptions, seriesOptions
 } from "./graphConfig";
 
 interface GraphProps {
@@ -124,7 +114,7 @@ const Graph: React.FC<GraphProps> = ({ streamId, sessionType }) => {
         );
       }
     }
-  }, [seriesData, isLoading, dispatch, fixedSessionTypeSelected]);
+  }, []);
 
   useEffect(() => {
     const graphElement = graphRef.current;

--- a/app/javascript/react/components/Graph/graphConfig.ts
+++ b/app/javascript/react/components/Graph/graphConfig.ts
@@ -104,7 +104,7 @@ const getXAxisOptions = (
     visible: true,
     minRange: 10000,
     events: {
-      setExtremes: function (e) {
+      afterSetExtremes: function (e) {
         handleSetExtremes(e);
       },
     },

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -1,39 +1,30 @@
-import { Map as GoogleMap, MapEvent } from "@vis.gl/react-google-maps";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
+import { Map as GoogleMap, MapEvent } from "@vis.gl/react-google-maps";
+
 import pinImage from "../../assets/icons/pinImage.svg";
 import {
-  DEFAULT_MAP_BOUNDS,
-  DEFAULT_MAP_CENTER,
-  DEFAULT_ZOOM,
-  MIN_ZOOM,
+    DEFAULT_MAP_BOUNDS, DEFAULT_MAP_CENTER, DEFAULT_ZOOM, MIN_ZOOM
 } from "../../const/coordinates";
 import { RootState } from "../../store";
 import {
-  selectFixedSessionPointsBySessionId,
-  selectFixedSessionsList,
-  selectFixedSessionsPoints,
-  selectFixedSessionsStatusFulfilled,
+    selectFixedSessionPointsBySessionId, selectFixedSessionsList, selectFixedSessionsPoints,
+    selectFixedSessionsStatusFulfilled
 } from "../../store/fixedSessionsSelectors";
 import { fetchFixedSessions } from "../../store/fixedSessionsSlice";
 import { fetchFixedStreamById } from "../../store/fixedStreamSlice";
 import { useAppDispatch } from "../../store/hooks";
 import { setLoading, setSessionsListOpen } from "../../store/mapSlice";
 import {
-  selectMobileSessionPointsBySessionId,
-  selectMobileSessionsList,
-  selectMobileSessionsPoints,
+    selectMobileSessionPointsBySessionId, selectMobileSessionsList, selectMobileSessionsPoints
 } from "../../store/mobileSessionsSelectors";
 import { fetchMobileSessions } from "../../store/mobileSessionsSlice";
 import { selectMobileStreamPoints } from "../../store/mobileStreamSelectors";
 import { fetchMobileStreamById } from "../../store/mobileStreamSlice";
-import {
-  fetchThresholds,
-  resetUserThresholds,
-} from "../../store/thresholdSlice";
+import { fetchThresholds, resetUserThresholds } from "../../store/thresholdSlice";
 import { SessionType, SessionTypes } from "../../types/filters";
 import { SessionList } from "../../types/sessionType";
 import { pubSub } from "../../utils/pubSubManager";
@@ -158,7 +149,6 @@ const Map = () => {
 
   // Effects
   useEffect(() => {
-    dispatch(fetchThresholds(thresholdFilters));
     if (loading) {
       fixedSessionTypeSelected
         ? dispatch(fetchFixedSessions({ filters }))
@@ -166,6 +156,10 @@ const Map = () => {
       dispatch(setLoading(false));
     }
   }, [dispatch, filters, loading, fixedSessionTypeSelected]);
+
+  useEffect(() => {
+    dispatch(fetchThresholds(thresholdFilters));
+  }, [thresholdFilters]);
 
   // Callbacks
   const onIdle = useCallback(

--- a/app/javascript/react/components/Map/Markers/StreamMarker/StreamMarker.style.tsx
+++ b/app/javascript/react/components/Map/Markers/StreamMarker/StreamMarker.style.tsx
@@ -11,20 +11,11 @@ const StreamMarkerCircle = styled.div<StreamMarkerProps>`
   background-color: ${(props) => props.color};
   position: absolute;
   transform: translate(-50%, -50%); /* Center the marker */
+  pointer-events: auto;
 
   &:hover {
     cursor: pointer;
   }
 `;
 
-const StreamMarkerTooltip = styled.div`
-  width: 1.2rem;
-  height: 1.2rem;
-  border-radius: 50%;
-
-  &:hover {
-    cursor: pointer;
-  }
-`;
-
-export { StreamMarkerCircle, StreamMarkerTooltip };
+export { StreamMarkerCircle };

--- a/app/javascript/react/components/Map/Markers/StreamMarkers.tsx
+++ b/app/javascript/react/components/Map/Markers/StreamMarkers.tsx
@@ -81,7 +81,6 @@ const StreamMarkers = ({ sessions, unitSymbol }: Props) => {
     <>
       {sessions.map((session) => (
         <React.Fragment key={session.id}>
-          {/* #DirtyButWorks Display transparent marker without transform property on top of stream marker to enable tooltip */}
           <AdvancedMarker
             title={`${session.lastMeasurementValue} ${unitSymbol}`}
             position={session.point}

--- a/app/javascript/react/components/Map/Markers/StreamMarkers.tsx
+++ b/app/javascript/react/components/Map/Markers/StreamMarkers.tsx
@@ -11,7 +11,6 @@ import { Session } from "../../../types/sessionType";
 import { getColorForValue } from "../../../utils/thresholdColors";
 import HoverMarker from "./HoverMarker/HoverMarker";
 import { StreamMarker } from "./StreamMarker/StreamMarker";
-import { StreamMarkerTooltip } from "./StreamMarker/StreamMarker.style";
 
 type Props = {
   sessions: Session[];
@@ -83,22 +82,6 @@ const StreamMarkers = ({ sessions, unitSymbol }: Props) => {
       {sessions.map((session) => (
         <React.Fragment key={session.id}>
           {/* #DirtyButWorks Display transparent marker without transform property on top of stream marker to enable tooltip */}
-          <AdvancedMarker
-            title={`${session.lastMeasurementValue} ${unitSymbol}`}
-            position={session.point}
-            key={`tooltip-${session.id}`}
-            zIndex={1}
-            ref={(marker) => {
-              if (marker && !markers[session.point.streamId]) {
-                setMarkers((prev) => ({
-                  ...prev,
-                  [session.point.streamId]: marker,
-                }));
-              }
-            }}
-          >
-            <StreamMarkerTooltip />
-          </AdvancedMarker>
           <AdvancedMarker
             title={`${session.lastMeasurementValue} ${unitSymbol}`}
             position={session.point}


### PR DESCRIPTION
### Done
**Improved Map Stability and Minor Performance Enhancements**

**Ticket**: [mobile device > mobile sessions > sessions list > click on session > close session > click on a different sessions > close session > click on a different session: map glitches and reloads](https://trello.com/c/oyCihhaV/1912-mobile-device-mobile-sessions-sessions-list-click-on-session-close-session-click-on-a-different-sessions-close-session-click-on)


### Remaining Issues:
- I did not address performance issues related to the graph-map integration, specifically the logic for displaying the blue dot on the map.

- Old:

https://github.com/HabitatMap/AirCasting/assets/24482637/53d98ad2-ee1e-4c11-ac69-d37308bf361d

- New:

https://github.com/HabitatMap/AirCasting/assets/24482637/923999e4-bb36-41fe-8080-330d2257ab9b

### Considerations for Future Improvements:

This is probably connected with the logic for displaying the blue dot on the map. In the old map implementation, the blue dot is displayed on the tooltip, and we should probably adopt the same strategy. We are postponing the hover refactor for now, as the quick fix (shown below) would break the tooltip and mobile behavior related to the issue described above.

```
mouseOver: function (this: Highcharts.Point) {
  const position: LatLngLiteral = (this as GraphPoint).position;
  return fixedSessionTypeSelected
    ? dispatch(setHoverStreamId(streamId))
    : !_.isEqual(hoverPosition, position) &&
        dispatch(setHoverPosition(position));
},
mouseOut: function (this: Highcharts.Point) {
  if (isMobile) {
    dispatch(setHoverStreamId(null));
    dispatch(setHoverPosition({ lat: 0, lng: 0 }));
  }
}
```

