### PR TITLE
Fix map legend being stretched out on mobile iOS/Safari

### DIFF
--- a/app/javascript/react/components/Map/Legend/Legend.style.tsx
+++ b/app/javascript/react/components/Map/Legend/Legend.style.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
-import { H2, H3 } from "../../Typography";
-import { acBlue, white, black, gray400 } from "../../../assets/styles/colors";
+import { acBlue, gray400, white } from "../../../assets/styles/colors";
 import { Button } from "../../Button/Button.style";
+import { H3 } from "../../Typography";
 
 const LegendContainer = styled.div`
   display: grid;
@@ -11,7 +11,6 @@ const LegendContainer = styled.div`
   bottom: 0;
   flex-direction: column;
   align-items: center;
-  height: fit-content;
   width: 100%;
   background-color: white;
   padding: 1.6rem;
@@ -91,10 +90,10 @@ const ApplyButton = styled(Button)`
 `;
 
 export {
+  ApplyButton,
+  CloseButton,
   Header,
   LegendContainer,
-  CloseButton,
-  Title,
   SliderContainer,
-  ApplyButton,
+  Title,
 };


### PR DESCRIPTION
This also causes the close button to be hidden behind other UI elements (another issue reported). Fixed by removing modal's height, it should be propagated by grid without a need for specific height.

Before:
![](https://github.com/user-attachments/assets/77e55fbb-d78a-40a9-bb2b-878bdbc01d84)

After:
![Simulator Screenshot - iPhone 15 - 2024-07-16 at 13 18 01 | width=100](https://github.com/user-attachments/assets/21f9c4aa-61bd-4808-b749-84364f3ee76e)
