### PR TITLE
Improve logic for threshold alert emails

### DIFF
--- a/app/workers/threshold_alerts_worker.rb
+++ b/app/workers/threshold_alerts_worker.rb
@@ -6,10 +6,11 @@ class ThresholdAlertsWorker
   def perform
     return unless A9n.sidekiq_threshold_exceeded_alerts_enabled
 
-    alerts = ThresholdAlert.all
+    current_time = Time.current
+    alerts = ThresholdAlert.joins(:user).all
 
     alerts.each do |alert|
-      next if was_recently_sent?(alert)
+      next if was_recently_sent?(alert, current_time)
 
       session = Session.joins(:streams).find_by_uuid(alert.session_uuid)
       next unless session
@@ -20,40 +21,43 @@ class ThresholdAlertsWorker
           .select { |stream| stream.sensor_name == alert.sensor_name }
           .first
 
-      date_to_compare = alert.last_email_at || alert.created_at
+      threshold_exceeded = measurements_above_threshold?(stream.id, alert)
 
-      if measurements_above_threshold?(
-           stream.id,
-           date_to_compare,
-           alert.threshold_value,
-         )
-        UserMailer
-          .with(
-            user: session.user,
-            title: session.title,
-            sensor: stream.sensor_name,
-          )
-          .threshold_exceeded_email
-          .deliver_later
+      ActiveRecord::Base.transaction do
+        alert.update!(last_check_at: current_time)
 
-        alert.update(last_email_at: Time.current)
+        alert.update!(last_email_at: current_time) if threshold_exceeded
+      end
+
+      if threshold_exceeded
+        send_email(alert.user, session.title, stream.sensor_name)
       end
     end
   end
 
   private
 
-  def was_recently_sent?(alert)
+  def was_recently_sent?(alert, current_time)
     return false unless alert.last_email_at
 
-    (alert.last_email_at + alert.frequency.hours) > Time.current
+    (alert.last_email_at + alert.frequency.hours) > current_time
   end
 
-  def measurements_above_threshold?(stream_id, time_to_compare, threshold_value)
+  def measurements_above_threshold?(stream_id, alert)
+    time_to_compare =
+      alert.last_email_at || alert.last_check_at || alert.created_at
+
     Measurement
       .where(stream_id: stream_id)
-      .where('time_with_time_zone > ?', time_to_compare)
-      .where('value > ?', threshold_value)
+      .where('time_with_time_zone >= ?', time_to_compare)
+      .where('value > ?', alert.threshold_value)
       .exists?
+  end
+
+  def send_email(user, title, sensor)
+    UserMailer
+      .with(user: user, title: title, sensor: sensor)
+      .threshold_exceeded_email
+      .deliver_later
   end
 end

--- a/db/migrate/20241115102748_add_last_check_at_to_threshold_alerts.rb
+++ b/db/migrate/20241115102748_add_last_check_at_to_threshold_alerts.rb
@@ -1,0 +1,5 @@
+class AddLastCheckAtToThresholdAlerts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :threshold_alerts, :last_check_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_20_182602) do
+ActiveRecord::Schema.define(version: 2024_11_15_102748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -196,6 +196,7 @@ ActiveRecord::Schema.define(version: 2024_05_20_182602) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "timezone_offset", default: 0
+    t.datetime "last_check_at"
     t.index ["session_uuid", "sensor_name"], name: "index_threshold_alerts_on_session_uuid_and_sensor_name"
   end
 

--- a/spec/workers/threshold_alerts_worker_spec.rb
+++ b/spec/workers/threshold_alerts_worker_spec.rb
@@ -30,6 +30,7 @@ describe ThresholdAlertsWorker do
         create_measurement!(
           stream: stream,
           time: Time.current + timezone_offset,
+          time_with_time_zone: Time.current - 20.minutes,
           value: 20,
         )
       end
@@ -58,6 +59,7 @@ describe ThresholdAlertsWorker do
         create_measurement!(
           stream: stream,
           time: Time.current + timezone_offset,
+          time_with_time_zone: Time.current - 20.minutes,
           value: 20,
         )
       end
@@ -68,6 +70,34 @@ describe ThresholdAlertsWorker do
           :threshold_exceeded_email,
         )
       end
+    end
+  end
+  context 'when measurements do not exceed threshold value' do
+    let!(:alert) do
+      ThresholdAlert.create(
+        user: user,
+        session_uuid: session.uuid,
+        sensor_name: stream.sensor_name,
+        threshold_value: 30,
+        frequency: 1,
+        last_email_at: Time.current - 70.minutes,
+        timezone_offset: timezone_offset,
+      )
+    end
+    let!(:measurement) do
+      create_measurement!(
+        stream: stream,
+        time: Time.current + timezone_offset,
+        time_with_time_zone: Time.current - 20.minutes,
+        value: 20,
+      )
+    end
+
+    it 'does not send alert email' do
+      expect { subject.perform }.not_to have_enqueued_mail(
+        UserMailer,
+        :threshold_exceeded_email,
+      )
     end
   end
 end

--- a/spec/workers/threshold_alerts_worker_spec.rb
+++ b/spec/workers/threshold_alerts_worker_spec.rb
@@ -7,6 +7,9 @@ describe ThresholdAlertsWorker do
   let(:session) { create_session!(user: user, title: 'Session Title') }
   let(:stream) { create_stream!(session: session, sensor_name: 'PM2.5') }
   let(:timezone_offset) { -18_000 }
+  let(:current_time) { Time.current }
+
+  before { allow(Time).to receive(:current).and_return(current_time) }
 
   before do
     allow(A9n).to receive(:sidekiq_threshold_exceeded_alerts_enabled)
@@ -22,15 +25,16 @@ describe ThresholdAlertsWorker do
           sensor_name: stream.sensor_name,
           threshold_value: 10,
           frequency: 1,
-          last_email_at: Time.current - 70.minutes,
+          last_email_at: current_time - 70.minutes,
+          last_check_at: current_time - 10.minutes,
           timezone_offset: timezone_offset,
         )
       end
       let!(:measurement) do
         create_measurement!(
           stream: stream,
-          time: Time.current + timezone_offset,
-          time_with_time_zone: Time.current - 20.minutes,
+          time: current_time + timezone_offset,
+          time_with_time_zone: current_time - 20.minutes,
           value: 20,
         )
       end
@@ -40,6 +44,66 @@ describe ThresholdAlertsWorker do
           UserMailer,
           :threshold_exceeded_email,
         )
+      end
+
+      context 'when measurement is exactly at the comparison time' do
+        let!(:alert) do
+          ThresholdAlert.create(
+            user: user,
+            session_uuid: session.uuid,
+            sensor_name: stream.sensor_name,
+            threshold_value: 10,
+            frequency: 1,
+            last_email_at: current_time - 70.minutes,
+            last_check_at: current_time - 10.minutes,
+            timezone_offset: timezone_offset,
+          )
+        end
+        let!(:measurement) do
+          create_measurement!(
+            stream: stream,
+            time: current_time + timezone_offset,
+            time_with_time_zone: alert.last_check_at,
+            value: 20,
+          )
+        end
+
+        it 'sends alert email' do
+          expect { subject.perform }.to have_enqueued_mail(
+            UserMailer,
+            :threshold_exceeded_email,
+          )
+        end
+      end
+
+      context 'when measurement is exactly at threshold value' do
+        let!(:alert) do
+          ThresholdAlert.create(
+            user: user,
+            session_uuid: session.uuid,
+            sensor_name: stream.sensor_name,
+            threshold_value: 10,
+            frequency: 1,
+            last_email_at: current_time - 70.minutes,
+            last_check_at: current_time - 10.minutes,
+            timezone_offset: timezone_offset,
+          )
+        end
+        let!(:measurement) do
+          create_measurement!(
+            stream: stream,
+            time: current_time + timezone_offset,
+            time_with_time_zone: current_time - 20.minutes,
+            value: 10,
+          )
+        end
+
+        it 'does not send alert email' do
+          expect { subject.perform }.not_to have_enqueued_mail(
+            UserMailer,
+            :threshold_exceeded_email,
+          )
+        end
       end
     end
 
@@ -51,15 +115,16 @@ describe ThresholdAlertsWorker do
           sensor_name: stream.sensor_name,
           threshold_value: 10,
           frequency: 1,
-          last_email_at: Time.current - 10.minutes,
+          last_email_at: current_time - 10.minutes,
+          last_check_at: current_time - 5.minutes,
           timezone_offset: timezone_offset,
         )
       end
       let!(:measurement) do
         create_measurement!(
           stream: stream,
-          time: Time.current + timezone_offset,
-          time_with_time_zone: Time.current - 20.minutes,
+          time: current_time + timezone_offset,
+          time_with_time_zone: current_time - 20.minutes,
           value: 20,
         )
       end
@@ -71,7 +136,38 @@ describe ThresholdAlertsWorker do
         )
       end
     end
+
+    context 'when time passed since last email is exactly at frequency' do
+      let!(:alert) do
+        ThresholdAlert.create(
+          user: user,
+          session_uuid: session.uuid,
+          sensor_name: stream.sensor_name,
+          threshold_value: 10,
+          frequency: 1,
+          last_email_at: current_time - 60.minutes,
+          last_check_at: current_time - 10.minutes,
+          timezone_offset: timezone_offset,
+        )
+      end
+      let!(:measurement) do
+        create_measurement!(
+          stream: stream,
+          time: current_time + timezone_offset,
+          time_with_time_zone: current_time - 20.minutes,
+          value: 20,
+        )
+      end
+
+      it 'sends alert email' do
+        expect { subject.perform }.to have_enqueued_mail(
+          UserMailer,
+          :threshold_exceeded_email,
+        )
+      end
+    end
   end
+
   context 'when measurements do not exceed threshold value' do
     let!(:alert) do
       ThresholdAlert.create(
@@ -80,15 +176,16 @@ describe ThresholdAlertsWorker do
         sensor_name: stream.sensor_name,
         threshold_value: 30,
         frequency: 1,
-        last_email_at: Time.current - 70.minutes,
+        last_email_at: current_time - 70.minutes,
+        last_check_at: current_time - 10.minutes,
         timezone_offset: timezone_offset,
       )
     end
     let!(:measurement) do
       create_measurement!(
         stream: stream,
-        time: Time.current + timezone_offset,
-        time_with_time_zone: Time.current - 20.minutes,
+        time: current_time + timezone_offset,
+        time_with_time_zone: current_time - 20.minutes,
         value: 20,
       )
     end


### PR DESCRIPTION
Improving logic behind sending threshold alert emails:
- use measurements time_with_time_zone for deciding whether an alert should be sent,
- send email to a user who set it up, instead of a session's owner,
- adjust period used for checking measurements values: checking only last 10 minutes of measurements if the email hasn't been sent yet, and time since last email if it has been sent already.
