### PR TITLE
Fix markers appearing while they should remain clustered

### DIFF
--- a/app/javascript/react/components/Map/Markers/FixedMarkers.tsx
+++ b/app/javascript/react/components/Map/Markers/FixedMarkers.tsx
@@ -108,7 +108,7 @@ const FixedMarkers = ({
     };
   }, [memoizedSessions]);
 
-  const updateClusterer = () => {
+  const updateClusterer = useCallback(() => {
     if (clusterer.current && memoizedSessions.length > 0) {
       const sessionStreamIds = memoizedSessions.map(
         (session) => session.point.streamId
@@ -125,12 +125,12 @@ const FixedMarkers = ({
       clusterer.current.clearMarkers();
       clusterer.current.addMarkers(validMarkers);
     }
-  };
+  }, [memoizedSessions, memoizedMarkers]);
 
   // Update MarkerClusterer when markers and sessions change
   useEffect(() => {
     updateClusterer();
-  }, [memoizedMarkers, memoizedSessions, thresholds]);
+  }, [updateClusterer]);
 
   // Pulsation
   useEffect(() => {
@@ -187,13 +187,16 @@ const FixedMarkers = ({
     };
   }, []);
 
-  const centerMapOnMarker = (position: LatLngLiteral, streamId: string) => {
-    if (map) {
-      map.setCenter(position);
-      map.setZoom(ZOOM_FOR_SELECTED_SESSION);
-    }
-    setSelectedMarkerKey(streamId === selectedMarkerKey ? null : streamId);
-  };
+  const centerMapOnMarker = useCallback(
+    (position: LatLngLiteral, streamId: string) => {
+      if (map) {
+        map.setCenter(position);
+        map.setZoom(ZOOM_FOR_SELECTED_SESSION);
+      }
+      setSelectedMarkerKey(streamId === selectedMarkerKey ? null : streamId);
+    },
+    [map, selectedMarkerKey]
+  );
 
   const setMarkerRef = useCallback(
     (marker: google.maps.marker.AdvancedMarkerElement | null, key: string) => {


### PR DESCRIPTION
### Problem:
The pulsation solution was affecting clusters and markers incorrectly. When a session was assigned a `pulsatingSessionId`, the markers were not clustering correctly and appeared individually instead of within a cluster. It was caused by incorrect pulsation clearing and marker clustering.

### Fixes:

- handle pulsating markers: refactored the code around pulsating markers - implemented a separate `MarkerClusterer` for handling pulsating markers to ensure they do not interfere with the main clusterer
- clear previous pulsating markers: before applying pulsation, clear any existing pulsating markers to avoid conflicts
- maintain clusters: ensured that markers remain part of the main clusterer even when they are pulsating by adding markers back to the main clusterer after the pulsation ends
- properly reset clusters: when `pulsatingSessionId` is set to null, clear the pulsating cluster and ensure the main clusterer is updated with all valid markers
- prevent markers from refreshing: to avoid refreshing all other markers when the pulsation stops, memoized the sessions and markers using `useMemo` to minimize unnecessary re-renders

### Optimizations:

- memoize sessions and markers: used `useMemo` to memoize sessions and markers to avoid unnecessary re-renders and improve performance
- update only relevant parts: ensured that only the pulsating markers or clusters are updated without affecting the rest of the markers, leading to a smoother user experience
- stable references for callbacks: ensured stable references for the `centerMapOnMarker` and `updateClusterer` functions by using `useCallback`
- type safety for callbacks: explicitly typed the callback functions for better type safety and readability

### Steps to reproduce the initial problem:

1. Click on a cluster on loaded map
2. Hover over sessions on session list
3. Zoom out so the markers should be clustered
4. Notice that hovered sessions are not being clustered
5. To re-cluster them we are forced to hover over session that should be clustered