### PR TITLE
Fix deleting streams

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -251,7 +251,7 @@ class Session < ApplicationRecord
               sensor_name: stream_data[:sensor_name],
             )
 
-          streams_to_destroy.update_all(last_hourly_average: nil)
+          streams_to_destroy.update_all(last_hourly_average_id: nil)
           streams_to_destroy.each(&:destroy)
         end
       end

--- a/app/services/api/to_user_sessions_hash2.rb
+++ b/app/services/api/to_user_sessions_hash2.rb
@@ -29,7 +29,7 @@ class Api::ToUserSessionsHash2
   def delete_sessions(sessions)
     sessions = Session.where(uuid: sessions.pluck(:uuid))
     streams = Stream.where(session: sessions)
-    streams.update_all(last_hourly_average: nil)
+    streams.update_all(last_hourly_average_id: nil)
     sessions.destroy_all
   end
 

--- a/app/services/api/to_user_sessions_hash2.rb
+++ b/app/services/api/to_user_sessions_hash2.rb
@@ -13,8 +13,8 @@ class Api::ToUserSessionsHash2
       {
         upload: new_in_params,
         download: new_in_database + outdated,
-        deleted: deleted
-      }
+        deleted: deleted,
+      },
     )
   end
 
@@ -27,7 +27,10 @@ class Api::ToUserSessionsHash2
   end
 
   def delete_sessions(sessions)
-    user.sessions.where(uuid: sessions.pluck(:uuid)).destroy_all
+    sessions = Session.where(uuid: sessions.pluck(:uuid))
+    streams = Stream.where(session: sessions)
+    streams.update_all(last_hourly_average: nil)
+    sessions.destroy_all
   end
 
   def deleted
@@ -57,7 +60,7 @@ class Api::ToUserSessionsHash2
         if (session.streams.count != 0) &&
              (session.streams.all? { |stream| stream.measurements.count != 0 })
           acc.push(
-            OpenStruct.new({ uuid: session.uuid, version: session.version })
+            OpenStruct.new({ uuid: session.uuid, version: session.version }),
           )
         end
 


### PR DESCRIPTION
As streams have double reference to stream_hourly_average table, there was a problem with deleting objects properly when a session (sync_with_versioning) or some streams for a session (update_session) were deleted.

It would be good to move these delete operations to a repository to have better control over what's getting deleted. 