### PR TITLE
Uniform distribution button fixes

### DIFF
--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -341,7 +341,6 @@ const Map = () => {
         : dispatch(fetchMobileStreamById(selectedStreamId));
     }
 
-    // Ensure sessionId is set in the URL for mobile devices
     if (isMobile) {
       if (fixedSessionTypeSelected) {
         newSearchParams.set(
@@ -352,7 +351,7 @@ const Map = () => {
           UrlParamsTypes.currentUserSettings,
           UserSettings.CalendarView
         );
-        newSearchParams.set(UrlParamsTypes.sessionId, id?.toString() || ""); // Add this line
+        newSearchParams.set(UrlParamsTypes.sessionId, id?.toString() || "");
         newSearchParams.set(
           UrlParamsTypes.streamId,
           selectedStreamId?.toString() || ""
@@ -362,7 +361,6 @@ const Map = () => {
       }
     }
 
-    // Update sessionId and streamId in the URL for desktop or general case
     if (!streamId) {
       newSearchParams.set(UrlParamsTypes.sessionId, id?.toString() || "");
       newSearchParams.set(

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -341,6 +341,7 @@ const Map = () => {
         : dispatch(fetchMobileStreamById(selectedStreamId));
     }
 
+    // Ensure sessionId is set in the URL for mobile devices
     if (isMobile) {
       if (fixedSessionTypeSelected) {
         newSearchParams.set(
@@ -351,13 +352,17 @@ const Map = () => {
           UrlParamsTypes.currentUserSettings,
           UserSettings.CalendarView
         );
-        navigate(
-          `/fixed_stream?streamId=${selectedStreamId}&${newSearchParams.toString()}`
+        newSearchParams.set(UrlParamsTypes.sessionId, id?.toString() || ""); // Add this line
+        newSearchParams.set(
+          UrlParamsTypes.streamId,
+          selectedStreamId?.toString() || ""
         );
+        navigate(`/fixed_stream?${newSearchParams.toString()}`);
         return;
       }
     }
 
+    // Update sessionId and streamId in the URL for desktop or general case
     if (!streamId) {
       newSearchParams.set(UrlParamsTypes.sessionId, id?.toString() || "");
       newSearchParams.set(

--- a/app/javascript/react/locales/en/translation.json
+++ b/app/javascript/react/locales/en/translation.json
@@ -84,7 +84,8 @@
     "altUniformDistribution": "Distribute the measurement thresholds uniformly",
     "uniformDistributionButton": "Fit\nto scale",
     "uniformDistributionButtonDesktop": "Scale to fit data",
-    "uniformDistributionButtonSameValuesError": "Can't distribute thresholds when Min and Max values are both the same.",
+    "sameValuesError": "Can't distribute thresholds when Min and Max values are both the same.",
+    "noValidDataErrorMessage": "Insufficient data to distribute thresholds.",
     "invalidOrderMessage": "The values should be in ascending order"
   },
   "notFoundPage": {

--- a/app/javascript/react/store/movingStreamSelectors.ts
+++ b/app/javascript/react/store/movingStreamSelectors.ts
@@ -17,7 +17,9 @@ const getMonthWeekBoundariesForDate = (
 ): { firstDayOfMonthWeek: Moment; lastDayOfMonthWeek: Moment } => {
   const year = date.year();
   const month = date.month();
-  const firstDayOfMonthWeek = moment([year, month]).startOf("month").startOf("week");
+  const firstDayOfMonthWeek = moment([year, month])
+    .startOf("month")
+    .startOf("week");
   const lastDayOfMonthWeek = moment([year, month]).endOf("month").endOf("week");
   return { firstDayOfMonthWeek, lastDayOfMonthWeek };
 };
@@ -132,4 +134,19 @@ const selectThreeMonthsDailyAverage = createSelector(
   }
 );
 
-export { selectThreeMonthsDailyAverage };
+const selectMovingCalendarMinMax = createSelector(
+  selectMovingCalendarData,
+  (calendarData) => {
+    if (!calendarData || calendarData.length === 0) {
+      return { min: null, max: null };
+    }
+
+    const values = calendarData.map((entry) => entry.value);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+
+    return { min, max };
+  }
+);
+
+export { selectThreeMonthsDailyAverage, selectMovingCalendarMinMax };


### PR DESCRIPTION
### Changes:

Integrating calendar data:

- modified the `UniformDistributionButton` to consider not just the `mobileStream` and `fixedStream` data but also the daily average values from the calendar data (`movingCalendarStream`).  `mobileStream` and `fixedStream` are used on session details. Calendar data is only used on calendar page.
- added a selector, `selectMovingCalendarMinMax`, to calculate the minimum and maximum values from the calendar data

Button not functioning on mobile calendar view:
- it turned out the session Id we are using for threshold distribution is not being passed to URL, added code to ensure that `sessionId` is correctly captured and passed
