### PR TITLE
Save bounds in url on map load

### DIFF
--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -440,6 +440,10 @@ const Map = () => {
       newSearchParams.set(UrlParamsTypes.streamId, "");
       newSearchParams.set(UrlParamsTypes.isActive, isActive.toString());
       newSearchParams.set(UrlParamsTypes.sessionType, sessionType);
+      newSearchParams.set(UrlParamsTypes.boundEast, boundEast.toString());
+      newSearchParams.set(UrlParamsTypes.boundNorth, boundNorth.toString());
+      newSearchParams.set(UrlParamsTypes.boundSouth, boundSouth.toString());
+      newSearchParams.set(UrlParamsTypes.boundWest, boundWest.toString());
 
       navigate(`?${newSearchParams.toString()}`);
     }


### PR DESCRIPTION
To fix this issue:
timelapse > copy link > open new browser window and navigate to staging > pan & zoom map > paste copied link: link doesn't preserve map view and timelapse selection

We need to have map bounds in url on map load.