### PR TITLE
Don't update bounds on each map move

### DIFF
--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -529,16 +529,6 @@ const Map = () => {
         isFirstRender.current = false;
       } else {
         if (
-          ([UserSettings.MapView].includes(currentUserSettings) &&
-            realtimeMapUpdates) ||
-          [UserSettings.CrowdMapView].includes(currentUserSettings)
-        ) {
-          const updatedParams = updateMapBounds(map, newSearchParams);
-          if (updatedParams) {
-            navigate(`?${updatedParams.toString()}`);
-          }
-          navigate(`?${newSearchParams.toString()}`);
-        } else if (
           [UserSettings.MapView].includes(currentUserSettings) ||
           [UserSettings.CrowdMapView].includes(currentUserSettings)
         ) {
@@ -551,8 +541,15 @@ const Map = () => {
           newSearchParams.set(UrlParamsTypes.currentZoom, currentZoom);
           Cookies.set(UrlParamsTypes.currentCenter, currentCenter);
           Cookies.set(UrlParamsTypes.currentZoom, currentZoom);
-
           navigate(`?${newSearchParams.toString()}`);
+
+          if (realtimeMapUpdates) {
+            const updatedParams = updateMapBounds(map, newSearchParams);
+            if (updatedParams) {
+              navigate(`?${updatedParams.toString()}`);
+            }
+            navigate(`?${newSearchParams.toString()}`);
+          }
         }
       }
     },

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -537,15 +537,6 @@ const Map = () => {
           if (updatedParams) {
             navigate(`?${updatedParams.toString()}`);
           }
-          const currentCenter = JSON.stringify(
-            map?.getCenter()?.toJSON() || previousCenter
-          );
-          const currentZoom = (map?.getZoom() || previousZoom).toString();
-
-          newSearchParams.set(UrlParamsTypes.currentCenter, currentCenter);
-          newSearchParams.set(UrlParamsTypes.currentZoom, currentZoom);
-          Cookies.set(UrlParamsTypes.currentCenter, currentCenter);
-          Cookies.set(UrlParamsTypes.currentZoom, currentZoom);
           navigate(`?${newSearchParams.toString()}`);
         } else if (
           [UserSettings.MapView].includes(currentUserSettings) ||

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -533,16 +533,34 @@ const Map = () => {
             realtimeMapUpdates) ||
           [UserSettings.CrowdMapView].includes(currentUserSettings)
         ) {
-          const updatedParams = updateMapBounds(
-            map,
-            newSearchParams,
-            previousCenter,
-            previousZoom
-          );
+          const updatedParams = updateMapBounds(map, newSearchParams);
           if (updatedParams) {
             navigate(`?${updatedParams.toString()}`);
           }
-        } else {
+          const currentCenter = JSON.stringify(
+            map?.getCenter()?.toJSON() || previousCenter
+          );
+          const currentZoom = (map?.getZoom() || previousZoom).toString();
+
+          newSearchParams.set(UrlParamsTypes.currentCenter, currentCenter);
+          newSearchParams.set(UrlParamsTypes.currentZoom, currentZoom);
+          Cookies.set(UrlParamsTypes.currentCenter, currentCenter);
+          Cookies.set(UrlParamsTypes.currentZoom, currentZoom);
+          navigate(`?${newSearchParams.toString()}`);
+        } else if (
+          [UserSettings.MapView].includes(currentUserSettings) ||
+          [UserSettings.CrowdMapView].includes(currentUserSettings)
+        ) {
+          const currentCenter = JSON.stringify(
+            map?.getCenter()?.toJSON() || previousCenter
+          );
+          const currentZoom = (map?.getZoom() || previousZoom).toString();
+
+          newSearchParams.set(UrlParamsTypes.currentCenter, currentCenter);
+          newSearchParams.set(UrlParamsTypes.currentZoom, currentZoom);
+          Cookies.set(UrlParamsTypes.currentCenter, currentCenter);
+          Cookies.set(UrlParamsTypes.currentZoom, currentZoom);
+
           navigate(`?${newSearchParams.toString()}`);
         }
       }

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -74,6 +74,7 @@ import { SessionTypes } from "../../types/filters";
 import { SessionList } from "../../types/sessionType";
 import { UserSettings } from "../../types/userStates";
 import * as Cookies from "../../utils/cookies";
+import { updateMapBounds } from "../../utils/mapBoundsHandler";
 import { UrlParamsTypes, useMapParams } from "../../utils/mapParamsHandler";
 import { useHandleScrollEnd } from "../../utils/scrollEnd";
 import useMobileDetection from "../../utils/useScreenSizeDetection";
@@ -528,40 +529,31 @@ const Map = () => {
         isFirstRender.current = false;
       } else {
         if (
-          [UserSettings.MapView, UserSettings.CrowdMapView].includes(
-            currentUserSettings
-          )
+          ([UserSettings.MapView].includes(currentUserSettings) &&
+            realtimeMapUpdates) ||
+          [UserSettings.CrowdMapView].includes(currentUserSettings)
         ) {
-          const currentCenter = JSON.stringify(
-            map.getCenter()?.toJSON() || previousCenter
+          const updatedParams = updateMapBounds(
+            map,
+            newSearchParams,
+            previousCenter,
+            previousZoom
           );
-          const currentZoom = (map.getZoom() || previousZoom).toString();
-          const bounds = map?.getBounds();
-          if (!bounds) {
-            return;
+          if (updatedParams) {
+            navigate(`?${updatedParams.toString()}`);
           }
-          const north = bounds.getNorthEast().lat();
-          const south = bounds.getSouthWest().lat();
-          const east = bounds.getNorthEast().lng();
-          const west = bounds.getSouthWest().lng();
-
-          newSearchParams.set(UrlParamsTypes.boundEast, east.toString());
-          newSearchParams.set(UrlParamsTypes.boundNorth, north.toString());
-          newSearchParams.set(UrlParamsTypes.boundSouth, south.toString());
-          newSearchParams.set(UrlParamsTypes.boundWest, west.toString());
-          newSearchParams.set(UrlParamsTypes.currentCenter, currentCenter);
-          newSearchParams.set(UrlParamsTypes.currentZoom, currentZoom);
-          Cookies.set(UrlParamsTypes.boundEast, east.toString());
-          Cookies.set(UrlParamsTypes.boundNorth, north.toString());
-          Cookies.set(UrlParamsTypes.boundSouth, south.toString());
-          Cookies.set(UrlParamsTypes.boundWest, west.toString());
-          Cookies.set(UrlParamsTypes.currentCenter, currentCenter);
-          Cookies.set(UrlParamsTypes.currentZoom, currentZoom);
+        } else {
           navigate(`?${newSearchParams.toString()}`);
         }
       }
     },
-    [currentUserSettings, mapInstance, searchParams, dispatch]
+    [
+      currentUserSettings,
+      mapInstance,
+      searchParams,
+      dispatch,
+      realtimeMapUpdates,
+    ]
   );
 
   // ref to currentUserSettings to get the current value from URL

--- a/app/javascript/react/components/RefreshMapButton/RefreshMapButton.tsx
+++ b/app/javascript/react/components/RefreshMapButton/RefreshMapButton.tsx
@@ -7,33 +7,36 @@ import { cleanSessions } from "../../store/fixedSessionsSlice";
 import { useAppDispatch } from "../../store/hooks";
 import { setFetchingData } from "../../store/mapSlice";
 import { clearMobileSessions } from "../../store/mobileSessionsSlice";
+import * as Cookies from "../../utils/cookies";
 import { updateMapBounds } from "../../utils/mapBoundsHandler";
-import { useMapParams } from "../../utils/mapParamsHandler";
+import { UrlParamsTypes, useMapParams } from "../../utils/mapParamsHandler";
 import * as S from "./RefreshMapButton.style";
 
 const RefreshMapButton = () => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const map = useMap();
-  const { previousCenter, previousZoom, searchParams } = useMapParams();
+  const { searchParams, previousCenter, previousZoom } = useMapParams();
   const navigate = useNavigate();
 
   const newSearchParams = new URLSearchParams(searchParams.toString());
 
   const handleClick = () => {
-    dispatch(clearMobileSessions());
-    dispatch(cleanSessions());
-    dispatch(setFetchingData(true));
-
-    const updatedParams = updateMapBounds(
-      map,
-      newSearchParams,
-      previousCenter,
-      previousZoom
-    );
+    const updatedParams = updateMapBounds(map, newSearchParams);
     if (updatedParams) {
       navigate(`?${updatedParams.toString()}`);
     }
+    const currentCenter = JSON.stringify(
+      map?.getCenter()?.toJSON() || previousCenter
+    );
+    const currentZoom = (map?.getZoom() || previousZoom).toString();
+    newSearchParams.set(UrlParamsTypes.currentCenter, currentCenter);
+    newSearchParams.set(UrlParamsTypes.currentZoom, currentZoom);
+    Cookies.set(UrlParamsTypes.currentCenter, currentCenter);
+    Cookies.set(UrlParamsTypes.currentZoom, currentZoom);
+    dispatch(clearMobileSessions());
+    dispatch(cleanSessions());
+    dispatch(setFetchingData(true));
   };
 
   return (

--- a/app/javascript/react/components/RefreshMapButton/RefreshMapButton.tsx
+++ b/app/javascript/react/components/RefreshMapButton/RefreshMapButton.tsx
@@ -1,20 +1,39 @@
+import { useMap } from "@vis.gl/react-google-maps";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
+import { useNavigate } from "react-router-dom";
 import { cleanSessions } from "../../store/fixedSessionsSlice";
 import { useAppDispatch } from "../../store/hooks";
 import { setFetchingData } from "../../store/mapSlice";
-import * as S from "./RefreshMapButton.style";
 import { clearMobileSessions } from "../../store/mobileSessionsSlice";
+import { updateMapBounds } from "../../utils/mapBoundsHandler";
+import { useMapParams } from "../../utils/mapParamsHandler";
+import * as S from "./RefreshMapButton.style";
 
 const RefreshMapButton = () => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
+  const map = useMap();
+  const { previousCenter, previousZoom, searchParams } = useMapParams();
+  const navigate = useNavigate();
+
+  const newSearchParams = new URLSearchParams(searchParams.toString());
 
   const handleClick = () => {
     dispatch(clearMobileSessions());
     dispatch(cleanSessions());
     dispatch(setFetchingData(true));
+
+    const updatedParams = updateMapBounds(
+      map,
+      newSearchParams,
+      previousCenter,
+      previousZoom
+    );
+    if (updatedParams) {
+      navigate(`?${updatedParams.toString()}`);
+    }
   };
 
   return (

--- a/app/javascript/react/components/SessionFilters/SessionTypeToggle.tsx
+++ b/app/javascript/react/components/SessionFilters/SessionTypeToggle.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useMap } from "@vis.gl/react-google-maps";
-import { useNavigate } from "react-router-dom";
 import mobileIcon from "../../assets/icons/mobileIcon.svg";
 import pinIcon from "../../assets/icons/pin.svg";
 import { useAppDispatch } from "../../store/hooks";
@@ -17,36 +15,17 @@ import {
 } from "../../store/sessionFiltersSlice";
 import { resetUserThresholds } from "../../store/thresholdSlice";
 import { SessionType, SessionTypes } from "../../types/filters";
-import { updateMapBounds } from "../../utils/mapBoundsHandler";
 import { useMapParams } from "../../utils/mapParamsHandler";
 import { FilterInfoPopup } from "./FilterInfoPopup";
 import * as S from "./SessionFilters.style";
 
 const SessionTypeToggle = () => {
   const dispatch = useAppDispatch();
-  const {
-    searchParams,
-    sessionType,
-    updateSessionType,
-    previousCenter,
-    previousZoom,
-  } = useMapParams();
+  const { searchParams, sessionType, updateSessionType } = useMapParams();
   const { t } = useTranslation();
-  const map = useMap();
-  const navigate = useNavigate();
-  const newSearchParams = new URLSearchParams(searchParams.toString());
 
   const handleClick = useCallback(
     (type: SessionType) => {
-      const updatedParams = updateMapBounds(
-        map,
-        newSearchParams,
-        previousCenter,
-        previousZoom
-      );
-      if (updatedParams) {
-        navigate(`?${updatedParams.toString()}`);
-      }
       dispatch(resetUserThresholds());
       dispatch(setBasicParametersModalOpen(false));
       dispatch(setCustomParametersModalOpen(false));
@@ -56,7 +35,7 @@ const SessionTypeToggle = () => {
       dispatch(setFetchingData(true));
       dispatch(setFixedSessionsType(FixedSessionsTypes.ACTIVE));
     },
-    [dispatch, searchParams, updateSessionType, map]
+    [dispatch, searchParams, updateSessionType]
   );
 
   return (

--- a/app/javascript/react/components/SessionFilters/SessionTypeToggle.tsx
+++ b/app/javascript/react/components/SessionFilters/SessionTypeToggle.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
+import { useMap } from "@vis.gl/react-google-maps";
+import { useNavigate } from "react-router-dom";
 import mobileIcon from "../../assets/icons/mobileIcon.svg";
 import pinIcon from "../../assets/icons/pin.svg";
 import { useAppDispatch } from "../../store/hooks";
@@ -15,17 +17,36 @@ import {
 } from "../../store/sessionFiltersSlice";
 import { resetUserThresholds } from "../../store/thresholdSlice";
 import { SessionType, SessionTypes } from "../../types/filters";
+import { updateMapBounds } from "../../utils/mapBoundsHandler";
 import { useMapParams } from "../../utils/mapParamsHandler";
 import { FilterInfoPopup } from "./FilterInfoPopup";
 import * as S from "./SessionFilters.style";
 
 const SessionTypeToggle = () => {
   const dispatch = useAppDispatch();
-  const { searchParams, sessionType, updateSessionType } = useMapParams();
+  const {
+    searchParams,
+    sessionType,
+    updateSessionType,
+    previousCenter,
+    previousZoom,
+  } = useMapParams();
   const { t } = useTranslation();
+  const map = useMap();
+  const navigate = useNavigate();
+  const newSearchParams = new URLSearchParams(searchParams.toString());
 
   const handleClick = useCallback(
     (type: SessionType) => {
+      const updatedParams = updateMapBounds(
+        map,
+        newSearchParams,
+        previousCenter,
+        previousZoom
+      );
+      if (updatedParams) {
+        navigate(`?${updatedParams.toString()}`);
+      }
       dispatch(resetUserThresholds());
       dispatch(setBasicParametersModalOpen(false));
       dispatch(setCustomParametersModalOpen(false));
@@ -35,7 +56,7 @@ const SessionTypeToggle = () => {
       dispatch(setFetchingData(true));
       dispatch(setFixedSessionsType(FixedSessionsTypes.ACTIVE));
     },
-    [dispatch, searchParams, updateSessionType]
+    [dispatch, searchParams, updateSessionType, map]
   );
 
   return (

--- a/app/javascript/react/utils/mapBoundsHandler.ts
+++ b/app/javascript/react/utils/mapBoundsHandler.ts
@@ -3,9 +3,7 @@ import { UrlParamsTypes } from "./mapParamsHandler";
 
 export const updateMapBounds = (
   map: google.maps.Map | null,
-  newSearchParams: URLSearchParams,
-  previousCenter: google.maps.LatLngLiteral,
-  previousZoom: number
+  newSearchParams: URLSearchParams
 ) => {
   const bounds = map?.getBounds();
   if (!bounds) return;
@@ -14,24 +12,16 @@ export const updateMapBounds = (
   const south = bounds.getSouthWest().lat();
   const east = bounds.getNorthEast().lng();
   const west = bounds.getSouthWest().lng();
-  const currentCenter = JSON.stringify(
-    map?.getCenter()?.toJSON() || previousCenter
-  );
-  const currentZoom = (map?.getZoom() || previousZoom).toString();
 
   newSearchParams.set(UrlParamsTypes.boundEast, east.toString());
   newSearchParams.set(UrlParamsTypes.boundNorth, north.toString());
   newSearchParams.set(UrlParamsTypes.boundSouth, south.toString());
   newSearchParams.set(UrlParamsTypes.boundWest, west.toString());
-  newSearchParams.set(UrlParamsTypes.currentCenter, currentCenter);
-  newSearchParams.set(UrlParamsTypes.currentZoom, currentZoom);
 
   Cookies.set(UrlParamsTypes.boundEast, east.toString());
   Cookies.set(UrlParamsTypes.boundNorth, north.toString());
   Cookies.set(UrlParamsTypes.boundSouth, south.toString());
   Cookies.set(UrlParamsTypes.boundWest, west.toString());
-  Cookies.set(UrlParamsTypes.currentCenter, currentCenter);
-  Cookies.set(UrlParamsTypes.currentZoom, currentZoom);
 
   return newSearchParams;
 };

--- a/app/javascript/react/utils/mapBoundsHandler.ts
+++ b/app/javascript/react/utils/mapBoundsHandler.ts
@@ -1,0 +1,37 @@
+import * as Cookies from "./cookies";
+import { UrlParamsTypes } from "./mapParamsHandler";
+
+export const updateMapBounds = (
+  map: google.maps.Map | null,
+  newSearchParams: URLSearchParams,
+  previousCenter: google.maps.LatLngLiteral,
+  previousZoom: number
+) => {
+  const bounds = map?.getBounds();
+  if (!bounds) return;
+
+  const north = bounds.getNorthEast().lat();
+  const south = bounds.getSouthWest().lat();
+  const east = bounds.getNorthEast().lng();
+  const west = bounds.getSouthWest().lng();
+  const currentCenter = JSON.stringify(
+    map?.getCenter()?.toJSON() || previousCenter
+  );
+  const currentZoom = (map?.getZoom() || previousZoom).toString();
+
+  newSearchParams.set(UrlParamsTypes.boundEast, east.toString());
+  newSearchParams.set(UrlParamsTypes.boundNorth, north.toString());
+  newSearchParams.set(UrlParamsTypes.boundSouth, south.toString());
+  newSearchParams.set(UrlParamsTypes.boundWest, west.toString());
+  newSearchParams.set(UrlParamsTypes.currentCenter, currentCenter);
+  newSearchParams.set(UrlParamsTypes.currentZoom, currentZoom);
+
+  Cookies.set(UrlParamsTypes.boundEast, east.toString());
+  Cookies.set(UrlParamsTypes.boundNorth, north.toString());
+  Cookies.set(UrlParamsTypes.boundSouth, south.toString());
+  Cookies.set(UrlParamsTypes.boundWest, west.toString());
+  Cookies.set(UrlParamsTypes.currentCenter, currentCenter);
+  Cookies.set(UrlParamsTypes.currentZoom, currentZoom);
+
+  return newSearchParams;
+};


### PR DESCRIPTION
The issue: fixed > nyc > zoom out > timelapse: when timelapse is activated, the map refreshes so it includes all stations in the map view

Fix: map bounds are updated and set in URL on "Refresh map" button click, on mobile session type toggle and while "Update when map moves" is selected.