### PR TITLE
Fix cluster position problems when map view shows IDL + default cluster zooming too close

### DIFF
--- a/app/javascript/react/components/Map/Markers/FixedMarkers.tsx
+++ b/app/javascript/react/components/Map/Markers/FixedMarkers.tsx
@@ -289,6 +289,10 @@ const FixedMarkers = ({
         selectedCluster,
         map
       );
+      const currentZoom = map.getZoom();
+      if (currentZoom !== null && currentZoom !== undefined) {
+        map.setZoom(currentZoom - 0.5);
+      }
       dispatch(setVisibility(false));
       setSelectedCluster(null);
       setClusterPosition(null);

--- a/app/javascript/react/utils/getClusterPixelPosition.ts
+++ b/app/javascript/react/utils/getClusterPixelPosition.ts
@@ -13,9 +13,14 @@ const getClusterPixelPosition = (
   }
 
   const scale = Math.pow(2, zoom);
+  const bounds = map.getBounds();
+  if (!bounds) {
+    throw new Error("Map bounds are undefined");
+  }
+
   const nw = new google.maps.LatLng(
-    map.getBounds()!.getNorthEast().lat(),
-    map.getBounds()!.getSouthWest().lng()
+    bounds.getNorthEast().lat(),
+    bounds.getSouthWest().lng()
   );
   const worldCoordinateNW = projection.fromLatLngToPoint(nw);
   const worldCoordinate = projection.fromLatLngToPoint(latLng);
@@ -23,9 +28,22 @@ const getClusterPixelPosition = (
     throw new Error("World coordinate is null");
   }
 
+  let xOffset = (worldCoordinate.x - worldCoordinateNW.x) * scale;
+  const yOffset = (worldCoordinate.y - worldCoordinateNW.y) * scale;
+
+  const totalWorldPixels = 256 * scale;
+
+  if (xOffset < -totalWorldPixels / 2) {
+    xOffset += totalWorldPixels;
+  } else if (xOffset > totalWorldPixels / 2) {
+    xOffset -= totalWorldPixels;
+  }
+
+  xOffset = (xOffset + totalWorldPixels) % totalWorldPixels;
+
   const pixelOffset = new google.maps.Point(
-    Math.floor((worldCoordinate.x - worldCoordinateNW.x) * scale),
-    Math.floor((worldCoordinate.y - worldCoordinateNW.y) * scale)
+    Math.floor(xOffset),
+    Math.floor(yOffset)
   );
 
   return pixelOffset;


### PR DESCRIPTION
### Tests detected issues:

1. if you zoom out far enough you can reach IDL, which causes `getClusterPixelPosition` calculations for the clusters right of the line go bonkers
2. if you click on a zoom in, the default zoom in zooms too close, so some of the markers are covered by the UI elements

### Changes:
**ad 1a.** I added a calculation to determine the total width of the world in pixels at the current zoom level
**ad 1b.** to adjust  xOffset for longitude wrap-around I introduced conditions to adjust `xOffset` if it falls outside the range of `-totalWorldPixels / 2` to` totalWorldPixels / 2` and ensured `xOffset` is within the range` [0, totalWorldPixels]` using modulo operation
**ad 2.** added a minimal zoom out on handleZoomIn to ensure none of the markers is hidden behind UI elements

### To test:
Zoom out as far as you can to reach the day line then click on clusters
Zoom in the cluster and check if the markers are not hidden by the UI