### PR TITLE
Fix Calendar's back to previous view on mobile issues

### DIFF
--- a/app/javascript/react/assets/icons/backArrowIconDesktop.svg
+++ b/app/javascript/react/assets/icons/backArrowIconDesktop.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="23" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.8125 8L3.1875 8M3.1875 8L7.96875 12.5M3.1875 8L7.96875 3.5" stroke="#3E4449" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -508,7 +508,6 @@ const Map = () => {
           selectedStreamId?.toString() || ""
         );
 
-        // Use replace here to avoid adding multiple history entries
         navigate(`/fixed_stream?${newSearchParams.toString()}`, {
           replace: true,
         });

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -258,6 +258,8 @@ const Map = () => {
     dispatch(fetchSensors(sessionType));
   }, [sessionType]);
 
+  
+
   useEffect(() => {
     const isFirstLoad = isFirstRender.current;
     if (isFirstLoad && fetchedSessions > 0 && !fixedSessionTypeSelected) {

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -258,8 +258,6 @@ const Map = () => {
     dispatch(fetchSensors(sessionType));
   }, [sessionType]);
 
-  
-
   useEffect(() => {
     const isFirstLoad = isFirstRender.current;
     if (isFirstLoad && fetchedSessions > 0 && !fixedSessionTypeSelected) {
@@ -509,7 +507,11 @@ const Map = () => {
           UrlParamsTypes.streamId,
           selectedStreamId?.toString() || ""
         );
-        navigate(`/fixed_stream?${newSearchParams.toString()}`);
+
+        // Use replace here to avoid adding multiple history entries
+        navigate(`/fixed_stream?${newSearchParams.toString()}`, {
+          replace: true,
+        });
         return;
       }
     }
@@ -558,7 +560,9 @@ const Map = () => {
 
   const setPreviousZoomInTheURL = () => {
     const desktopCondition: boolean =
-      !isMobile && currentUserSettings !== UserSettings.ModalView;
+      !isMobile &&
+      currentUserSettings !== UserSettings.ModalView &&
+      previousUserSettings !== UserSettings.CalendarView;
     const mobileCondition: boolean =
       isMobile && currentUserSettings === UserSettings.MapView;
     const mobileConditionForSessionList: boolean =
@@ -695,7 +699,9 @@ const Map = () => {
 
       {currentUserSettings === UserSettings.ModalView && (
         <SessionDetailsModal
-          onClose={() => revertUserSettingsAndResetIds()}
+          onClose={() => {
+            revertUserSettingsAndResetIds();
+          }}
           sessionType={sessionType}
           streamId={streamId}
         />

--- a/app/javascript/react/components/Map/Markers/FixedMarkers.tsx
+++ b/app/javascript/react/components/Map/Markers/FixedMarkers.tsx
@@ -222,17 +222,36 @@ const FixedMarkers = ({
     };
   }, []);
 
-  useEffect(() => {
-    if (selectedStreamId) {
-      const s = sessions.find(
-        (session) => session?.point?.streamId === selectedStreamId?.toString()
-      );
-      if (s?.point) {
-        centerMapOnMarker(s.point, s.point.streamId);
-      }
-    }
-  }, [sessions]);
+  const currentCenter = map?.getCenter();
 
+useEffect(() => {
+  if (clusterer.current) {
+    clusterer.current.clearMarkers();
+    dispatch(fetchClusterData(sessions.map(session => session.point.streamId)));
+  }
+}, [map, sessions]);
+
+useEffect(() => {
+  if (selectedStreamId) {
+    const s = sessions.find(
+      (session) => session?.point?.streamId === selectedStreamId?.toString()
+    );
+    if (s?.point) {    
+      const urlCenter = currentCenter; 
+
+      if (
+        currentCenter &&
+        urlCenter &&
+        currentCenter.lat === urlCenter.lat &&
+        currentCenter.lng === urlCenter.lng
+      ) {
+        return;
+      }
+
+      centerMapOnMarker(s.point, s.point.streamId);
+    }
+  }
+}, [sessions, selectedStreamId, map, currentCenter]);
   useEffect(() => {
     updateClusterer();
   }, [updateClusterer]);

--- a/app/javascript/react/components/Navbar/BackButton.tsx
+++ b/app/javascript/react/components/Navbar/BackButton.tsx
@@ -10,7 +10,7 @@ import { UserSettings } from "../../types/userStates";
 import backArrowIcon from "../../assets/icons/backArrowIcon.svg";
 import backArrowIconDesktop from "../../assets/icons/backArrowIconDesktop.svg";
 
-const BackToMapButton = () => {
+const BackButton = () => {
   const { t } = useTranslation();
 
   const {
@@ -64,4 +64,4 @@ const BackToMapButton = () => {
   );
 };
 
-export { BackToMapButton };
+export { BackButton };

--- a/app/javascript/react/components/Navbar/BackButton.tsx
+++ b/app/javascript/react/components/Navbar/BackButton.tsx
@@ -1,41 +1,23 @@
 import React, { useCallback } from "react";
 import * as S from "./Navbar.style";
 import { useTranslation } from "react-i18next";
-import { UrlParamsTypes, useMapParams } from "../../utils/mapParamsHandler";
-import { useNavigate } from "react-router-dom";
-import useMobileDetection from "../../utils/useScreenSizeDetection";
 
-import { urls } from "../../const/urls";
+import { useMapParams } from "../../utils/mapParamsHandler";
+import useMobileDetection from "../../utils/useScreenSizeDetection";
+import { useCalendarBackNavigation } from "../../hooks/useBackNavigation";
+
 import { UserSettings } from "../../types/userStates";
+
 import backArrowIcon from "../../assets/icons/backArrowIcon.svg";
 import backArrowIconDesktop from "../../assets/icons/backArrowIconDesktop.svg";
 
 const BackButton = () => {
   const { t } = useTranslation();
+  const handleCalendarGoBack = useCalendarBackNavigation();
 
-  const {
-    currentUserSettings,
-    previousUserSettings,
-    searchParams,
-    revertUserSettingsAndResetIds,
-  } = useMapParams();
-  const navigate = useNavigate();
+  const { previousUserSettings } = useMapParams();
+
   const isMobile = useMobileDetection();
-
-  const handleGoBackClick = useCallback(() => {
-    const newSearchParams = new URLSearchParams(searchParams.toString());
-    newSearchParams.set(
-      UrlParamsTypes.previousUserSettings,
-      currentUserSettings
-    );
-    newSearchParams.set(
-      UrlParamsTypes.currentUserSettings,
-      previousUserSettings
-    );
-    isMobile && newSearchParams.delete(UrlParamsTypes.streamId);
-    isMobile && newSearchParams.delete(UrlParamsTypes.sessionId);
-    navigate(`${urls.reactMap}?${newSearchParams.toString()}`);
-  }, [currentUserSettings, navigate, previousUserSettings, searchParams]);
 
   const icon = isMobile ? backArrowIcon : backArrowIconDesktop;
 
@@ -53,7 +35,7 @@ const BackButton = () => {
   }, [previousUserSettings, t]);
 
   return (
-    <S.GoBack onClick={handleGoBackClick} aria-label={t("navbar.mapPage")}>
+    <S.GoBack onClick={handleCalendarGoBack} aria-label={t("navbar.mapPage")}>
       <img
         src={icon}
         alt={t("navbar.altGoBackIcon")}

--- a/app/javascript/react/components/Navbar/BackToMapButton.tsx
+++ b/app/javascript/react/components/Navbar/BackToMapButton.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback } from "react";
+import * as S from "./Navbar.style";
+import { useTranslation } from "react-i18next";
+import { UrlParamsTypes, useMapParams } from "../../utils/mapParamsHandler";
+import { useNavigate } from "react-router-dom";
+import useMobileDetection from "../../utils/useScreenSizeDetection";
+
+import { urls } from "../../const/urls";
+import { UserSettings } from "../../types/userStates";
+import backArrowIcon from "../../assets/icons/backArrowIcon.svg";
+import backArrowIconDesktop from "../../assets/icons/backArrowIconDesktop.svg";
+
+const BackToMapButton = () => {
+  const { t } = useTranslation();
+
+  const {
+    currentUserSettings,
+    previousUserSettings,
+    searchParams,
+    revertUserSettingsAndResetIds,
+  } = useMapParams();
+  const navigate = useNavigate();
+  const isMobile = useMobileDetection();
+
+  const handleGoBackClick = useCallback(() => {
+    const newSearchParams = new URLSearchParams(searchParams.toString());
+    newSearchParams.set(
+      UrlParamsTypes.previousUserSettings,
+      currentUserSettings
+    );
+    newSearchParams.set(
+      UrlParamsTypes.currentUserSettings,
+      previousUserSettings
+    );
+    isMobile && newSearchParams.delete(UrlParamsTypes.streamId);
+    isMobile && newSearchParams.delete(UrlParamsTypes.sessionId);
+    navigate(`${urls.reactMap}?${newSearchParams.toString()}`);
+  }, [currentUserSettings, navigate, previousUserSettings, searchParams]);
+
+  const icon = isMobile ? backArrowIcon : backArrowIconDesktop;
+
+  const getButtonText = useCallback(() => {
+    switch (previousUserSettings) {
+      case UserSettings.SessionListView:
+        return t("navbar.goBackToSessions");
+      case UserSettings.MapView:
+        return t("navbar.goBackToMap");
+      case UserSettings.ModalView:
+        return t("navbar.goBackToSession");
+      default:
+        return t("navbar.goBackToMap");
+    }
+  }, [previousUserSettings, t]);
+
+  return (
+    <S.GoBack onClick={handleGoBackClick} aria-label={t("navbar.mapPage")}>
+      <img
+        src={icon}
+        alt={t("navbar.altGoBackIcon")}
+        aria-label={t("navbar.goBackToSessions")}
+      />
+      {getButtonText()}
+    </S.GoBack>
+  );
+};
+
+export { BackToMapButton };

--- a/app/javascript/react/components/Navbar/DesktopHeader.tsx
+++ b/app/javascript/react/components/Navbar/DesktopHeader.tsx
@@ -18,6 +18,7 @@ import { RealtimeMapUpdatesButton } from "../RealtimeMapUpdatesButton/RealtimeMa
 import { RefreshMapButton } from "../RefreshMapButton";
 import NavList from "./NavList/NavList";
 import * as S from "./Navbar.style";
+import { BackToMapButton } from "./BackToMapButton";
 
 interface DesktopHeaderProps {
   isMapPage: boolean;
@@ -87,12 +88,15 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({
           </S.Container>
         </>
       ) : (
-        <a
-          href={urls.habitatMap}
-          aria-label={t("navbar.sections.aircastingPage")}
-        >
-          <S.AircastingLogo alt={t("navbar.altLogo")} src={logo} />
-        </a>
+        <>
+          <BackToMapButton />
+          <a
+            href={urls.habitatMap}
+            aria-label={t("navbar.sections.aircastingPage")}
+          >
+            <S.AircastingLogo alt={t("navbar.altLogo")} src={logo} />
+          </a>
+        </>
       )}
       <S.Container>
         {!isExtraTinyScreen && (

--- a/app/javascript/react/components/Navbar/DesktopHeader.tsx
+++ b/app/javascript/react/components/Navbar/DesktopHeader.tsx
@@ -18,7 +18,7 @@ import { RealtimeMapUpdatesButton } from "../RealtimeMapUpdatesButton/RealtimeMa
 import { RefreshMapButton } from "../RefreshMapButton";
 import NavList from "./NavList/NavList";
 import * as S from "./Navbar.style";
-import { BackToMapButton } from "./BackToMapButton";
+import { BackButton } from "./BackButton";
 
 interface DesktopHeaderProps {
   isMapPage: boolean;
@@ -89,7 +89,7 @@ const DesktopHeader: React.FC<DesktopHeaderProps> = ({
         </>
       ) : (
         <>
-          <BackToMapButton />
+          <BackButton />
           <a
             href={urls.habitatMap}
             aria-label={t("navbar.sections.aircastingPage")}

--- a/app/javascript/react/components/Navbar/MobileHeader.tsx
+++ b/app/javascript/react/components/Navbar/MobileHeader.tsx
@@ -14,7 +14,7 @@ import { RealtimeMapUpdatesButton } from "../RealtimeMapUpdatesButton/RealtimeMa
 import { RefreshMapButton } from "../RefreshMapButton";
 import * as S from "./Navbar.style";
 import NavList from "./NavList/NavList";
-import { BackToMapButton } from "./BackToMapButton";
+import { BackButton } from "./BackButton";
 
 export const MobileHeader = ({
   isTimelapseView,
@@ -92,7 +92,7 @@ export const MobileHeader = ({
 export const MobileCalendarHeader = ({ t }: { t: Function }) => {
   return (
     <S.MobileContainer>
-      <BackToMapButton />
+      <BackButton />
     </S.MobileContainer>
   );
 };

--- a/app/javascript/react/components/Navbar/MobileHeader.tsx
+++ b/app/javascript/react/components/Navbar/MobileHeader.tsx
@@ -14,6 +14,7 @@ import { RealtimeMapUpdatesButton } from "../RealtimeMapUpdatesButton/RealtimeMa
 import { RefreshMapButton } from "../RefreshMapButton";
 import * as S from "./Navbar.style";
 import NavList from "./NavList/NavList";
+import { BackToMapButton } from "./BackToMapButton";
 
 export const MobileHeader = ({
   isTimelapseView,
@@ -89,35 +90,9 @@ export const MobileHeader = ({
 };
 
 export const MobileCalendarHeader = ({ t }: { t: Function }) => {
-  const { currentUserSettings, previousUserSettings, searchParams } =
-    useMapParams();
-  const navigate = useNavigate();
-
-  const handleGoBackClick = useCallback(() => {
-    const newSearchParams = new URLSearchParams(searchParams.toString());
-    newSearchParams.set(
-      UrlParamsTypes.previousUserSettings,
-      currentUserSettings
-    );
-    newSearchParams.set(
-      UrlParamsTypes.currentUserSettings,
-      previousUserSettings
-    );
-    navigate(`${urls.reactMap}?${newSearchParams.toString()}`);
-  }, [currentUserSettings, navigate, previousUserSettings, searchParams]);
-
   return (
     <S.MobileContainer>
-      <S.GoBack onClick={handleGoBackClick} aria-label={t("navbar.mapPage")}>
-        <img
-          src={backArrowIcon}
-          alt={t("navbar.altGoBackIcon")}
-          aria-label={t("navbar.goBackToSessions")}
-        />
-        {previousUserSettings === UserSettings.SessionListView
-          ? t("navbar.goBackToSessions")
-          : t("navbar.goBackToMap")}
-      </S.GoBack>
+      <BackToMapButton />
     </S.MobileContainer>
   );
 };

--- a/app/javascript/react/components/Navbar/Navbar.style.tsx
+++ b/app/javascript/react/components/Navbar/Navbar.style.tsx
@@ -176,6 +176,30 @@ const GoBack = styled.a`
   background-color: ${white};
   padding: 0.5rem 1rem;
   border-radius: 5px;
+  cursor: pointer;
+
+  @media ${media.smallDesktop} {
+    padding: 1.6rem;
+    text-transform: uppercase;
+    font-size: 1.4rem;
+    height: 4.8rem;
+    box-shadow: 0px 4px 4px 0px rgba(76, 86, 96, 0.1);
+    justify-content: center;
+  }
+`;
+
+const GoBackButtonContainer = styled.div`
+  top: 8rem;
+  left: 2rem;
+  position: fixed;
+`;
+
+const DesktopHeaderContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: column;
+  gap: 1.2rem;
 `;
 
 const SmallDesktopContainer = styled.div`
@@ -238,7 +262,9 @@ export {
   BuyCTAWhite,
   Container,
   DesktopContainer,
+  DesktopHeaderContainer,
   GoBack,
+  GoBackButtonContainer,
   Header,
   MapControls,
   MenuButton,

--- a/app/javascript/react/hooks/useBackNavigation.tsx
+++ b/app/javascript/react/hooks/useBackNavigation.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { UrlParamsTypes, useMapParams } from "../utils/mapParamsHandler";
+import useMobileDetection from "../utils/useScreenSizeDetection";
+import { urls } from "../const/urls";
+
+const useCalendarBackNavigation = () => {
+  const navigate = useNavigate();
+  const isMobile = useMobileDetection();
+
+  const { currentUserSettings, previousUserSettings, searchParams } =
+    useMapParams();
+
+  const handleCalendarGoBack = useCallback(() => {
+    const newSearchParams = new URLSearchParams(searchParams.toString());
+    newSearchParams.set(
+      UrlParamsTypes.previousUserSettings,
+      currentUserSettings
+    );
+    newSearchParams.set(
+      UrlParamsTypes.currentUserSettings,
+      previousUserSettings
+    );
+    if (isMobile) {
+      newSearchParams.delete(UrlParamsTypes.streamId);
+      newSearchParams.delete(UrlParamsTypes.sessionId);
+    }
+    navigate(`${urls.reactMap}?${newSearchParams.toString()}`);
+  }, [
+    currentUserSettings,
+    navigate,
+    previousUserSettings,
+    searchParams,
+    isMobile,
+  ]);
+
+  return handleCalendarGoBack;
+};
+
+export { useCalendarBackNavigation };

--- a/app/javascript/react/locales/en/translation.json
+++ b/app/javascript/react/locales/en/translation.json
@@ -16,6 +16,7 @@
     "altGoBack": "Go back icon",
     "goBackToMap": "Back to map",
     "goBackToSessions": "Back to sessions",
+    "goBackToSession": "Back to session",
     "mapPage": "Map page",
     "refreshMap": "Refresh map",
     "realtimeMapUpdates": "update when map moves",

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -1,5 +1,5 @@
 import moment from "moment";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Graph } from "../../components/Graph";
@@ -12,25 +12,28 @@ import { FixedStreamStationHeader } from "../../components/molecules/FixedStream
 import { ThresholdsConfigurator } from "../../components/ThresholdConfigurator";
 import { ResetButton } from "../../components/ThresholdConfigurator/ThresholdButtons/ResetButton";
 import { ThresholdButtonVariant } from "../../components/ThresholdConfigurator/ThresholdButtons/ThresholdButton";
-import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
+import { UniformDistributionButton } from "../../components/ThresholdConfigurator/ThresholdButtons/UniformDistributionButton";
+
 import {
   fetchFixedStreamById,
   selectFixedData,
 } from "../../store/fixedStreamSlice";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
 import {
   fetchNewMovingStream,
   movingData,
 } from "../../store/movingCalendarStreamSlice";
 import { setDefaultThresholdsValues } from "../../store/thresholdSlice";
+
 import { SessionTypes } from "../../types/filters";
-import { UrlParamsTypes, useMapParams } from "../../utils/mapParamsHandler";
+
+import { useMapParams } from "../../utils/mapParamsHandler";
 import { formatTime } from "../../utils/measurementsCalc";
 import useMobileDetection from "../../utils/useScreenSizeDetection";
+import { useCalendarBackNavigation } from "../../hooks/useBackNavigation";
+
 import * as S from "./CalendarPage.style";
-import { UniformDistributionButton } from "../../components/ThresholdConfigurator/ThresholdButtons/UniformDistributionButton";
-import { urls } from "../../const/urls";
-import { useNavigate } from "react-router-dom";
 
 interface CalendarPageProps {
   children: React.ReactNode;
@@ -40,15 +43,10 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
   const dispatch = useAppDispatch();
   const isMobile = useMobileDetection();
   const { t } = useTranslation();
-  const navigate = useNavigate();
 
-  const {
-    unitSymbol,
-    revertUserSettingsAndResetIds,
-    searchParams,
-    currentUserSettings,
-    previousUserSettings,
-  } = useMapParams();
+  const handleCalendarGoBack = useCalendarBackNavigation();
+
+  const { unitSymbol } = useMapParams();
 
   const { streamId } = useMapParams();
 
@@ -76,29 +74,13 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
     streamId && dispatch(fetchFixedStreamById(streamId));
   }, []);
 
-  const handleBackNavigation = useCallback(() => {
-    const newSearchParams = new URLSearchParams(searchParams.toString());
-    newSearchParams.set(
-      UrlParamsTypes.previousUserSettings,
-      currentUserSettings
-    );
-    newSearchParams.set(
-      UrlParamsTypes.currentUserSettings,
-      previousUserSettings
-    );
-
-    isMobile && newSearchParams.delete(UrlParamsTypes.streamId);
-    isMobile && newSearchParams.delete(UrlParamsTypes.sessionId);
-    navigate(`${urls.reactMap}?${newSearchParams.toString()}`);
-  }, [currentUserSettings, navigate, previousUserSettings, searchParams]);
-
   useEffect(() => {
-    window.addEventListener("popstate", handleBackNavigation);
+    window.addEventListener("popstate", handleCalendarGoBack);
 
     return () => {
-      window.removeEventListener("popstate", handleBackNavigation);
+      window.removeEventListener("popstate", handleCalendarGoBack);
     };
-  }, [handleBackNavigation]);
+  }, [handleCalendarGoBack]);
 
   useEffect(() => {
     const formattedEndMoment = moment(streamEndTime, "YYYY-MM-DD");

--- a/app/javascript/react/utils/mapParamsHandler.ts
+++ b/app/javascript/react/utils/mapParamsHandler.ts
@@ -293,6 +293,11 @@ export const useMapParams = () => {
   );
 
   const revertUserSettingsAndResetIds = useCallback(() => {
+    const finalPreviousUserSettings =
+      !isMobile && previousUserSettings === UserSettings.CalendarView
+        ? UserSettings.MapView
+        : previousUserSettings;
+
     setUrlParams([
       { key: UrlParamsTypes.sessionId, value: "" },
       { key: UrlParamsTypes.streamId, value: "" },
@@ -302,12 +307,11 @@ export const useMapParams = () => {
       },
       {
         key: UrlParamsTypes.currentUserSettings,
-        value: previousUserSettings,
+        value: finalPreviousUserSettings,
       },
     ]);
-  }, [searchParams]);
+  }, [searchParams, previousUserSettings, currentUserSettings, setUrlParams]);
 
-  
   const setFilters = useCallback(
     (key: UrlParamsTypes, value: string) => {
       if (isMobile) {

--- a/app/javascript/react/utils/mapParamsHandler.ts
+++ b/app/javascript/react/utils/mapParamsHandler.ts
@@ -1,6 +1,6 @@
 import { debounce } from "lodash";
 import { useCallback, useEffect, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { MAP_CONFIGS } from "../components/Map/mapConfigs";
 import { defaultGridSize } from "../components/SessionFilters/CrowdMapGridSize";
@@ -77,6 +77,8 @@ export const useMapParams = () => {
     },
     [searchParams, setSearchParams]
   );
+
+  const navigate = useNavigate();
 
   const boundEast = parseFloat(
     getSearchParam(
@@ -305,6 +307,7 @@ export const useMapParams = () => {
     ]);
   }, [searchParams]);
 
+  
   const setFilters = useCallback(
     (key: UrlParamsTypes, value: string) => {
       if (isMobile) {


### PR DESCRIPTION
### Changes
- extracted a separate back button component, so we can reuse it on desktop
- enhanced logic around going back from calendar to previous view (fixed the problem with map being centered on the session when going back from Calendar page instead of the previous map preview)
- fixed issues when going from calendar back to session details modal caused issues when closing the modal (the calendar view was invoked instead of a map view)
- added experimental browser back handling - we are listening to `popstate` event and in case it goes off, we are applying our own back logic, the same as in the button;). This is far from ideal solution, but fixing what is going on in history would take much more time, which we don't have at this moment
- extracted back hook we are using in two places to keep the logic in one place