### PR TITLE
Update measurements legend on mobile calendar

### DIFF
--- a/app/javascript/react/components/Map/Map.style.tsx
+++ b/app/javascript/react/components/Map/Map.style.tsx
@@ -64,21 +64,21 @@ const ThresholdContainer = styled.div`
   box-shadow: 2px 2px 4px 0px ${colors.gray900};
 
   @media (${media.desktop}) {
-    padding: 1.6rem 4.1rem;
+    padding: 1.1rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;
   }
 
   @media (${media.smallDesktop}) {
-    padding: 1.6rem 4.1rem;
+    padding: 1.1rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;
   }
 
   @media (${media.largeDesktop}) {
-    padding: 1.6rem 4.1rem;
+    padding: 1.1rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;

--- a/app/javascript/react/components/Map/Map.style.tsx
+++ b/app/javascript/react/components/Map/Map.style.tsx
@@ -64,21 +64,21 @@ const ThresholdContainer = styled.div`
   box-shadow: 2px 2px 4px 0px ${colors.gray900};
 
   @media (${media.desktop}) {
-    padding: 1.1rem 4.1rem;
+    padding: 1.6rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;
   }
 
   @media (${media.smallDesktop}) {
-    padding: 1.1rem 4.1rem;
+    padding: 1.6rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;
   }
 
   @media (${media.largeDesktop}) {
-    padding: 1.1rem 4.1rem;
+    padding: 1.6rem 4.1rem;
     height: 6.4rem;
     grid-template-columns: 1fr auto;
     margin-bottom: 0;

--- a/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
@@ -30,9 +30,9 @@ const ColorBox = styled.div`
 
 const StaticMobileSliderContainer = styled.div`
   display: grid;
-  grid-template-columns: 1fr 7.5% 1fr 9.5% 1fr 11.5% 1fr 18% 1fr;
+  grid-template-columns: repeat(4, auto 1fr) auto;
   grid-template-rows: auto;
-  gap: 9px;
+  gap: 0.9rem;
   align-items: center;
   width: 100%;
 `;
@@ -285,8 +285,9 @@ const ColorBoxNumberInput = styled.input`
   justify-content: center;
   position: relative;
   width: 100%;
-  min-width: 24px;
-  height: 50px;
+  min-width: 2.4rem;
+  max-width: 2.6rem;
+  height: 5rem;
   justify-content: space-between;
   text-align: center;
   border-radius: 5px;

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.style.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.style.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 
-import { gray100, gray300, white } from "../../assets/styles/colors";
-import { Button } from "../../components/Button/Button.style";
+import { gray100, white } from "../../assets/styles/colors";
 import { NAVBAR_HEIGHT } from "../../components/Navbar/Navbar.style";
 import { H3 } from "../../components/Typography";
 import { media } from "../../utils/media";
@@ -65,13 +64,12 @@ const StyledContainer = styled.div`
   }
 `;
 
-const ThresholdContainer = styled.div`
+const ThresholdContainer = styled.div<{ $isMobile: boolean }>`
   display: flex;
   flex-direction: column;
   position: relative;
   width: 100%;
   margin-bottom: 3rem;
-  padding: 1.5rem;
   background-color: ${white};
 
   @media ${media.desktop} {
@@ -83,6 +81,7 @@ const ThresholdContainer = styled.div`
     padding: 3rem 10rem;
     margin-bottom: 0;
   }
+  ${(props) => props.$isMobile && `padding: 1.5rem; gap: 2rem;`}
 `;
 
 const SliderWrapper = styled.div`

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -90,7 +90,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
         <S.StationDataContainer>
           <FixedStreamStationHeader />
           {!isMobile && (
-            <S.ThresholdContainer>
+            <S.ThresholdContainer $isMobile={isMobile}>
               <HeaderToggle
                 titleText={
                   <S.StyledContainer>
@@ -120,7 +120,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
             <EmptyCalendar />
           )}
           {isMobile && (
-            <S.ThresholdContainer>
+            <S.ThresholdContainer $isMobile={isMobile}>
               <HeaderToggle
                 titleText={
                   <S.StyledContainer>
@@ -132,6 +132,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
                   <ThresholdsConfigurator
                     resetButtonVariant={ResetButtonVariant.TextWithIcon}
                     resetButtonText={t("thresholdConfigurator.resetButton")}
+                    useColorBoxStyle
                   />
                 }
               />


### PR DESCRIPTION
Changes:
- instead of draggable slider we are using mobile map legend design on measurements legend 
- fulfil request to make all the coloured boxes of equal length (as there's no point in keeping the different lengths with no way of dragging them) - requested in the ticket: **[1904-mobile-devices-fixed-mobile-sessions-measurements-legend-is-obscured](https://trello.com/c/UJ6I9HEA/1904-mobile-devices-fixed-mobile-sessions-measurements-legend-is-obscured)**

New Calendar measurement legend preview:
![Simulator Screenshot - iPhone 15 - 2024-07-16 at 16 27 22](https://github.com/user-attachments/assets/0da53975-2eef-4547-ac34-916ddf9bd398)

Updated map legend (equal colour boxes length):
![Screenshot 2024-07-16 at 16 30 45](https://github.com/user-attachments/assets/c997029c-9e99-495e-a503-e01ab1f8a96d)
