### PR TITLE
Fix date formatting in Calendar

### DIFF
--- a/app/javascript/react/components/molecules/Calendar/CalendarHook.ts
+++ b/app/javascript/react/components/molecules/Calendar/CalendarHook.ts
@@ -1,17 +1,16 @@
+import moment, { Moment } from "moment";
+import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import { useState, useEffect } from "react";
-import { Moment } from "moment";
-import moment from "moment";
 
-import { MovesKeys } from "../../../types/movesKeys";
 import { useAppDispatch } from "../../../store/hooks";
-import { selectThreeMonthsDailyAverage } from "../../../store/movingStreamSelectors";
 import {
-  movingData,
   fetchNewMovingStream,
+  movingData,
 } from "../../../store/movingCalendarStreamSlice";
-import { CalendarMonthlyData } from "../../../types/movingStream";
+import { selectThreeMonthsDailyAverage } from "../../../store/movingStreamSelectors";
 import { DateFormat } from "../../../types/dateFormat";
+import { MovesKeys } from "../../../types/movesKeys";
+import { CalendarMonthlyData } from "../../../types/movingStream";
 
 interface MovableCalendarData {
   currentStartDate: string;
@@ -94,9 +93,10 @@ const useCalendarHook = ({
 
     const firstElementIdx = 0;
     const firstDataPoint = movingCalendarData.data[firstElementIdx].date;
-    const processedFirstDataPoint = moment(firstDataPoint, DateFormat.default).format(
-      DateFormat.us
-    );
+    const processedFirstDataPoint = moment(
+      firstDataPoint,
+      DateFormat.default
+    ).format(DateFormat.us);
 
     return {
       firstDate: processedFirstDataPoint,
@@ -106,7 +106,6 @@ const useCalendarHook = ({
   };
 
   useEffect(() => {
-    console.log("On appear, all data considered for calendar: ", movingCalendarData)
     const formattedDateRange = getFormattedDateRange();
     const processedMaxEndDate = formattedDateRange.lastDate;
     const processedFirstDataPoint = formattedDateRange.firstDate;
@@ -120,7 +119,6 @@ const useCalendarHook = ({
       .subtract(SEEN_MONTHS_NUMBER - 1, "months")
       .format(DateFormat.us);
 
-    console.log("On appear, first and last point of viewed calendar identified: ", processedFirstDataPoint, processedMaxEndDate)
     setDateReference((prevState) => ({
       ...prevState,
       currentStartDate: newStartDate,
@@ -155,10 +153,9 @@ const useCalendarHook = ({
       .format(DateFormat.us);
 
     const newStartDateMoment = moment(newStartDate, DateFormat.us).date(1);
-    const minCalendarMoment = moment(minCalendarDate, DateFormat.default).date(1);
-
-    console.log("Identify new min moment...", minCalendarMoment)
-    console.log("Proposed new start date", newStartDateMoment)
+    const minCalendarMoment = moment(minCalendarDate, DateFormat.default).date(
+      1
+    );
 
     if (newStartDateMoment.isBefore(minCalendarMoment)) {
       setIsLeftButtonDisabled(true);

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -14,12 +14,12 @@ import { ResetButton } from "../../components/ThresholdConfigurator/ThresholdBut
 import { ThresholdButtonVariant } from "../../components/ThresholdConfigurator/ThresholdButtons/ThresholdButton";
 import { UniformDistributionButton } from "../../components/ThresholdConfigurator/ThresholdButtons/UniformDistributionButton";
 
+import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
 import {
   fetchFixedStreamById,
   selectFixedData,
 } from "../../store/fixedStreamSlice";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
-import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
 import {
   fetchNewMovingStream,
   movingData,
@@ -28,10 +28,10 @@ import { setDefaultThresholdsValues } from "../../store/thresholdSlice";
 
 import { SessionTypes } from "../../types/filters";
 
+import { useCalendarBackNavigation } from "../../hooks/useBackNavigation";
 import { useMapParams } from "../../utils/mapParamsHandler";
 import { formatTime } from "../../utils/measurementsCalc";
 import useMobileDetection from "../../utils/useScreenSizeDetection";
-import { useCalendarBackNavigation } from "../../hooks/useBackNavigation";
 
 import * as S from "./CalendarPage.style";
 
@@ -89,12 +89,6 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
       .date(1)
       .subtract(2, "months")
       .format("YYYY-MM-DD");
-
-    console.log(
-      "Downloading first time - moving stream data. Start - End: ",
-      newStartDate,
-      formattedEndDate
-    );
     if (streamId) {
       dispatch(
         fetchNewMovingStream({

--- a/app/javascript/react/store/fixedStreamSelectors.ts
+++ b/app/javascript/react/store/fixedStreamSelectors.ts
@@ -55,16 +55,18 @@ const selectFixedStreamShortInfo = createSelector(
   (fixedStreamData, lastDailyAverage): FixedStreamShortInfo => {
     const { value: lastMeasurementValue, date } = lastDailyAverage || {};
 
-    const lastMeasurementDateLabel = moment.utc(date).format("MMM D");
+    const lastMeasurementDateLabel = moment(date).format("MMM D");
+
     const lastUpdate = moment
       .utc(fixedStreamData.stream.lastUpdate)
+      .local()
       .format("HH:mm MMM D YYYY");
 
-    const startTime = moment
-      .utc(fixedStreamData.stream.startTime)
+    const startTime = moment(fixedStreamData.stream.startTime)
+      .local()
       .format(DateFormat.us_with_time);
-    const endTime = moment
-      .utc(fixedStreamData.stream.endTime)
+    const endTime = moment(fixedStreamData.stream.endTime)
+      .local()
       .format(DateFormat.us_with_time);
 
     const active = fixedStreamData.stream.active;
@@ -72,9 +74,7 @@ const selectFixedStreamShortInfo = createSelector(
 
     const sortedStreamDailyAverages = [
       ...fixedStreamData.streamDailyAverages,
-    ].sort(
-      (a, b) => moment.utc(b.date).valueOf() - moment.utc(a.date).valueOf()
-    );
+    ].sort((a, b) => moment(b.date).valueOf() - moment(a.date).valueOf());
 
     const newestAverageObject = sortedStreamDailyAverages[0];
     const newestAverageValue = newestAverageObject
@@ -83,13 +83,11 @@ const selectFixedStreamShortInfo = createSelector(
 
     const newestDate =
       fixedStreamData.measurements.length > 0
-        ? moment.utc(
-            Math.max(...fixedStreamData.measurements.map((m) => m.time))
-          )
-        : moment.utc();
+        ? moment(Math.max(...fixedStreamData.measurements.map((m) => m.time)))
+        : moment();
 
     const newestDayMeasurements = fixedStreamData.measurements.filter((m) =>
-      moment.utc(m.time).isSame(newestDate, "day")
+      moment(m.time).isSame(newestDate, "day")
     );
 
     const maxMeasurementValue = Math.max(

--- a/app/javascript/react/store/movingStreamSelectors.ts
+++ b/app/javascript/react/store/movingStreamSelectors.ts
@@ -1,14 +1,14 @@
 import { createSelector } from "@reduxjs/toolkit";
 import moment, { Moment } from "moment";
 
-import { lastItemFromArray } from "../utils/lastArrayItem";
+import { RootState } from ".";
 import {
   CalendarCellData,
   CalendarMonthlyData,
   StreamDailyAverage,
 } from "../types/movingStream";
 import { StreamDailyAverage as MovingStreamDailyAverage } from "../types/StreamDailyAverage";
-import { RootState } from ".";
+import { lastItemFromArray } from "../utils/lastArrayItem";
 
 const WEEKDAYS_COUNT = 7;
 
@@ -149,4 +149,4 @@ const selectMovingCalendarMinMax = createSelector(
   }
 );
 
-export { selectThreeMonthsDailyAverage, selectMovingCalendarMinMax };
+export { selectMovingCalendarMinMax, selectThreeMonthsDailyAverage };


### PR DESCRIPTION
There are two types of dates in Calendar short info:

- "2024-06-04"
-  "2024-09-02T13:00:00.000Z"

They needed different formatting to display the local time.

[Trello task](https://trello.com/c/3vMi2pz4/1952-fixed-calendar-daily-average-is-not-upating)