### PR TITLE
Fix: session lists styling

### DIFF
--- a/app/javascript/react/components/SessionsListView/MobileSessionList/MobileSessionList.style.tsx
+++ b/app/javascript/react/components/SessionsListView/MobileSessionList/MobileSessionList.style.tsx
@@ -52,6 +52,7 @@ const VerticalContainer = styled.div`
   width: 100%;
   margin-top: 1.25rem;
   max-height: 100%;
+  padding-bottom: 2rem;
 `;
 
 const SessionListStyled = styled.div`
@@ -59,6 +60,9 @@ const SessionListStyled = styled.div`
   overflow-y: auto;
   margin-left: 1.25rem;
   margin-right: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 `;
 
 export {

--- a/app/javascript/react/components/SessionsListView/SessionsListView.style.tsx
+++ b/app/javascript/react/components/SessionsListView/SessionsListView.style.tsx
@@ -41,7 +41,8 @@ const SessionListContainer = styled.div`
   overflow-y: auto;
   overflow-x: hidden;
   width: calc(100% + 1rem);
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
   padding-bottom: 1rem;
 


### PR DESCRIPTION
Tiny fixes, for session list tiles being distributed weirdly, and mobile session list tiles being clustered. I also added the session list padding for mobile, because the last child of session tiles was cut off on mobile devices.