### PR TITLE
Fix input field click zoom in the view on ios

### DIFF
--- a/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
+++ b/app/javascript/react/components/ThresholdConfigurator/ThresholdConfigurator.style.tsx
@@ -286,14 +286,14 @@ const ColorBoxNumberInput = styled.input`
   position: relative;
   width: 100%;
   min-width: 2.4rem;
-  max-width: 2.6rem;
+  max-width: 2.9rem;
   height: 5rem;
   justify-content: space-between;
   text-align: center;
   border-radius: 5px;
   border: 1px solid ${colors.darkBlueTransparent};
   z-index: 5;
-  font-size: 1.2rem;
+  font-size: 1.6rem;
   color: ${colors.darkBlue};
 
   @media (${media.mobile}) {


### PR DESCRIPTION
Clicking input field on Map Legend thresholds caused a whole view zoom in

This happens because iOS requires 16px minimum font size, but we use 12px in our designs and I followed them. 
I changed the font-size and threshold width a bit to adjust the view.