### PR TITLE
Sort the calendar months on mobile devices

### DIFF
--- a/app/javascript/react/components/molecules/Calendar/Calendar.tsx
+++ b/app/javascript/react/components/molecules/Calendar/Calendar.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch } from "../../../store/hooks";
 import { updateUserSettings } from "../../../store/userSettingsSlice";
 import { MovesKeys } from "../../../types/movesKeys";
 import { UserSettings } from "../../../types/userStates";
+import isMobile from "../../../utils/useScreenSizeDetection";
 import * as S from "./Calendar.style";
 import useCalendarHook from "./CalendarHook";
 import HeaderToggle from "./HeaderToggle/HeaderToggle";
@@ -34,12 +35,16 @@ const Calendar: React.FC<CalendarProps> = ({
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
 
+  const sortedThreeMonthsData = isMobile()
+    ? [...threeMonthsData].reverse()
+    : threeMonthsData;
+
   useEffect(() => {
     dispatch(updateUserSettings(UserSettings.CalendarView));
   }, []);
 
   return (
-    threeMonthsData && (
+    sortedThreeMonthsData && (
       <S.CalendarContainer>
         <HeaderToggle
           titleText={t("calendarHeader.calendarTitle")}
@@ -73,7 +78,7 @@ const Calendar: React.FC<CalendarProps> = ({
                     handleClick={handleLeftClick}
                   />
                 </S.DesktopSwipeLeftContainer>
-                {threeMonthsData.map((month) => (
+                {sortedThreeMonthsData.map((month) => (
                   <Month key={month.monthName} {...month} />
                 ))}
                 <S.DesktopSwipeRightContainer>


### PR DESCRIPTION
### Issue

Fixed sessions on mobile devices show the oldest month, the request is to show the latest month on top

### Changes
As a three months array always starts with the oldest month, we can just reverse an array for mobile devices to show the latest month on top on mobile devices.

### Related trello ticket:
https://trello.com/c/90Da6b6e/1903-mobile-devices-fixed-sessions-calendar-show-most-recent-month-on-top