### PR TITLE
add redirect from old maps to the new one with transition page

### DIFF
--- a/app/javascript/react/App.tsx
+++ b/app/javascript/react/App.tsx
@@ -17,8 +17,7 @@ import { NotFoundPage } from "./pages/NotFoundPage";
 import { RedirectPage } from "./pages/RedirectPage";
 import store from "./store/index";
 
-const MOBILE_MAP_PATH = "/mobile_map";
-const FIXED_MAP_PATH = "/fixed_map";
+const NEW_MAP = "/new_map";
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -48,7 +47,7 @@ const router = createBrowserRouter(
         }
       />
       <Route
-        path={MOBILE_MAP_PATH || FIXED_MAP_PATH}
+        path={NEW_MAP}
         element={
           <RedirectPage>
             <Navbar isMapPage={false} />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,9 +19,9 @@ Rails.application.routes.draw do
                passwords: 'passwords',
              }
 
-  get 'map', to: redirect('mobile_map', status: 302)
-  get 'mobile_map' => 'maps#index'
-  get 'fixed_map' => 'maps#index'
+  get 'map', to: redirect('/', status: 302)
+  get 'mobile_map', to: redirect('/new_map', status: 302)
+  get 'fixed_map', to: redirect('/new_map', status: 302)
 
   get 's/:url_token' => 'measurement_sessions#show',
       :constraints => {


### PR DESCRIPTION
This is a temporary change while we are in the transition period, to redirect people from old maps to the `/new_map` - once we don't want it anymore, we can get rid of these redirects.