### PR TITLE
Improve fixed markers and clusters performance

### DIFF
--- a/app/javascript/react/components/Map/Markers/ClusterConfiguration.tsx
+++ b/app/javascript/react/components/Map/Markers/ClusterConfiguration.tsx
@@ -60,7 +60,28 @@ const calculateClusterStyleIndex = (
   return styleIndex;
 };
 
-export const customRenderer = (thresholds: Thresholds) => ({
+export const updateClusterStyle = (
+  clusterElement: google.maps.marker.AdvancedMarkerElement,
+  markers: google.maps.marker.AdvancedMarkerElement[],
+  thresholds: Thresholds
+) => {
+  const styleIndex = calculateClusterStyleIndex(markers, thresholds);
+
+  const { url, height, width, textSize } = clusterStyles[styleIndex];
+  const div = clusterElement.content as HTMLDivElement;
+
+  div.style.backgroundImage = `url(${url})`;
+  div.style.width = `${width}px`;
+  div.style.height = `${height}px`;
+  div.style.fontSize = `${textSize}px`;
+};
+
+export const customRenderer = (
+  thresholds: Thresholds,
+  clusterElementsRef: React.MutableRefObject<
+    Map<Cluster, google.maps.marker.AdvancedMarkerElement>
+  >
+) => ({
   render: (cluster: Cluster) => {
     const { markers, count, position } = cluster;
 
@@ -84,11 +105,15 @@ export const customRenderer = (thresholds: Thresholds) => ({
     span.textContent = `${count}`;
     div.appendChild(span);
 
-    return new google.maps.marker.AdvancedMarkerElement({
+    const clusterElement = new google.maps.marker.AdvancedMarkerElement({
       position,
       content: div,
       title: `${count}`,
-    }) as Marker;
+    });
+
+    clusterElementsRef.current.set(cluster, clusterElement);
+
+    return clusterElement;
   },
 });
 

--- a/app/javascript/react/components/Map/Markers/FixedMarkers.tsx
+++ b/app/javascript/react/components/Map/Markers/FixedMarkers.tsx
@@ -358,7 +358,7 @@ const FixedMarkers = ({
       if (!clusterer.current) {
         clusterer.current = new MarkerClusterer({
           map,
-          renderer: customRenderer(thresholds, clusterElementsRef), // Ensure thresholds are passed only once here
+          renderer: customRenderer(thresholds, clusterElementsRef),
           algorithm: new SuperClusterAlgorithm({
             maxZoom: 21,
             radius: 40,


### PR DESCRIPTION
The threshold update now only affects the visual appearance of clusters, avoiding a full re-render of markers and clusters, which optimizes performance, especially in large datasets.

## Changes:

### Threshold Update Handling:

**Before**: When thresholds were updated, all markers and clusters were reloaded, causing unnecessary performance overhead and loading took sometimes up to 25 seconds.
**After**: A new function `updateClusterStyle` was added, which dynamically updates the styles (colors) of clusters and markers without reloading them. This function is called whenever thresholds change, ensuring that only the color and visual properties are updated based on the new thresholds.

### Cluster Rendering:

**Before**: The `customRenderer` directly created new cluster elements every time thresholds changed.
**After**: The `customRenderer` now references existing clusters and updates their styles using the `updateClusterStyle` function. Additionally, the `customRenderer` now stores a reference to each cluster element (clusterElementsRef), so these elements can be updated without recreating them.