### PR TITLE
Fix map buttons display logic and styles

### DIFF
--- a/app/javascript/react/components/Map/Map.style.tsx
+++ b/app/javascript/react/components/Map/Map.style.tsx
@@ -32,11 +32,12 @@ const MobileButtons = styled.div<{
   align-items: center;
   gap: 0.4rem;
   position: fixed;
+  right: 0.4rem;
+  left: 0;
   bottom: 0;
   padding: 1rem 0.4rem;
   direction: rtl;
   z-index: ${(props) => (props.$isTimelapseView ? 3 : 2)};
-  width: 100%;
 `;
 
 const ThresholdContainer = styled.div`

--- a/app/javascript/react/components/Map/Map.style.tsx
+++ b/app/javascript/react/components/Map/Map.style.tsx
@@ -32,7 +32,7 @@ const MobileButtons = styled.div<{
   align-items: center;
   gap: 0.4rem;
   position: fixed;
-  right: 0.4rem;
+  right: 0.3rem;
   left: 0;
   bottom: 0;
   padding: 1rem 0.4rem;

--- a/app/javascript/react/components/Map/Map.style.tsx
+++ b/app/javascript/react/components/Map/Map.style.tsx
@@ -23,25 +23,20 @@ const MobileContainer = styled.div`
   }
 `;
 
-const MobileButtons = styled.div<{ $isTimelapseView: boolean }>`
+const MobileButtons = styled.div<{
+  $isTimelapseView: boolean;
+}>`
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   justify-items: center;
   align-items: center;
-  gap: 1rem;
+  gap: 0.4rem;
   position: fixed;
-  bottom: 0.1rem;
-  right: 1.4rem;
+  bottom: 0;
+  padding: 1rem 0.4rem;
   direction: rtl;
   z-index: ${(props) => (props.$isTimelapseView ? 3 : 2)};
-
-  @media (min-width: 390px) {
-    right: 3.5rem;
-  }
-
-  @media (${media.smallDesktop}) {
-    right: 0.4rem;
-  }
+  width: 100%;
 `;
 
 const ThresholdContainer = styled.div`
@@ -54,7 +49,6 @@ const ThresholdContainer = styled.div`
   width: 100%;
   bottom: 0;
 
-  z-index: 1;
   background-color: ${colors.white};
   box-shadow: 2px 2px 4px 0px ${colors.gray900};
 
@@ -62,6 +56,7 @@ const ThresholdContainer = styled.div`
     height: 4.7rem;
     margin-bottom: 0;
     grid-template-columns: 1fr;
+    z-index: 1;
   }
 
   @media (min-width: 769px) and (max-width: 1023px) {
@@ -71,6 +66,7 @@ const ThresholdContainer = styled.div`
     margin-bottom: 0;
     align-items: center;
     grid-gap: 0.5rem;
+    z-index: 1;
   }
 
   @media (${media.desktop}) {

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -713,43 +713,45 @@ const Map = () => {
         />
       )}
       <S.MobileContainer>
-        <S.MobileButtons $isTimelapseView={isTimelapseView}>
-          <SectionButton
-            title={t("map.listSessions")}
-            image={pinImage}
-            alt={t("map.altListSessions")}
-            onClick={() => goToUserSettings(UserSettings.SessionListView)}
-            isNotTimelapseButton={isTimelapseView}
-            isActive={currentUserSettings === UserSettings.SessionListView}
-          />
-          <SectionButton
-            title={t("map.legendTile")}
-            image={mapLegend}
-            alt={t("map.altlegendTile")}
-            onClick={() => goToUserSettings(UserSettings.MapLegendView)}
-            isNotTimelapseButton={isTimelapseView}
-            isActive={currentUserSettings === UserSettings.MapLegendView}
-          />
-          {fixedSessionTypeSelected && (
+        {currentUserSettings !== UserSettings.ModalView && (
+          <S.MobileButtons $isTimelapseView={isTimelapseView}>
             <SectionButton
-              title={t("map.timelapsTile")}
-              image={clockIcon}
-              alt={t("map.altTimelapstile")}
-              onClick={openTimelapse}
-              isNotTimelapseButton={false}
-              isActive={currentUserSettings === UserSettings.TimelapseView}
-              isDisabled={isTimelapseDisabled}
+              title={t("map.listSessions")}
+              image={pinImage}
+              alt={t("map.altListSessions")}
+              onClick={() => goToUserSettings(UserSettings.SessionListView)}
+              isNotTimelapseButton={isTimelapseView}
+              isActive={currentUserSettings === UserSettings.SessionListView}
             />
-          )}
-          <SectionButton
-            title={t("filters.filters")}
-            image={filterIcon}
-            alt={t("filters.altFiltersIcon")}
-            onClick={openFilters}
-            isNotTimelapseButton={false}
-            isActive={currentUserSettings === UserSettings.FiltersView}
-          />
-        </S.MobileButtons>
+            <SectionButton
+              title={t("map.legendTile")}
+              image={mapLegend}
+              alt={t("map.altlegendTile")}
+              onClick={() => goToUserSettings(UserSettings.MapLegendView)}
+              isNotTimelapseButton={isTimelapseView}
+              isActive={currentUserSettings === UserSettings.MapLegendView}
+            />
+            {fixedSessionTypeSelected && (
+              <SectionButton
+                title={t("map.timelapsTile")}
+                image={clockIcon}
+                alt={t("map.altTimelapstile")}
+                onClick={openTimelapse}
+                isNotTimelapseButton={false}
+                isActive={currentUserSettings === UserSettings.TimelapseView}
+                isDisabled={isTimelapseDisabled}
+              />
+            )}
+            <SectionButton
+              title={t("filters.filters")}
+              image={filterIcon}
+              alt={t("filters.altFiltersIcon")}
+              onClick={openFilters}
+              isNotTimelapseButton={false}
+              isActive={currentUserSettings === UserSettings.FiltersView}
+            />
+          </S.MobileButtons>
+        )}
         {currentUserSettings === UserSettings.MapLegendView && (
           <Legend onClose={() => goToUserSettings(previousUserSettings)} />
         )}

--- a/app/javascript/react/components/SectionButton/SectionButton.style.tsx
+++ b/app/javascript/react/components/SectionButton/SectionButton.style.tsx
@@ -10,7 +10,6 @@ const StyledSectionButton = styled.button<{
   background-color: ${(props) => (props.$isActive ? blue : white)};
   border-radius: 1rem;
   box-shadow: 0 0.4rem 0.8rem rgba(0, 0, 0, 0.1);
-  margin-bottom: 0.4rem;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -33,7 +32,6 @@ const StyledSectionButton = styled.button<{
     pointer-events: none;`}
 
   @media (min-width: 390px) {
-    width: 8.5rem;
     padding: 0;
   }
 `;

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.style.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.style.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { gray100, gray400, white, red } from "../../assets/styles/colors";
+import { gray100, gray400, red, white } from "../../assets/styles/colors";
 import { NAVBAR_HEIGHT } from "../../components/Navbar/Navbar.style";
 import { H3 } from "../../components/Typography";
 import { media } from "../../utils/media";


### PR DESCRIPTION
Changes:
- instead of playing with z-indices, I decided to just not show buttons behind the session details (unnecessary element)
- I changed the map buttons styling so it will always fit the screen size on mobile devices, unfortunately our 100% goes outside device view, so I decided to manually adjust paddings, and the right side placement. I know it's not nice, but fixing the width will be harder.