### PR TITLE
Remove button outline on session details' buttons

### DIFF
--- a/app/javascript/react/components/Modals/SessionDetailsModal/SessionDetailsModal.style.tsx
+++ b/app/javascript/react/components/Modals/SessionDetailsModal/SessionDetailsModal.style.tsx
@@ -181,8 +181,14 @@ const Button = styled(ActionButton)`
   background-color: ${gray100};
   box-shadow: none;
   padding: 1.6rem;
-  outline: 0 !important;
-  border: 0;
+  border: none;
+
+   {
+    /* fix for outlines appearing on component load */
+  }
+  body:not(.user-is-tabbing) &:focus-visible {
+    outline: none;
+  }
 `;
 
 const BlueButton = styled(Link)`
@@ -205,8 +211,13 @@ const BlueButton = styled(Link)`
   text-decoration: none;
   border: none;
   margin-right: 0.5rem;
-  outline: 0 !important;
-  border: none;
+
+   {
+    /* fix for outlines appearing on component load */
+  }
+  body:not(.user-is-tabbing) &:focus-visible {
+    outline: none;
+  }
 
   @media ${media.largeDesktop} {
     padding: 1.6rem;

--- a/app/javascript/react/components/Modals/SessionDetailsModal/SessionDetailsModal.style.tsx
+++ b/app/javascript/react/components/Modals/SessionDetailsModal/SessionDetailsModal.style.tsx
@@ -181,6 +181,8 @@ const Button = styled(ActionButton)`
   background-color: ${gray100};
   box-shadow: none;
   padding: 1.6rem;
+  outline: 0 !important;
+  border: 0;
 `;
 
 const BlueButton = styled(Link)`
@@ -203,6 +205,8 @@ const BlueButton = styled(Link)`
   text-decoration: none;
   border: none;
   margin-right: 0.5rem;
+  outline: 0 !important;
+  border: none;
 
   @media ${media.largeDesktop} {
     padding: 1.6rem;

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/StationActionButtons/StationActionButtons.style.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/StationActionButtons/StationActionButtons.style.tsx
@@ -5,8 +5,6 @@ import { media } from "../../../../../utils/media";
 const MobileButtons = styled.div`
   display: flex;
   gap: 24px;
-  outline: none !important;
-
   @media ${media.desktop} {
     display: none;
   }
@@ -16,11 +14,10 @@ const DesktopButtons = styled.div`
   display: none;
 
   @media ${media.desktop} {
-    outline: none !important;
     display: flex;
     flex-wrap: wrap;
     gap: 20px;
   }
 `;
 
-export { MobileButtons, DesktopButtons };
+export { DesktopButtons, MobileButtons };

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/StationActionButtons/StationActionButtons.style.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/StationActionButtons/StationActionButtons.style.tsx
@@ -5,6 +5,7 @@ import { media } from "../../../../../utils/media";
 const MobileButtons = styled.div`
   display: flex;
   gap: 24px;
+  outline: none !important;
 
   @media ${media.desktop} {
     display: none;
@@ -15,6 +16,7 @@ const DesktopButtons = styled.div`
   display: none;
 
   @media ${media.desktop} {
+    outline: none !important;
     display: flex;
     flex-wrap: wrap;
     gap: 20px;


### PR DESCRIPTION
> In six swift lines, a transformation gleams,
Two buttons refined, now sleek as dreams.
Outline and border, both cast away,
A cleaner export, in order they stay.
An empty line, no more it lingers,
Elegance crafted by deft coder's fingers.
_July, 2024  by Chat GPT_

I needed some inspiration to write appropriate PR description. Please double check on your machines if the outline is gone. On my mac, linux, and windows these are no more, but if you see something sus please let me know.