### PR TITLE
Fix reset ranges design button on mobile

### DIFF
--- a/app/javascript/react/components/Map/Map.style.tsx
+++ b/app/javascript/react/components/Map/Map.style.tsx
@@ -64,21 +64,21 @@ const ThresholdContainer = styled.div`
   box-shadow: 2px 2px 4px 0px ${colors.gray900};
 
   @media (${media.desktop}) {
-    padding: 1.6rem 4.1rem;
+    padding: 1.1rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;
   }
 
   @media (${media.smallDesktop}) {
-    padding: 1.6rem 4.1rem;
+    padding: 1.1rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;
   }
 
   @media (${media.largeDesktop}) {
-    padding: 1.6rem 4.1rem;
+    padding: 1.1rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;

--- a/app/javascript/react/components/Map/Map.style.tsx
+++ b/app/javascript/react/components/Map/Map.style.tsx
@@ -64,21 +64,21 @@ const ThresholdContainer = styled.div`
   box-shadow: 2px 2px 4px 0px ${colors.gray900};
 
   @media (${media.desktop}) {
-    padding: 1.1rem 4.1rem;
+    padding: 1.6rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;
   }
 
   @media (${media.smallDesktop}) {
-    padding: 1.1rem 4.1rem;
+    padding: 1.6rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;
   }
 
   @media (${media.largeDesktop}) {
-    padding: 1.1rem 4.1rem;
+    padding: 1.6rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;

--- a/app/javascript/react/components/ThresholdConfigurator/ResetButton.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ResetButton.tsx
@@ -70,6 +70,7 @@ const ResetButton: React.FC<ResetButtonProps> = ({
     <S.ResetButton
       onClick={resetThresholds}
       style={{ color: resetButtonTextColor }}
+      variant={variant}
     >
       {buttonContent}
     </S.ResetButton>

--- a/app/javascript/react/components/ThresholdConfigurator/ResetButton.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ResetButton.tsx
@@ -32,7 +32,7 @@ const ResetButton: React.FC<ResetButtonProps> = ({
     ? colors.darkBlue
     : colors.gray300;
   const resetButtonDefaultText = t("thresholdConfigurator.resetButton", {
-    defaultValue: "Reset",
+    defaultValue: "Reset to Default",
   });
   const finalResetButtonText = resetButtonText || resetButtonDefaultText;
 
@@ -40,21 +40,23 @@ const ResetButton: React.FC<ResetButtonProps> = ({
     dispatch(resetUserThresholds());
   };
 
+  const altResetButtonText = t("thresholdConfigurator.altResetButton");
+
   const buttonContent = useMemo(() => {
     if (variant === ResetButtonVariant.TextWithIcon) {
       return swapIconTextPosition ? (
-        <>
+        <S.ResetButtonWrapper>
           {finalResetButtonText}
-          <img src={icon} alt={t("thresholdConfigurator.altResetButton")} />
-        </>
+          <img src={icon} alt={altResetButtonText} />
+        </S.ResetButtonWrapper>
       ) : (
-        <>
-          <img src={icon} alt={t("thresholdConfigurator.altResetButton")} />
+        <S.ResetButtonWrapper>
+          <img src={icon} alt={altResetButtonText} />
           {finalResetButtonText}
-        </>
+        </S.ResetButtonWrapper>
       );
     }
-    return <img src={icon} alt={t("thresholdConfigurator.altResetButton")} />;
+    return <img src={icon} alt={altResetButtonText} />;
   }, [variant, swapIconTextPosition, finalResetButtonText, icon, t]);
 
   if (variant === ResetButtonVariant.TextWithIcon) {

--- a/app/javascript/react/components/ThresholdConfigurator/ResetButton.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ResetButton.tsx
@@ -31,9 +31,7 @@ const ResetButton: React.FC<ResetButtonProps> = ({
   const resetButtonTextColor = useDarkBlueIcon
     ? colors.darkBlue
     : colors.gray300;
-  const resetButtonDefaultText = t("thresholdConfigurator.resetButton", {
-    defaultValue: "Reset to Default",
-  });
+  const resetButtonDefaultText = t("thresholdConfigurator.resetButtonDesktop");
   const finalResetButtonText = resetButtonText || resetButtonDefaultText;
 
   const resetThresholds = () => {

--- a/app/javascript/react/components/ThresholdConfigurator/ResetButton.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ResetButton.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch } from "react-redux";
 import returnArrow from "../../assets/icons/returnArrow.svg";
 import returnArrowDarkBlue from "../../assets/icons/returnArrowDarkBlue.svg";
 import * as colors from "../../assets/styles/colors";
+import { useAppDispatch } from "../../store/hooks";
 import { resetUserThresholds } from "../../store/thresholdSlice";
 import * as S from "./ThresholdConfigurator.style";
 
@@ -20,58 +20,59 @@ interface ResetButtonProps {
 }
 
 const ResetButton: React.FC<ResetButtonProps> = ({
-  variant = "iconOnly",
+  variant = ResetButtonVariant.IconOnly,
   resetButtonText,
   swapIconTextPosition = false,
   useDarkBlueIcon = false,
 }) => {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const icon = useDarkBlueIcon ? returnArrowDarkBlue : returnArrow;
   const resetButtonTextColor = useDarkBlueIcon
     ? colors.darkBlue
     : colors.gray300;
   const resetButtonDefaultText = t("thresholdConfigurator.resetButtonDesktop");
   const finalResetButtonText = resetButtonText || resetButtonDefaultText;
+  const altResetButtonText = t("thresholdConfigurator.altResetButton");
 
   const resetThresholds = () => {
     dispatch(resetUserThresholds());
   };
 
-  const altResetButtonText = t("thresholdConfigurator.altResetButton");
-
   const buttonContent = useMemo(() => {
     if (variant === ResetButtonVariant.TextWithIcon) {
-      return swapIconTextPosition ? (
+      return (
         <S.ResetButtonWrapper>
-          {finalResetButtonText}
-          <img src={icon} alt={altResetButtonText} />
-        </S.ResetButtonWrapper>
-      ) : (
-        <S.ResetButtonWrapper>
-          <img src={icon} alt={altResetButtonText} />
-          {finalResetButtonText}
+          {swapIconTextPosition ? (
+            <>
+              {finalResetButtonText}
+              <img src={icon} alt={altResetButtonText} />
+            </>
+          ) : (
+            <>
+              <img src={icon} alt={altResetButtonText} />
+              {finalResetButtonText}
+            </>
+          )}
         </S.ResetButtonWrapper>
       );
     }
     return <img src={icon} alt={altResetButtonText} />;
-  }, [variant, swapIconTextPosition, finalResetButtonText, icon, t]);
-
-  if (variant === ResetButtonVariant.TextWithIcon) {
-    return (
-      <S.ResetButton
-        onClick={resetThresholds}
-        style={{ color: resetButtonTextColor }}
-      >
-        {buttonContent}
-      </S.ResetButton>
-    );
-  }
+  }, [
+    variant,
+    swapIconTextPosition,
+    finalResetButtonText,
+    icon,
+    altResetButtonText,
+  ]);
 
   return (
-    <S.ThresholdResetButton onClick={resetThresholds}>
+    <S.ResetButton
+      onClick={resetThresholds}
+      style={{ color: resetButtonTextColor }}
+    >
       {buttonContent}
-    </S.ThresholdResetButton>
+    </S.ResetButton>
   );
 };
 

--- a/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import * as colors from "../../assets/styles/colors";
 import { media } from "../../utils/media";
 import { Button } from "../Button/Button.style";
+import { ResetButtonVariant } from "./ResetButton";
 
 interface Props {
   $isMobileOldStyle?: boolean;
@@ -65,7 +66,7 @@ const InputContainer = styled.div<Props>`
   }
 `;
 
-const ResetButton = styled(Button)`
+const ResetButton = styled(Button)<{ variant: ResetButtonVariant }>`
   white-space: nowrap;
   background: ${colors.gray100};
   border: none;
@@ -78,6 +79,11 @@ const ResetButton = styled(Button)`
 
   @media ${media.desktop} {
     margin-left: 0;
+    ${(props) =>
+      props.variant === ResetButtonVariant.IconOnly &&
+      `
+        height: 32px;
+      `}
   }
 
   @media ${media.mobile} {

--- a/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
@@ -73,18 +73,32 @@ const ResetButton = styled(Button)`
   width: fit-content;
   margin-left: auto;
   text-transform: uppercase;
+  align-items: center;
+  justify-content: center;
 
   @media ${media.desktop} {
     margin-left: 0;
   }
 
   @media ${media.mobile} {
-    white-space: wrap;
+    white-space: pre-line;
     text-align: left;
     line-height: 1.6rem;
     width: 33%;
+    min-width: 100px;
     padding: 0.6rem 1.85rem;
     font-size: 1.2rem;
+  }
+`;
+
+const ResetButtonWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+  align-items: center;
+
+  @media ${media.mobile} {
+    max-width: 100px;
+    gap: 10px;
   }
 `;
 
@@ -95,8 +109,14 @@ const ThresholdResetButton = styled(ResetButton)`
   color: ${colors.gray300};
   width: fit-content;
   height: 3.2rem;
+  text-transform: uppercase;
+
   @media ${media.desktop} {
     margin-left: 0;
+  }
+
+  @media ${media.mobile} {
+    display: none;
   }
 `;
 
@@ -461,6 +481,7 @@ export {
   OldStyleSliderText,
   RangeInput,
   ResetButton,
+  ResetButtonWrapper,
   SliderContainer,
   StaticMobileSliderContainer,
   StyledContainer,

--- a/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
@@ -105,23 +105,6 @@ const ResetButtonWrapper = styled.div`
   }
 `;
 
-const ThresholdResetButton = styled(ResetButton)`
-  white-space: nowrap;
-  background: ${colors.gray100};
-  border: none;
-  color: ${colors.gray300};
-  width: fit-content;
-  height: 3.2rem;
-
-  @media ${media.desktop} {
-    margin-left: 0;
-  }
-
-  @media ${media.mobile} {
-    display: none;
-  }
-`;
-
 const ThresholdsDisclaimer = styled.h3`
   font-size: 1.2rem;
   font-weight: 600;
@@ -487,7 +470,6 @@ export {
   SliderContainer,
   StaticMobileSliderContainer,
   StyledContainer,
-  ThresholdResetButton,
   ThresholdsDisclaimer,
   Units,
   Wrapper,

--- a/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
@@ -71,16 +71,17 @@ const ResetButton = styled(Button)`
   border: none;
   color: ${colors.gray300};
   width: fit-content;
-  margin-left: auto;
   text-transform: uppercase;
   align-items: center;
   justify-content: center;
+  align-content: center;
 
   @media ${media.desktop} {
     margin-left: 0;
   }
 
   @media ${media.mobile} {
+    margin-left: auto;
     white-space: pre-line;
     text-align: left;
     line-height: 1.6rem;
@@ -92,11 +93,13 @@ const ResetButton = styled(Button)`
 `;
 
 const ResetButtonWrapper = styled.div`
-  display: flex;
+  display: grid;
   gap: 10px;
   align-items: center;
+  grid-template-columns: auto 1fr;
 
   @media ${media.mobile} {
+    grid-template-columns: 1fr auto;
     max-width: 100px;
     gap: 10px;
   }
@@ -109,7 +112,6 @@ const ThresholdResetButton = styled(ResetButton)`
   color: ${colors.gray300};
   width: fit-content;
   height: 3.2rem;
-  text-transform: uppercase;
 
   @media ${media.desktop} {
     margin-left: 0;

--- a/app/javascript/react/locales/en/translation.json
+++ b/app/javascript/react/locales/en/translation.json
@@ -75,8 +75,9 @@
     "validValueMessage": "Value must be between {{minValue}} and {{maxValue}}",
     "maxLessThanMinMessage": "The maximum value should be higher than {{minValue}}",
     "minGreaterThanMaxMessage": "The minimum value should be lower than {{maxValue}}",
-    "resetButton": "Reset legend",
+    "resetButton": "Reset ranges",
     "altResetButton": "Reset the threshold values to default",
+    "resetButtonDesktop": "Reset to default",
     "measurementsUnits": "µg/m³",
     "invalidOrderMessage": "The values should be in ascending order"
   },

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.style.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.style.tsx
@@ -58,6 +58,7 @@ const StyledContainer = styled.div`
   align-items: right;
   grid-gap: 1rem;
   width: 100%;
+  justify-items: flex-end;
 
   @media ${media.mobile} {
     display: inline;
@@ -91,24 +92,9 @@ const SliderWrapper = styled.div`
   }
 `;
 
-const ResetButton = styled(Button)`
-  white-space: nowrap;
-  background: ${gray100};
-  border: none;
-  color: ${gray300};
-  width: fit-content;
-  margin-left: auto;
-  @media ${media.desktop} {
-    margin-left: 0;
-    grid-column: -1;
-    justify-self: end;
-  }
-`;
-
 export {
   CalendarPageLayout,
   Heading,
-  ResetButton,
   SliderWrapper,
   StationDataContainer,
   StyledContainer,

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.style.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.style.tsx
@@ -77,10 +77,7 @@ const ThresholdContainer = styled.div`
     padding: 3rem 10rem;
     margin-bottom: 0;
   }
-  @media ${media.smallDesktop} {
-    padding: 3rem 10rem;
-    margin-bottom: 0;
-  }
+
   @media ${media.largeDesktop} {
     padding: 3rem 10rem;
     margin-bottom: 0;

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -98,9 +98,6 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
                     <S.Units>{t("calendarHeader.measurementsUnits")}</S.Units>
                     <ResetButton
                       variant={ResetButtonVariant.TextWithIcon}
-                      resetButtonText={t(
-                        "thresholdConfigurator.resetButtonDesktop"
-                      )}
                       swapIconTextPosition={true}
                     ></ResetButton>
                   </S.StyledContainer>

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -22,10 +22,7 @@ import {
   fetchNewMovingStream,
   movingData,
 } from "../../store/movingCalendarStreamSlice";
-import {
-  resetUserThresholds,
-  setDefaultThresholdsValues,
-} from "../../store/thresholdSlice";
+import { setDefaultThresholdsValues } from "../../store/thresholdSlice";
 import useMobileDetection from "../../utils/useScreenSizeDetection";
 import * as S from "./CalendarPage.style";
 
@@ -85,10 +82,6 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
     }
     dispatch(setDefaultThresholdsValues(fixedStreamData.stream));
   }, [fixedStreamData, dispatch]);
-
-  const resetThresholds = () => {
-    dispatch(resetUserThresholds());
-  };
 
   return (
     <>

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -4,13 +4,15 @@ import { useSelector } from "react-redux";
 import { useSearchParams } from "react-router-dom";
 
 import { useTranslation } from "react-i18next";
-import returnArrow from "../../assets/icons/returnArrow.svg";
 import { Calendar } from "../../components/molecules/Calendar";
 import { EmptyCalendar } from "../../components/molecules/Calendar/EmptyCalendar";
 import HeaderToggle from "../../components/molecules/Calendar/HeaderToggle/HeaderToggle";
 import { FixedStreamStationHeader } from "../../components/molecules/FixedStreamStationHeader";
 import { ThresholdsConfigurator } from "../../components/ThresholdConfigurator";
-import { ResetButtonVariant } from "../../components/ThresholdConfigurator/ResetButton";
+import {
+  ResetButton,
+  ResetButtonVariant,
+} from "../../components/ThresholdConfigurator/ResetButton";
 import {
   fetchFixedStreamById,
   selectFixedData,
@@ -101,13 +103,13 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
                   <S.StyledContainer>
                     {t("calendarHeader.legendTitle")}
                     <S.Units>{t("calendarHeader.measurementsUnits")}</S.Units>
-                    <S.ResetButton onClick={resetThresholds}>
-                      {t("thresholdConfigurator.resetButtonDesktop")}
-                      <img
-                        src={returnArrow}
-                        alt={t("thresholdConfigurator.altResetButton")}
-                      />
-                    </S.ResetButton>
+                    <ResetButton
+                      variant={ResetButtonVariant.TextWithIcon}
+                      resetButtonText={t(
+                        "thresholdConfigurator.resetButtonDesktop"
+                      )}
+                      swapIconTextPosition={true}
+                    ></ResetButton>
                   </S.StyledContainer>
                 }
                 componentToToggle={

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -102,7 +102,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
                     {t("calendarHeader.legendTitle")}
                     <S.Units>{t("calendarHeader.measurementsUnits")}</S.Units>
                     <S.ResetButton onClick={resetThresholds}>
-                      {t("thresholdConfigurator.resetButton")}
+                      {t("thresholdConfigurator.resetButtonDesktop")}
                       <img
                         src={returnArrow}
                         alt={t("thresholdConfigurator.altResetButton")}
@@ -139,6 +139,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
                 componentToToggle={
                   <ThresholdsConfigurator
                     resetButtonVariant={ResetButtonVariant.TextWithIcon}
+                    resetButtonText={t("thresholdConfigurator.resetButton")}
                   />
                 }
               />


### PR DESCRIPTION
**Changes:**
- reuse `ResetButton` on `CalendarPage` instead of adding and styling a new one
- added grid within reset button wrapper to make sure it's behaving as intended in all cases we have (centered with accurate space for icon) (I can use flex if you want, but I'm a big grid lover as you might have noticed)
- fixed reset button text from reset legend to reset ranges (probably has been missed during rebases)
- setup default reset button text to desktop version, so if no one provides Reset Button with differentt txt reset to default will be displayed
- make sure the button width on mobile is not smaller than 100px -> if the button is smaller in a future we might just use the smaller gaps or reuse no text, only icon button or whatever - I did not focus on that as we don't have a design for it and these cases would be rare)
- simplify reset Button logic a bit, as it was kinda complicated