### PR TITLE
[Calendar] add calendar data card dynamic color styles

### DIFF
--- a/app/javascript/react/assets/styles/colors.ts
+++ b/app/javascript/react/assets/styles/colors.ts
@@ -21,6 +21,9 @@ const red = "#E95F5F";
 const orange = "#FCA443";
 const yellow = "#FFD960";
 const green = "#96D788";
+const lightCrimson = '#ED6B86'
+const rose = '#FF38B5'
+const royalPurple = "#7D3EBE";
 const grey = "#a0a2ad";
 const black = "#000";
 const mapLabels = "#acacac";
@@ -38,6 +41,7 @@ export {
   acBlueTransparent,
   black,
   blue,
+  lightCrimson,
   cta,
   darkBlue,
   darkBlueTransparent,
@@ -63,7 +67,9 @@ export {
   mint,
   mobileStreamPath,
   orange,
+  royalPurple,
   red,
+  rose,
   theme,
   white,
   yellow,

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.style.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.style.tsx
@@ -1,7 +1,5 @@
 import styled from "styled-components";
 import {
-  blue,
-  green,
   gray100,
   gray300,
 } from "../../../../../assets/styles/colors";
@@ -10,21 +8,18 @@ import { media } from "../../../../../utils/media";
 
 interface ContainerProps {
   $isActive?: boolean;
+  $color?: string;
 }
 
 const Container = styled.div<ContainerProps>`
   background: ${(props) =>
     props.$isActive
-      ? `linear-gradient(
-      241deg,
-      ${hexToRGBA(blue, 0.4)} -2.4%,
-      ${hexToRGBA(blue, 0.0)} 94.94%
-    ), ${green}`
+      ? props.$color 
       : `linear-gradient(
-        241deg,
-        ${hexToRGBA(gray100, 0.4)} -2.4%,
-        ${hexToRGBA(gray100, 0.0)} 94.94%
-      ), ${gray300}`};
+          241deg,
+          ${hexToRGBA(gray100, 0.4)} -2.4%,
+          ${hexToRGBA(gray100, 0.0)} 94.94%
+        ), ${gray300}`};
   display: flex;
   flex-direction: column;
   align-self: stretch;
@@ -61,6 +56,7 @@ const TextContainer = styled.div`
 
   @media ${media.desktop} {
     text-align: right;
+    padding-top: 0;
   }
 `;
 

--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/atoms/ValueLabel/ValueLabel.tsx
@@ -2,7 +2,10 @@ import { useTranslation } from "react-i18next";
 import React from "react";
 
 import BroadCastLogo from "../../../../../assets/icons/broadCastLogo.svg";
+import { getColorForCalendarDataCard, getColorForValue } from "../../../../../utils/thresholdColors";
 import * as S from "./ValueLabel.style";
+import { useAppSelector } from "../../../../../store/hooks";
+import { selectThresholds } from "../../../../../store/thresholdSlice";
 
 interface StationValues {
   unitSymbol: string;
@@ -14,8 +17,13 @@ interface StationValues {
 const ValueLabel = ({ date, value, unitSymbol, isActive }: StationValues) => {
   const { t } = useTranslation();
 
+  const thresholds = useAppSelector(selectThresholds);
+
+  const averageValueColor = getColorForValue(thresholds, value ?? -1000);
+  const dataCardColor = getColorForCalendarDataCard(averageValueColor);
+
   return (
-    <S.Container $isActive={isActive}>
+    <S.Container $isActive={isActive} $color={dataCardColor}>
       <S.ImageContainer
         src={BroadCastLogo}
         alt={t("stationValue.altLogo")}

--- a/app/javascript/react/utils/thresholdColors.ts
+++ b/app/javascript/react/utils/thresholdColors.ts
@@ -1,5 +1,6 @@
 import * as colors from "../assets/styles/colors";
 import { Thresholds } from "../types/thresholds";
+import hexToRGBA from "./hexToRGB";
 
 const COLORS_FOR_RANGES = (thresholdValues: Thresholds) => [
   { max: thresholdValues.min - 1, color: colors.grey }, // grey color for values below min
@@ -27,4 +28,19 @@ const getColorForValue = (
   return defaultColor;
 };
 
-export { getColorForValue };
+const getColorForCalendarDataCard = (color: string) => {
+  switch (color) {
+    case colors.green:
+      return `linear-gradient(241deg, ${hexToRGBA(colors.blue, 0.48)} -2.4%, ${hexToRGBA(colors.blue, 0.15)} 94.94%), ${colors.green}`;
+    case colors.red:
+      return `linear-gradient(241deg, ${hexToRGBA(colors.royalPurple, 0.4)} -38.43%, ${hexToRGBA(colors.royalPurple, 0)} 94.94%), ${colors.red}`;
+    case colors.orange:
+      return `linear-gradient(241deg, ${hexToRGBA(colors.lightCrimson, 0.4)} -2.4%, ${hexToRGBA(colors.lightCrimson, 0)} 94.94%), ${colors.orange}`;
+    case colors.yellow:
+      return `linear-gradient(241deg, ${hexToRGBA(colors.rose, 0.2)} -43.4%, ${hexToRGBA(colors.white, 0)} 34.94%), ${colors.yellow}`;
+    default:
+      return `linear-gradient(241deg, ${hexToRGBA(colors.gray100, 0.4)} -2.4%, ${hexToRGBA(colors.gray100, 0)} 94.94%), ${colors.gray300}`;
+  }
+};
+
+export { getColorForValue,getColorForCalendarDataCard };


### PR DESCRIPTION
**Changes**
- Adjust the calendar card colors as per requirements -> they should change the color based on thresholds and avg value we receive.

**Design note:** _Based on the color theory the colors we are using for threshold are quite connected to each other, so I decided to adjust colors, shades and % of gradient we are applying in each case, while trying to retain a modern gradient look. Personally yellow is the hardest ;)_ 


Based on designs by yours truly:
https://www.figma.com/design/wxBRnvjC2Y8T1FBNaiIAyv/AC---Calendar-Data-Card?node-id=0-1&node-type=CANVAS&t=rakNIwwu4uoFwNVV-0