### PR TITLE
fix: arrow icon on modal for mobile sessions and calendar page for fixed sessions [mobile device]

### DIFF
--- a/app/javascript/react/components/Modals/SessionDetailsModal/SessionInfo/ModalMobileHeader.tsx
+++ b/app/javascript/react/components/Modals/SessionDetailsModal/SessionInfo/ModalMobileHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+
 import toggleIcon from "../../../../assets/icons/toggleIcon.svg";
 import { MobileStreamShortInfo as StreamShortInfo } from "../../../../types/mobileStream";
 import { Thresholds } from "../../../../types/thresholds";
@@ -47,7 +48,7 @@ const ModalMobileHeader: React.FC<ModalMobileHeaderProps> = ({
           <S.RotatedIcon
             src={toggleIcon}
             alt={t("headerToggle.arrowIcon")}
-            $rotated={!isVisible}
+            $rotated={isVisible}
             onClick={toggleVisibility}
           />
           <S.SessionName>{streamShortInfo.title}</S.SessionName>

--- a/app/javascript/react/components/molecules/Calendar/HeaderToggle/HeaderToggle.tsx
+++ b/app/javascript/react/components/molecules/Calendar/HeaderToggle/HeaderToggle.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import headerArrowIcon from "../../../../assets/icons/headerArrowIcon.svg";
-
 import useMobileDetection from "../../../../utils/useScreenSizeDetection";
 import * as S from "./HeaderToggle.style";
 
@@ -35,7 +34,7 @@ const HeaderToggle = ({
           <S.RotatedIcon
             src={headerArrowIcon}
             alt={t("headerToggle.arrowIcon")}
-            $rotated={!isVisible}
+            $rotated={isVisible}
             onClick={toggleVisibility}
           />
           <S.Heading onClick={toggleVisibility}>{titleText}</S.Heading>


### PR DESCRIPTION
Ticket: [Mobile device > mobile session: collapse/expand arrows are opposite of what they should be](https://trello.com/c/B3aBDn1Q/1930-mobile-device-mobile-session-collapse-expand-arrows-are-opposite-of-what-they-should-be)