### PR TITLE
fix: clear sessions only when user turns on realtimeMapUpdates

### DIFF
--- a/app/javascript/react/components/RealtimeMapUpdatesButton/RealtimeMapUpdatesButton.tsx
+++ b/app/javascript/react/components/RealtimeMapUpdatesButton/RealtimeMapUpdatesButton.tsx
@@ -21,8 +21,8 @@ const RealtimeMapUpdatesButton = () => {
   );
 
   useEffect(() => {
-    dispatch(clearMobileSessions());
-  }, [realtimeMapUpdates]);
+    realtimeMapUpdates && dispatch(clearMobileSessions());
+  }, [realtimeMapUpdates, dispatch]);
 
   const handleRealtimeMapUpdatesChange = (isChecked: boolean) => {
     dispatch(setRealtimeMapUpdates(isChecked));


### PR DESCRIPTION
We were clearing session list when update map button was unchecked, and this action does not trigger a refetch, so I added a guard against this case

https://github.com/user-attachments/assets/7af5eff3-15f3-4c7e-a802-967ee41de5d7

