### PR TITLE
Add crowdmap toggle and adjust related components

### DIFF
--- a/app/javascript/react/components/SessionFilters/CrowdmapToggle.tsx
+++ b/app/javascript/react/components/SessionFilters/CrowdmapToggle.tsx
@@ -1,29 +1,111 @@
-import React from "react";
+import React, { useEffect, useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { debounce } from "lodash";
 
 import { UserSettings } from "../../types/userStates";
-import { useMapParams } from "../../utils/mapParamsHandler";
+import { UrlParamsTypes, useMapParams } from "../../utils/mapParamsHandler";
 import * as S from "./SessionFilters.style";
-
+import { FilterInfoPopup } from "./FilterInfoPopup";
+import { Toggle } from "../Toggle/Toggle";
 const CrowdMapToggle = () => {
-  const { currentUserSettings, goToUserSettings } = useMapParams();
+  const {
+    currentUserSettings,
+    goToUserSettings,
+    previousUserSettings,
+    setUrlParams,
+  } = useMapParams();
+  const { t } = useTranslation();
 
-  const handleCrowdMap = () => {
-    goToUserSettings(UserSettings.CrowdMapView);
-    if (currentUserSettings === UserSettings.CrowdMapView) {
-      goToUserSettings(UserSettings.MapView);
-    }
+  const getInitialMobileState = () =>
+    window.matchMedia("(max-width: 1023px)").matches;
+
+  const getInitialCrowdMapState = () => {
+    return getInitialMobileState()
+      ? previousUserSettings === UserSettings.CrowdMapView
+      : currentUserSettings === UserSettings.CrowdMapView;
   };
 
+  const [isMobile, setIsMobile] = useState(getInitialMobileState);
+  const [isCrowdMapActive, setIsCrowdMapActive] = useState(
+    getInitialCrowdMapState
+  );
+
+  const isFiltersViewActive = currentUserSettings === UserSettings.FiltersView;
+
+  useEffect(() => {
+    const checkMobile = debounce(() => {
+      const mobileState = window.matchMedia("(max-width: 1023px)").matches;
+      setIsMobile(mobileState);
+    }, 200);
+
+    window.addEventListener("resize", checkMobile);
+    return () => {
+      window.removeEventListener("resize", checkMobile);
+      checkMobile.cancel();
+    };
+  }, []);
+
+  useEffect(() => {
+    const newCrowdMapState = isMobile
+      ? previousUserSettings === UserSettings.CrowdMapView
+      : currentUserSettings === UserSettings.CrowdMapView;
+
+    if (newCrowdMapState !== isCrowdMapActive) {
+      setIsCrowdMapActive(newCrowdMapState);
+    }
+  }, [currentUserSettings, previousUserSettings, isMobile, isCrowdMapActive]);
+
+  const handleToggleClick = useCallback(() => {
+    const newCheckedState = !isCrowdMapActive;
+
+    if (isMobile && isFiltersViewActive) {
+      setUrlParams([
+        {
+          key: UrlParamsTypes.previousUserSettings,
+          value: newCheckedState
+            ? UserSettings.CrowdMapView
+            : UserSettings.MapView,
+        },
+      ]);
+    } else {
+      goToUserSettings(
+        newCheckedState ? UserSettings.CrowdMapView : UserSettings.MapView
+      );
+    }
+    setIsCrowdMapActive(newCheckedState);
+  }, [
+    isCrowdMapActive,
+    isMobile,
+    isFiltersViewActive,
+    setUrlParams,
+    goToUserSettings,
+  ]);
+
   return (
-    <S.SessionToggleWrapper>
-      {/* temporary solution, ticket: Session Filter [Mobile]: Crowdmap Toggle */}
-      <S.CrowdMapButton
-        onClick={handleCrowdMap}
-        disabled={[UserSettings.ModalView].includes(currentUserSettings)}
-      >
-        crowdmap
-      </S.CrowdMapButton>
-    </S.SessionToggleWrapper>
+    <S.Wrapper>
+      <S.SingleFilterWrapper>
+        <S.CrowdMapSettingsContainer>
+          <S.CrowdMapToggleWrapper onClick={handleToggleClick}>
+            <Toggle
+              isChecked={isCrowdMapActive}
+              onChange={handleToggleClick}
+              variant="toggle"
+              noLabel
+              biggerMobileVersion
+            />
+            <S.CrowdMapToggleText>
+              {t("filters.crowdMapLabel")}{" "}
+              <S.CrowdMapToggleOnOff>
+                {isCrowdMapActive
+                  ? t("filters.crowdMapToggleOn")
+                  : t("filters.crowdMapToggleOff")}
+              </S.CrowdMapToggleOnOff>
+            </S.CrowdMapToggleText>
+          </S.CrowdMapToggleWrapper>
+        </S.CrowdMapSettingsContainer>
+        <FilterInfoPopup filterTranslationLabel="filters.crowdMapInfo" />
+      </S.SingleFilterWrapper>
+    </S.Wrapper>
   );
 };
 

--- a/app/javascript/react/components/SessionFilters/SessionFilters.style.tsx
+++ b/app/javascript/react/components/SessionFilters/SessionFilters.style.tsx
@@ -4,6 +4,7 @@ import {
   acBlue,
   acBlueTransparent,
   black,
+  blue,
   gray100,
   gray200,
   gray300,
@@ -210,6 +211,41 @@ const InfoPopup = styled(SmallPopup)`
 `;
 
 const CrowdMapButton = styled(Button)``;
+
+const CrowdMapSettingsContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto;
+  // grid-gap: 0.8rem; // unused until grid size selector is added
+  justify-content: center;
+  align-items: center;
+  border: 1px solid ${gray200};
+  min-height: 4.2rem;
+  width: 100%;
+  padding: 1.1rem 1.6rem;
+  border-radius: 0.5rem;
+`;
+
+const CrowdMapToggleWrapper = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-gap: 0.8rem;
+  align-items: center;
+  font-size: 1.4rem;
+  color: ${gray600};
+  width: 100%;
+`;
+
+const CrowdMapToggleText = styled.span<{ $isActive?: boolean }>`
+  &::first-letter {
+    text-transform: uppercase;
+  }
+`;
+
+const CrowdMapToggleOnOff = styled.span`
+  text-transform: uppercase;
+  font-weight: 700;
+`;
 
 const SelectedOptionButton = styled(Button)<{ $isActive: boolean }>`
   width: 100%;
@@ -494,6 +530,10 @@ export {
   ChevronIcon,
   CloseSelectedItemButton,
   CrowdMapButton,
+  CrowdMapSettingsContainer,
+  CrowdMapToggleText,
+  CrowdMapToggleOnOff,
+  CrowdMapToggleWrapper,
   CustomParameter,
   CustomParameterItem,
   CustomParameterList,

--- a/app/javascript/react/components/Toggle/Toggle.style.tsx
+++ b/app/javascript/react/components/Toggle/Toggle.style.tsx
@@ -2,18 +2,19 @@ import styled from "styled-components";
 import { blue, gray400, gray600, white } from "../../assets/styles/colors";
 import { media } from "../../utils/media";
 
-const ToggleLabel = styled.label`
+const ToggleLabel = styled.label<{ biggerMobileVersion: boolean }>`
   position: relative;
   display: inline-block;
   width: 3.6rem;
   height: 1.8rem;
+
   @media ${media.mobile} {
-    width: 2.5rem;
-    height: 1.3rem;
+    width: ${(props) => (props.biggerMobileVersion ? "3.6rem" : "2.5rem")};
+    height: ${(props) => (props.biggerMobileVersion ? "1.8rem" : "1.3rem")};
   }
 `;
 
-const ToggleInput = styled.input`
+const ToggleInput = styled.input<{ biggerMobileVersion: boolean }>`
   opacity: 0;
   width: 3.6rem;
   height: 1.8rem;
@@ -22,18 +23,26 @@ const ToggleInput = styled.input`
 
   &:checked + span:before {
     transform: translateX(1.8rem);
+
     @media ${media.mobile} {
-      transform: translateX(1.2rem);
+      transform: ${(props) =>
+        props.biggerMobileVersion
+          ? "translateX(1.8rem)"
+          : "translateX(1.2rem)"};
     }
   }
 
   @media ${media.mobile} {
-    width: 2.5rem;
-    height: 1.3rem;
+    width: ${(props) => (props.biggerMobileVersion ? "3.6rem" : "2.5rem")};
+    height: ${(props) => (props.biggerMobileVersion ? "1.8rem" : "1.3rem")};
   }
 `;
 
-const Slider = styled.span<{ $isActive: boolean; $variant: string }>`
+const Slider = styled.span<{
+  $isActive: boolean;
+  $variant: string;
+  biggerMobileVersion: boolean;
+}>`
   position: absolute;
   cursor: pointer;
   top: 0;
@@ -58,8 +67,8 @@ const Slider = styled.span<{ $isActive: boolean; $variant: string }>`
     border-radius: 50%;
 
     @media ${media.mobile} {
-      height: 0.9rem;
-      width: 0.9rem;
+      height: ${(props) => (props.biggerMobileVersion ? "1.4rem" : "0.9rem")};
+      width: ${(props) => (props.biggerMobileVersion ? "1.4rem" : "0.9rem")};
       left: 0.18rem;
       bottom: 0.18rem;
     }

--- a/app/javascript/react/components/Toggle/Toggle.tsx
+++ b/app/javascript/react/components/Toggle/Toggle.tsx
@@ -10,16 +10,20 @@ import {
 interface ToggleProps {
   isChecked: boolean;
   onChange: (isChecked: boolean) => void;
-  labelLeft: string;
+  noLabel?: boolean;
+  labelLeft?: string;
   labelRight?: string;
+  biggerMobileVersion?: boolean;
   variant: "switch" | "toggle";
 }
 
 const Toggle: React.FC<ToggleProps> = ({
   isChecked,
   onChange,
+  noLabel = false,
   labelLeft,
   labelRight,
+  biggerMobileVersion = false,
   variant,
 }) => {
   const handleClick = () => {
@@ -28,14 +32,23 @@ const Toggle: React.FC<ToggleProps> = ({
 
   return (
     <ToggleContainer onClick={handleClick}>
-      <Label $isActive={!isChecked && variant === "switch"}>{labelLeft}</Label>
-      <ToggleLabel>
+      {!noLabel && (
+        <Label $isActive={!isChecked && variant === "switch"}>
+          {labelLeft}
+        </Label>
+      )}
+      <ToggleLabel biggerMobileVersion={biggerMobileVersion}>
         <ToggleInput
           type="checkbox"
           checked={isChecked}
           onChange={handleClick}
+          biggerMobileVersion={biggerMobileVersion}
         />
-        <Slider $isActive={isChecked} $variant={variant} />
+        <Slider
+          $isActive={isChecked}
+          $variant={variant}
+          biggerMobileVersion={biggerMobileVersion}
+        />
       </ToggleLabel>
       {variant === "switch" && labelRight && (
         <Label $isActive={isChecked}>{labelRight}</Label>

--- a/app/javascript/react/locales/en/translation.json
+++ b/app/javascript/react/locales/en/translation.json
@@ -177,10 +177,17 @@
     "editFilters": "edit filters",
     "showSessions": "show sessions",
     "mobileFixedInfo": "The mobile tab displays measurements from mobile sessions. When recording mobile sessions, measurements are created, timestamped, and geolocated once per second. Average values for the duration of the session are displayed inside the session map markers. The fixed tab displays measurements from fixed sessions. When recording fixed sessions, geocoordinates are fixed to a set location. The most recent measurement is displayed inside the session map markers.",
+
     "profileNamesInfo": "Enter a profile name or names to filter the sessions by profile name.",
     "tagNamesInfo": "Enter a tag or tags to filter the sessions by tags. Tags are keywords assigned to sessions.",
     "profileNames": "profile names",
     "tagsNames": "tags names",
+
+    "crowdMapLabel": "crowd map",
+    "crowdMapInfo": "The CrowdMap averages together all the measurements from all the sessions listed on the sessions list and displays these averages as colored grid cells. The color of each grid cell corresponds to the average intensity of all the measurements recorded in that area. Click on a grid cell to view the underlying data.",
+    "crowdMapToggleOn": "on",
+    "crowdMapToggleOff": "off",
+
     "parameterInfo": "The parameter field describes the broad category of environmental or physiological measurements being recorded. The AirCasting platform is device agnostic i.e. it will ingest and display data from any instrument that formats and communicates data according to our formatting and communications protocol.",
     "parameter": "parameter",
     "customParameters": "custom parameters",


### PR DESCRIPTION
### Changes
Refined the crowdmap toggle
- on desktop, it directly toggles between `CrowdMapView` and `MapView`
- on mobile, when filters are open, it updates `previousUserSettings` instead of `currentUserSettings` (I am aware it's not perfect, but I think that's the quickest solution)
- the crowdmap toggle respects the active view when switching between map types and handles the case when the filters view is active on mobile
- I made sure the CrowdMap toggle is ready for grid cell sizes (just uncomment the grid-gap property and add a new component or code below `CrowdMapToggleWrapper` within `CrowdMapSettingsContainer`

Adjusted default toggle component:
- added new props to default toggle so we can use it without labels and if needed on mobile have a bigger toggle (same as on desktop) - this design varies between components, so I'd rather keep it flexible

### Design:
- I am totally aware that the toggle button on mobile is on the right in the designs, but I want to convince Michael that it is inconsistent with dormant session and that we should keep one way of showing the toggle in filters (we can decide whether it's right or left, because otherwise it's bad for UX). Let me know if you think that instead of complaining I should implement it as per designs against my better judgment. 

Mobile preview:

https://github.com/user-attachments/assets/06e31d95-39a0-402e-8557-eda75da8ea28



