### PR TITLE
Stream hourly averages

### DIFF
--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -1,6 +1,9 @@
 class Stream < ApplicationRecord
   belongs_to :session
   belongs_to :threshold_set
+  belongs_to :last_hourly_average,
+             class_name: 'StreamHourlyAverage',
+             optional: true
 
   has_many :measurements, dependent: :delete_all
   has_many :stream_daily_averages, dependent: :delete_all

--- a/app/models/stream_hourly_average.rb
+++ b/app/models/stream_hourly_average.rb
@@ -1,0 +1,6 @@
+class StreamHourlyAverage < ApplicationRecord
+  belongs_to :stream
+
+  validates :value, :date_time, presence: true
+  validates :date_time, uniqueness: { scope: :stream_id }
+end

--- a/app/services/stream_hourly_averages/repository.rb
+++ b/app/services/stream_hourly_averages/repository.rb
@@ -1,0 +1,65 @@
+module StreamHourlyAverages
+  class Repository
+    def insert_stream_hourly_averages(start_date_time:, end_date_time:)
+      values_to_insert =
+        hourly_average_values_for_fixed_streams(start_date_time, end_date_time)
+
+      if values_to_insert.any?
+        insert_records(values_to_insert, end_date_time)
+      else
+        []
+      end
+    end
+
+    def update_last_hourly_average(stream_ids_with_last_hourly_average_ids)
+      streams = Stream.where(id: stream_ids_with_last_hourly_average_ids.keys)
+
+      streams.each do |stream|
+        stream.update(
+          last_hourly_average_id:
+            stream_ids_with_last_hourly_average_ids[stream.id],
+        )
+      end
+    end
+
+    private
+
+    def hourly_average_values_for_fixed_streams(start_date_time, end_date_time)
+      # That's a temporary solution until we have stream_configuration in place to store information about sensor type
+      airnow_user = User.find_by!(username: 'US EPA AirNow')
+
+      Measurement
+        .unscoped
+        .joins(stream: :session)
+        .where(
+          'time_with_time_zone > ? AND time_with_time_zone <= ?',
+          start_date_time,
+          end_date_time,
+        )
+        .where(sessions: { type: 'FixedSession' })
+        .where.not(sessions: { user_id: airnow_user.id })
+        .group(:stream_id)
+        .average(:value)
+        .map { |stream_id, value| { stream_id: stream_id, value: value.round } }
+    end
+
+    def insert_records(values, end_date_time)
+      current_time = Time.current
+
+      # It returns a hash with stream_ids as keys and stream_hourly_average_ids as values.
+      StreamHourlyAverage
+        .create_with(
+          date_time: end_date_time,
+          created_at: current_time,
+          updated_at: current_time,
+        )
+        .insert_all(
+          values,
+          returning: %i[stream_id id],
+          unique_by: %i[stream_id date_time],
+        )
+        .rows
+        .to_h
+    end
+  end
+end

--- a/app/services/stream_hourly_averages/updater.rb
+++ b/app/services/stream_hourly_averages/updater.rb
@@ -1,0 +1,29 @@
+module StreamHourlyAverages
+  class Updater
+    def initialize(repository: Repository.new)
+      @repository = repository
+    end
+
+    def call
+      start_date_time, end_date_time = date_time_range
+
+      insert_result =
+        repository.insert_stream_hourly_averages(
+          start_date_time: start_date_time,
+          end_date_time: end_date_time,
+        )
+      repository.update_last_hourly_average(insert_result) if insert_result.any?
+    end
+
+    private
+
+    attr_reader :repository
+
+    def date_time_range
+      end_date_time = Time.current.beginning_of_hour
+      start_date_time = end_date_time - 1.hour
+
+      [start_date_time, end_date_time]
+    end
+  end
+end

--- a/app/services/stream_hourly_averages/updater.rb
+++ b/app/services/stream_hourly_averages/updater.rb
@@ -7,12 +7,15 @@ module StreamHourlyAverages
     def call
       start_date_time, end_date_time = date_time_range
 
-      insert_result =
+      ActiveRecord::Base.transaction do
         repository.insert_stream_hourly_averages(
           start_date_time: start_date_time,
           end_date_time: end_date_time,
         )
-      repository.update_last_hourly_average(insert_result) if insert_result.any?
+        repository.update_streams_last_hourly_average_ids(
+          date_time: end_date_time,
+        )
+      end
     end
 
     private

--- a/app/workers/update_stream_hourly_averages_worker.rb
+++ b/app/workers/update_stream_hourly_averages_worker.rb
@@ -1,0 +1,9 @@
+require 'sidekiq-scheduler'
+
+class UpdateStreamHourlyAveragesWorker
+  include Sidekiq::Worker
+
+  def perform
+    StreamHourlyAverages::Updater.new.call
+  end
+end

--- a/app/workers/update_stream_hourly_averages_worker.rb
+++ b/app/workers/update_stream_hourly_averages_worker.rb
@@ -4,6 +4,8 @@ class UpdateStreamHourlyAveragesWorker
   include Sidekiq::Worker
 
   def perform
+    return unless A9n.sidekiq_averages_calculation_enabled
+
     StreamHourlyAverages::Updater.new.call
   end
 end

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -18,3 +18,4 @@ defaults:
   sidekiq_session_stopped_alerts_enabled: false
   sidekiq_air_now_import_measurements_enabled: false
   sidekiq_threshold_exceeded_alerts_enabled: false
+  sidekiq_averages_calculation_enabled: false

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -21,3 +21,8 @@
     cron: "56 * * * *"
     class: AirNowImportMeasurementsWorker
     queue: slow
+
+  update_stream_hourly_averages:
+    cron: "1 * * * *"
+    class: UpdateStreamHourlyAveragesWorker
+    queue: slow

--- a/db/migrate/20241206140549_create_stream_hourly_averages.rb
+++ b/db/migrate/20241206140549_create_stream_hourly_averages.rb
@@ -1,0 +1,13 @@
+class CreateStreamHourlyAverages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :stream_hourly_averages do |t|
+      t.references :stream, null: false, index: false, foreign_key: true
+      t.integer :value, null: false
+      t.datetime :date_time, null: false
+
+      t.timestamps
+    end
+
+    add_index :stream_hourly_averages, %i[stream_id date_time], unique: true
+  end
+end

--- a/db/migrate/20241206155713_add_last_hourly_average_to_streams.rb
+++ b/db/migrate/20241206155713_add_last_hourly_average_to_streams.rb
@@ -1,0 +1,9 @@
+class AddLastHourlyAverageToStreams < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :streams,
+                  :last_hourly_average,
+                  foreign_key: {
+                    to_table: :stream_hourly_averages,
+                  }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_19_133112) do
+ActiveRecord::Schema.define(version: 2024_12_06_155713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -134,6 +134,15 @@ ActiveRecord::Schema.define(version: 2024_11_19_133112) do
     t.index ["stream_id"], name: "index_stream_daily_averages_on_stream_id"
   end
 
+  create_table "stream_hourly_averages", force: :cascade do |t|
+    t.bigint "stream_id", null: false
+    t.integer "value", null: false
+    t.datetime "date_time", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["stream_id", "date_time"], name: "index_stream_hourly_averages_on_stream_id_and_date_time", unique: true
+  end
+
   create_table "streams", id: :serial, force: :cascade do |t|
     t.string "sensor_name"
     t.string "unit_name"
@@ -151,6 +160,8 @@ ActiveRecord::Schema.define(version: 2024_11_19_133112) do
     t.decimal "start_longitude", precision: 12, scale: 9
     t.decimal "start_latitude", precision: 12, scale: 9
     t.integer "threshold_set_id", null: false
+    t.bigint "last_hourly_average_id"
+    t.index ["last_hourly_average_id"], name: "index_streams_on_last_hourly_average_id"
     t.index ["max_latitude"], name: "index_streams_on_max_latitude"
     t.index ["max_longitude"], name: "index_streams_on_max_longitude"
     t.index ["min_latitude"], name: "index_streams_on_min_latitude"
@@ -245,6 +256,8 @@ ActiveRecord::Schema.define(version: 2024_11_19_133112) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "stream_daily_averages", "streams"
+  add_foreign_key "stream_hourly_averages", "streams"
+  add_foreign_key "streams", "stream_hourly_averages", column: "last_hourly_average_id"
   add_foreign_key "streams", "threshold_sets"
   add_foreign_key "threshold_alerts", "streams"
 end

--- a/spec/factories/stream_hourly_averages.rb
+++ b/spec/factories/stream_hourly_averages.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :stream_hourly_average do
+    value { 10 }
+    date_time { Time.current.beginning_of_hour }
+    stream
+  end
+end

--- a/spec/factories/streams.rb
+++ b/spec/factories/streams.rb
@@ -11,4 +11,8 @@ FactoryBot.define do
     threshold_set
     association :session, factory: :mobile_session
   end
+
+  trait :fixed do
+    association :session, factory: :fixed_session
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,4 +74,5 @@ RSpec.configure do |config|
   end
 
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/services/stream_hourly_averages/repository_spec.rb
+++ b/spec/services/stream_hourly_averages/repository_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe StreamHourlyAverages::Repository do
+  subject { described_class.new }
+
+  describe '#insert_stream_hourly_averages' do
+    it 'creates stream_hourly_average records based on calculated measurements average values' do
+      #TODO: remove once stream_configuration is in place
+      create(:user, username: 'US EPA AirNow')
+      start_date_time = Time.parse('2024-12-10 11:00:00 +00:00')
+      end_date_time = Time.parse('2024-12-10 12:00:00 +00:00')
+
+      stream_1 = create(:stream, :fixed)
+      stream_1_measurement_1 =
+        create(
+          :measurement,
+          stream: stream_1,
+          time_with_time_zone: Time.parse('2024-12-10 11:30:00 +00:00'),
+          value: 2,
+        )
+      stream_1_measurement_2 =
+        create(
+          :measurement,
+          stream: stream_1,
+          time_with_time_zone: Time.parse('2024-12-10 12:00:00 +00:00'),
+          value: 4,
+        )
+      stream_2 = create(:stream, :fixed)
+      stream_2_measurement_1 =
+        create(
+          :measurement,
+          stream: stream_2,
+          time_with_time_zone: Time.parse('2024-12-10 11:30:00 +00:00'),
+          value: 6,
+        )
+
+      _stream_2_measurement_old =
+        create(
+          :measurement,
+          stream: stream_2,
+          time_with_time_zone: Time.parse('2024-12-09 12:00:00 +00:00'),
+          value: 6,
+        )
+
+      subject.insert_stream_hourly_averages(
+        start_date_time: start_date_time,
+        end_date_time: end_date_time,
+      )
+
+      attributes = StreamHourlyAverage.pluck(:stream_id, :value, :date_time)
+      expect(attributes).to match_array(
+        [
+          [stream_1.id, 3, Time.parse('2024-12-10 12:00:00 +00:00')],
+          [stream_2.id, 6, Time.parse('2024-12-10 12:00:00 +00:00')],
+        ],
+      )
+    end
+  end
+
+  describe '#update_streams_last_hourly_average_ids' do
+    it 'updates the last_hourly_average_ids for the streams' do
+      date_time = Time.parse('2024-12-10 12:00:00 +00:00')
+
+      stream_1 = create(:stream, :fixed)
+      stream_2 = create(:stream, :fixed)
+
+      stream_1_hourly_average =
+        create(:stream_hourly_average, stream: stream_1, date_time: date_time)
+      stream_2_hourly_average =
+        create(:stream_hourly_average, stream: stream_2, date_time: date_time)
+      _other_stream_hourly_average =
+        create(
+          :stream_hourly_average,
+          stream: stream_2,
+          date_time: (date_time - 3.hours),
+        )
+
+      subject.update_streams_last_hourly_average_ids(date_time: date_time)
+
+      expect(stream_1.reload.last_hourly_average_id).to eq(
+        stream_1_hourly_average.id,
+      )
+      expect(stream_2.reload.last_hourly_average_id).to eq(
+        stream_2_hourly_average.id,
+      )
+    end
+  end
+end

--- a/spec/services/stream_hourly_averages/updater_spec.rb
+++ b/spec/services/stream_hourly_averages/updater_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe StreamHourlyAverages::Updater do
+  subject { described_class.new }
+
+  describe '#call' do
+    before { allow(Time).to receive(:current).and_return(stubbed_time_current) }
+    let(:stubbed_time_current) { Time.parse('2024-12-10 12:10:00 +00:00') }
+
+    it 'creates stream_hourly_average records and updates stream references to last_hourly_average' do
+      #TODO: remove once stream_configuration is in place
+      create(:user, username: 'US EPA AirNow')
+
+      stream = create(:stream, :fixed, last_hourly_average: nil)
+      create(
+        :measurement,
+        stream: stream,
+        time_with_time_zone: Time.parse('2024-12-10 11:10:00 +00:00'),
+        value: 2,
+      )
+      create(
+        :measurement,
+        stream: stream,
+        time_with_time_zone: Time.parse('2024-12-10 11:20:00 +00:00'),
+        value: 6,
+      )
+
+      subject.call
+
+      stream_hourly_average = StreamHourlyAverage.last
+
+      expect(stream_hourly_average).to have_attributes(
+        stream_id: stream.id,
+        value: 4,
+        date_time: Time.parse('2024-12-10 12:00:00 +00:00'),
+      )
+
+      expect(stream.reload.last_hourly_average_id).to eq(
+        stream_hourly_average.id,
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Stream hourly averages
<p>Hourly averages are calculated for the preceding hour, and the average represents completed data for the full hour. We only calculate averages for fixed streams. The value is an integer, we round to the nearest whole number.</p>
<p>Example:</p>

Time intervals for measurement | Labeled as
-- | --
(10:00, 11:00] → 10:00:01 - 11:00:00 | 11:00:00
(11:00, 12:00] → 11:00:01 - 12:00:00 | 12:00:00
(12:00, 13:00] → 12:00:01 - 13:00:00 | 13:00:00


<p><strong>Note: to use the same approach to handle AirBeam and AirNow data, it’s important to have left-open, right-closed interval.</strong></p>

## DB changes
- Create table for aggregated data - `stream_hourly_averages`.
- Add reference to `last_hourly_average` to streams (additional one to one association) for easy access to relevant average value when showing a stream.

## Workers to periodically calculate the average values

There are some differences between AirBeam and AirNow streams:

- They are updated at different frequency (1 min for AB and 1 hour for AirNow).
- Value reported by AirNow represents average concentration for the preceding hour, so we want to save it as both a single measurement value and as a hourly average value.
- AirNow data is available with some delay.

That's why averages calculation will be handled separately for AirBeam and AirNow streams.

### This PR covers AirBeam streams
Worker is run 1 minute past every hour (1 * * * *). It creates `stream_hourly_average` records based on available measurements from the preceding hour and update reference to the last record for relevant streams.
