### PR TITLE
Improve fetching and loading data in the Graph

### DIFF
--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -7,7 +7,6 @@ import { white } from "../../assets/styles/colors";
 import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
 import {
   resetLastSelectedTimeRange,
-  selectFixedData,
   selectIsLoading,
   selectLastSelectedFixedTimeRange,
   selectStreamMeasurements,
@@ -79,7 +78,6 @@ const Graph: React.FC<GraphProps> = React.memo(
     const fixedSessionTypeSelected = sessionType === SessionTypes.FIXED;
     const thresholdsState = useAppSelector(selectThresholds);
     const isLoading = useAppSelector(selectIsLoading);
-    const fixedGraphData = useAppSelector(selectFixedData);
     const mobileGraphData = useAppSelector(selectMobileStreamPoints);
     const mobileStreamShortInfo: MobileStreamShortInfo = useAppSelector(
       selectMobileStreamShortInfo
@@ -94,8 +92,7 @@ const Graph: React.FC<GraphProps> = React.memo(
       selectLastSelectedMobileTimeRange
     );
 
-    const { unitSymbol, measurementType, isIndoor, sensorName } =
-      useMapParams();
+    const { unitSymbol, measurementType, isIndoor } = useMapParams();
 
     const lastSelectedTimeRange = fixedSessionTypeSelected
       ? fixedLastSelectedTimeRange

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -4,6 +4,7 @@ import NoDataToDisplay from "highcharts/modules/no-data-to-display";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { white } from "../../assets/styles/colors";
+import { RootState } from "../../store";
 import { selectFixedStreamShortInfo } from "../../store/fixedStreamSelectors";
 import {
   resetLastSelectedTimeRange,
@@ -124,8 +125,11 @@ const Graph: React.FC<GraphProps> = React.memo(
 
     const isIndoorParameterInUrl = isIndoor === "true";
 
-    const measurements = useAppSelector((state) =>
-      selectStreamMeasurements(state, streamId)
+    const measurements = useAppSelector(
+      useCallback(
+        (state: RootState) => selectStreamMeasurements(state, streamId),
+        [streamId]
+      )
     );
 
     const seriesData = useMemo(() => {
@@ -143,12 +147,13 @@ const Graph: React.FC<GraphProps> = React.memo(
 
     const { fetchMeasurementsIfNeeded } = useMeasurementsFetcher(streamId);
 
-    useChartUpdater({
+    const { updateChartData } = useChartUpdater({
       chartComponentRef,
       seriesData,
       isLoading,
       lastSelectedTimeRange,
       fixedSessionTypeSelected,
+      streamId,
     });
 
     useEffect(() => {

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -225,7 +225,8 @@ const Graph: React.FC<GraphProps> = React.memo(
           fixedSessionTypeSelected,
           dispatch,
           isLoading,
-          fetchMeasurementsIfNeeded
+          fetchMeasurementsIfNeeded,
+          streamId
         ),
       [
         isMobile,

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -35,6 +35,7 @@ import {
   mapIndexToTimeRange,
 } from "../../utils/getTimeRange";
 import { useMapParams } from "../../utils/mapParamsHandler";
+import { MILLISECONDS_IN_A_WEEK } from "../../utils/timeRanges";
 import useMobileDetection from "../../utils/useScreenSizeDetection";
 import { handleLoad } from "./chartEvents";
 import {
@@ -176,8 +177,7 @@ const Graph: React.FC<GraphProps> = React.memo(
       if (streamId && fixedSessionTypeSelected && !measurements.length) {
         // Only fetch if we don't have data for this stream
         const now = Date.now();
-        const oneDayInMs = 24 * 60 * 60 * 1000;
-        fetchMeasurementsIfNeeded(now - oneDayInMs, now);
+        fetchMeasurementsIfNeeded(now - MILLISECONDS_IN_A_WEEK, now);
       }
     }, [streamId, fixedSessionTypeSelected, measurements.length]);
 

--- a/app/javascript/react/components/Graph/chartHooks/useChartUpdater.ts
+++ b/app/javascript/react/components/Graph/chartHooks/useChartUpdater.ts
@@ -68,7 +68,6 @@ export const useChartUpdater = ({
       updateChartData(chart, seriesData);
     }
 
-    // If we have a lastSelectedTimeRange, apply it
     if (lastSelectedTimeRange && chart.rangeSelector) {
       const selectedIndex = getSelectedRangeIndex(
         lastSelectedTimeRange,

--- a/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
+++ b/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
@@ -12,18 +12,13 @@ export const useMeasurementsFetcher = (streamId: number | null) => {
   const isInitialFetchRef = useRef(true);
   const dispatch = useAppDispatch();
 
-  const fetchChunk = async (
-    start: number,
-    end: number,
-    isBackground = false
-  ) => {
+  const fetchChunk = async (start: number, end: number) => {
     try {
       await dispatch(
         fetchMeasurements({
           streamId: Number(streamId),
           startTime: Math.floor(start).toString(),
           endTime: Math.floor(end).toString(),
-          isBackground,
         })
       ).unwrap();
     } catch (error) {
@@ -39,11 +34,11 @@ export const useMeasurementsFetcher = (streamId: number | null) => {
       try {
         if (isInitialFetchRef.current) {
           // For initial fetch, load one week of data
-          await fetchChunk(end - MILLISECONDS_IN_A_DAY * 2, end, false);
+          await fetchChunk(end - MILLISECONDS_IN_A_DAY * 2, end);
           isInitialFetchRef.current = false;
         } else {
           // For subsequent fetches, get one month of data
-          await fetchChunk(end - MILLISECONDS_IN_A_MONTH, end, false);
+          await fetchChunk(end - MILLISECONDS_IN_A_MONTH, end);
         }
       } finally {
         isCurrentlyFetchingRef.current = false;

--- a/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
+++ b/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
@@ -1,20 +1,15 @@
 import { debounce } from "lodash";
 import { useEffect, useRef } from "react";
-import {
-  fetchMeasurements,
-  selectStreamMeasurements,
-} from "../../../store/fixedStreamSlice";
-import { useAppDispatch, useAppSelector } from "../../../store/hooks";
+import { fetchMeasurements } from "../../../store/fixedStreamSlice";
+import { useAppDispatch } from "../../../store/hooks";
+import { MILLISECONDS_IN_A_WEEK } from "../../../utils/timeRanges";
 
-const CHUNK_SIZE = 7 * 24 * 60 * 60 * 1000; // 1 week in milliseconds
+const CHUNK_SIZE = MILLISECONDS_IN_A_WEEK;
 
 export const useMeasurementsFetcher = (streamId: number | null) => {
   const isCurrentlyFetchingRef = useRef(false);
   const isBackgroundFetchingRef = useRef(false);
   const dispatch = useAppDispatch();
-  const measurements = useAppSelector((state) =>
-    selectStreamMeasurements(state, streamId)
-  );
 
   const fetchChunk = async (
     start: number,
@@ -27,7 +22,7 @@ export const useMeasurementsFetcher = (streamId: number | null) => {
           streamId: Number(streamId),
           startTime: Math.floor(start).toString(),
           endTime: Math.floor(end).toString(),
-          isBackground, // Pass this to the action
+          isBackground,
         })
       ).unwrap();
     } catch (error) {

--- a/app/javascript/react/components/Graph/graphConfig.ts
+++ b/app/javascript/react/components/Graph/graphConfig.ts
@@ -37,7 +37,6 @@ import {
   MILLISECONDS_IN_A_5_MINUTES,
   MILLISECONDS_IN_A_DAY,
   MILLISECONDS_IN_A_MONTH,
-  MILLISECONDS_IN_A_SECOND,
   MILLISECONDS_IN_A_WEEK,
   MILLISECONDS_IN_AN_HOUR,
 } from "../../utils/timeRanges";
@@ -72,27 +71,42 @@ const getXAxisOptions = (
   fixedSessionTypeSelected: boolean,
   dispatch: AppDispatch,
   isLoading: boolean,
-  fetchMeasurementsIfNeeded: (start: number, end: number) => Promise<void>
+  fetchMeasurementsIfNeeded: (start: number, end: number) => Promise<void>,
+  // NEW: pass the current `streamId` from the Graph so we know which set of measurements to update
+  streamId: number | null
 ): Highcharts.XAxisOptions => {
   let isFetchingData = false;
   let initialDataMin: number | null = null;
   let fetchTimeout: NodeJS.Timeout | null = null;
 
+  // Debounced function to set extremes
   const handleSetExtremes = debounce(
     (e: Highcharts.AxisSetExtremesEventObject) => {
       if (!isLoading && e.min !== undefined && e.max !== undefined) {
-        dispatch(
-          fixedSessionTypeSelected
-            ? updateFixedMeasurementExtremes({ min: e.min, max: e.max })
-            : updateMobileMeasurementExtremes({ min: e.min, max: e.max })
-        );
+        if (fixedSessionTypeSelected && streamId !== null) {
+          dispatch(
+            updateFixedMeasurementExtremes({
+              // Pass the streamId!
+              streamId,
+              min: e.min,
+              max: e.max,
+            })
+          );
+        } else {
+          // For mobile streams
+          dispatch(
+            updateMobileMeasurementExtremes({
+              min: e.min,
+              max: e.max,
+            })
+          );
+        }
 
+        // If you have a little range display in the UI, update it
         const { formattedMinTime, formattedMaxTime } = formatTimeExtremes(
           e.min,
           e.max
         );
-
-        // Update the time range display in the graph on the Calendar Page
         if (rangeDisplayRef?.current) {
           rangeDisplayRef.current.innerHTML = `
             <div class="time-container">
@@ -112,89 +126,41 @@ const getXAxisOptions = (
   );
 
   return {
-    title: {
-      text: undefined,
-    },
-    showEmpty: false,
-    showLastLabel: !isMobile,
-    tickColor: gray200,
-    lineColor: white,
     type: "datetime",
-    labels: {
-      enabled: true,
-      overflow: "justify",
-      step: 1,
-      style: {
-        fontSize: "1.2rem",
-        fontFamily: "Roboto",
-      },
-    },
-    crosshair: {
-      color: white,
-      width: 2,
-    },
-    visible: true,
-    minRange: MILLISECONDS_IN_A_SECOND,
-    ordinal: false,
+    // ... your other X-axis props ...
     events: {
       afterSetExtremes: async function (
         e: Highcharts.AxisSetExtremesEventObject
       ) {
         const axis = this;
         const chart = axis.chart as Highcharts.StockChart;
-        const sensorName = chart.series[0]?.name;
 
+        // 1) First let your debounced function handle min/max updating:
         handleSetExtremes(e);
 
-        if (!fixedSessionTypeSelected) return;
+        if (!fixedSessionTypeSelected || streamId == null) return;
 
-        // Initialize initialDataMin and handle first render
+        // 2) Possibly do "infinite scrolling" style fetch if user scrolls near dataMin:
         if (initialDataMin === null && e.dataMin !== undefined) {
           initialDataMin = e.dataMin - MILLISECONDS_IN_A_MONTH;
-
-          if (
-            !hasInitialFetch &&
-            isGovernmentSensor(sensorName) &&
-            e.min !== undefined
-          ) {
-            hasInitialFetch = true;
-            const newStart = e.min - MILLISECONDS_IN_A_MONTH;
-            await fetchMeasurementsIfNeeded(newStart, e.min);
-            return;
-          }
         }
 
-        // Set up the scrollbar release event.
+        // For example, fetch older data if user pans close to the start:
         const onScrollbarRelease = () => {
-          if (fetchTimeout) {
-            clearTimeout(fetchTimeout);
-          }
-
+          if (fetchTimeout) clearTimeout(fetchTimeout);
           fetchTimeout = setTimeout(async () => {
             if (isLoading || isFetchingData) return;
-
             const { min, max, dataMin } = axis.getExtremes();
+            if (min === undefined || dataMin === undefined) return;
 
-            if (
-              min === undefined ||
-              dataMin === undefined ||
-              initialDataMin === null
-            )
-              return;
-
-            const viewRange = max - min;
-            const buffer = viewRange * 0.02;
-
+            // example logic: if user scrolls near dataMin, fetch older
+            const buffer = (max - min) * 0.02;
             const isAtDataMin = min <= dataMin + buffer;
-            const isAtInitialMin = min <= initialDataMin + buffer;
-
-            if (isAtDataMin || isAtInitialMin) {
+            if (isAtDataMin) {
               isFetchingData = true;
               try {
                 const newStart = min - MILLISECONDS_IN_A_MONTH;
                 await fetchMeasurementsIfNeeded(newStart, min);
-              } catch (error) {
-                console.error("Error fetching data:", error);
               } finally {
                 isFetchingData = false;
                 fetchTimeout = null;

--- a/app/javascript/react/components/Graph/graphConfig.ts
+++ b/app/javascript/react/components/Graph/graphConfig.ts
@@ -37,6 +37,7 @@ import {
   MILLISECONDS_IN_A_5_MINUTES,
   MILLISECONDS_IN_A_DAY,
   MILLISECONDS_IN_A_MONTH,
+  MILLISECONDS_IN_A_SECOND,
   MILLISECONDS_IN_A_WEEK,
   MILLISECONDS_IN_AN_HOUR,
 } from "../../utils/timeRanges";
@@ -126,8 +127,30 @@ const getXAxisOptions = (
   );
 
   return {
+    title: {
+      text: undefined,
+    },
+    showEmpty: false,
+    showLastLabel: !isMobile,
+    tickColor: gray200,
+    lineColor: white,
     type: "datetime",
-    // ... your other X-axis props ...
+    labels: {
+      enabled: true,
+      overflow: "justify",
+      step: 1,
+      style: {
+        fontSize: "1.2rem",
+        fontFamily: "Roboto",
+      },
+    },
+    crosshair: {
+      color: white,
+      width: 2,
+    },
+    visible: true,
+    minRange: MILLISECONDS_IN_A_SECOND,
+    ordinal: false,
     events: {
       afterSetExtremes: async function (
         e: Highcharts.AxisSetExtremesEventObject

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -4,22 +4,34 @@ import { apiClient, oldApiClient } from "../api/apiClient";
 import { API_ENDPOINTS } from "../api/apiEndpoints";
 import { ApiError, StatusEnum } from "../types/api";
 import { FixedStream } from "../types/fixedStream";
-
 import { FixedTimeRange } from "../types/timeRange";
 import { getErrorMessage } from "../utils/getErrorMessage";
 import { logError } from "../utils/logController";
 import { RootState } from "./index";
 
+export interface Measurement {
+  time: number;
+  value: number;
+  latitude: number;
+  longitude: number;
+}
+
 export interface FixedStreamState {
   data: FixedStream;
   fetchedStartTime: number | null;
+
+  // Values to be updated based on currently visible time range:
   minMeasurementValue: number | null;
   maxMeasurementValue: number | null;
   averageMeasurementValue: number | null;
+
   status: StatusEnum;
   error: ApiError | null;
   isLoading: boolean;
+
   lastSelectedTimeRange: FixedTimeRange;
+
+  // Dictionary: streamId -> array of measurements
   measurements: {
     [streamId: number]: Measurement[];
   };
@@ -62,14 +74,7 @@ const initialState: FixedStreamState = {
   measurements: {},
 };
 
-export interface Measurement {
-  time: number;
-  value: number;
-  latitude: number;
-  longitude: number;
-}
-
-// Thunk for fetching stream data by ID
+// Thunk: fetch one fixed stream by ID
 export const fetchFixedStreamById = createAsyncThunk<
   FixedStream,
   number,
@@ -90,14 +95,13 @@ export const fetchFixedStreamById = createAsyncThunk<
         endpoint: API_ENDPOINTS.fetchFixedStreamById(id),
       },
     };
-
     logError(error, apiError);
 
     return rejectWithValue(apiError);
   }
 });
 
-// Thunk for fetching measurements
+// Thunk: fetch measurements for a given [startTime, endTime]
 export const fetchMeasurements = createAsyncThunk(
   "fixedStream/fetchMeasurements",
   async (
@@ -125,24 +129,21 @@ export const fetchMeasurements = createAsyncThunk(
   }
 );
 
-// Reducer
 const fixedStreamSlice = createSlice({
   name: "fixedStream",
   initialState,
   reducers: {
+    // IMPORTANT: We now require the streamId in the payload
     updateFixedMeasurementExtremes(
       state,
-      action: PayloadAction<{ min: number; max: number }>
+      action: PayloadAction<{ streamId: number; min: number; max: number }>
     ) {
-      const { min, max } = action.payload;
-      let startTime = min;
-      let endTime = max;
+      const { streamId, min, max } = action.payload;
+      const allMeasurements = state.measurements[streamId] || [];
 
-      const values = state.data.measurements
-        .filter(
-          (measurement) =>
-            measurement.time >= startTime && measurement.time <= endTime
-        )
+      // Filter only the measurements in the [min, max] time range
+      const values = allMeasurements
+        .filter((m) => m.time >= min && m.time <= max)
         .map((m) => m.value);
 
       const newMin = values.length > 0 ? Math.min(...values) : 0;
@@ -156,20 +157,25 @@ const fixedStreamSlice = createSlice({
       state.maxMeasurementValue = newMax;
       state.averageMeasurementValue = newAvg;
     },
+
     resetFixedStreamState(state) {
       return initialState;
     },
+
     setLastSelectedTimeRange(state, action: PayloadAction<FixedTimeRange>) {
       state.lastSelectedTimeRange = action.payload;
       localStorage.setItem("lastSelectedTimeRange", action.payload);
     },
+
     resetLastSelectedTimeRange(state) {
       state.lastSelectedTimeRange = FixedTimeRange.Day;
       localStorage.setItem("lastSelectedTimeRange", FixedTimeRange.Day);
     },
+
     resetStreamMeasurements(state, action: PayloadAction<number>) {
       state.measurements[action.payload] = [];
     },
+
     updateStreamMeasurements(
       state,
       action: PayloadAction<{ streamId: number; measurements: Measurement[] }>
@@ -193,44 +199,45 @@ const fixedStreamSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
+    // ================ fetchFixedStreamById =================
     builder.addCase(fetchFixedStreamById.pending, (state) => {
       state.status = StatusEnum.Pending;
       state.error = null;
       state.isLoading = true;
     });
-    builder.addCase(
-      fetchFixedStreamById.fulfilled,
-      (state, action: PayloadAction<FixedStream>) => {
-        state.status = StatusEnum.Fulfilled;
-        state.data = action.payload;
-        state.isLoading = false;
-        state.error = null;
-      }
-    );
-    builder.addCase(
-      fetchFixedStreamById.rejected,
-      (state, action: PayloadAction<ApiError | undefined>) => {
-        state.status = StatusEnum.Rejected;
-        state.error = action.payload || { message: "Unknown error occurred" };
-        state.data = initialState.data;
-        state.isLoading = false;
-      }
-    );
+    builder.addCase(fetchFixedStreamById.fulfilled, (state, action) => {
+      state.status = StatusEnum.Fulfilled;
+      state.data = action.payload;
+      state.isLoading = false;
+      state.error = null;
+    });
+    builder.addCase(fetchFixedStreamById.rejected, (state, action) => {
+      state.status = StatusEnum.Rejected;
+      state.error = action.payload || {
+        message: "Unknown error occurred fetching stream",
+      };
+      state.data = initialState.data;
+      state.isLoading = false;
+    });
+
+    // ================ fetchMeasurements =================
     builder.addCase(fetchMeasurements.pending, (state, action) => {
+      // If it's not a background fetch, set loading status
       if (!action.meta.arg.isBackground) {
         state.status = StatusEnum.Pending;
         state.error = null;
         state.isLoading = true;
       }
     });
+
     builder.addCase(fetchMeasurements.fulfilled, (state, action) => {
+      // End loading if not a background fetch
       if (!action.meta.arg.isBackground) {
         state.status = StatusEnum.Fulfilled;
         state.isLoading = false;
         state.error = null;
       }
-
-      // Get streamId from the thunk arg
+      // Merge measurements
       const streamId = Number(action.meta?.arg?.streamId);
       if (streamId) {
         const existingMeasurements = state.measurements[streamId] || [];
@@ -250,18 +257,23 @@ const fixedStreamSlice = createSlice({
         }
       }
     });
+
     builder.addCase(fetchMeasurements.rejected, (state, action) => {
       state.status = StatusEnum.Rejected;
       state.error = {
-        message: action.error.message || "Unknown error occurred",
+        message:
+          (action.error && action.error.message) ||
+          "Unknown error occurred fetching measurements",
       };
       state.isLoading = false;
     });
   },
 });
 
+// Export the reducer
 export default fixedStreamSlice.reducer;
 
+// Export your actions
 export const {
   updateFixedMeasurementExtremes,
   resetFixedStreamState,
@@ -271,11 +283,14 @@ export const {
   updateStreamMeasurements,
 } = fixedStreamSlice.actions;
 
+// Selectors
 export const selectFixedData = (state: RootState) => state.fixedStream.data;
 export const selectIsLoading = (state: RootState) =>
   state.fixedStream.isLoading;
 export const selectLastSelectedFixedTimeRange = (state: RootState) =>
   state.fixedStream.lastSelectedTimeRange;
+
+// Grab the array of measurements from the dictionary
 export const selectStreamMeasurements = (
   state: RootState,
   streamId: number | null

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -128,7 +128,6 @@ const fixedStreamSlice = createSlice({
   name: "fixedStream",
   initialState,
   reducers: {
-    // IMPORTANT: We now require the streamId in the payload
     updateFixedMeasurementExtremes(
       state,
       action: PayloadAction<{ streamId: number; min: number; max: number }>
@@ -264,10 +263,8 @@ const fixedStreamSlice = createSlice({
   },
 });
 
-// Export the reducer
 export default fixedStreamSlice.reducer;
 
-// Export your actions
 export const {
   updateFixedMeasurementExtremes,
   resetFixedStreamState,

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -19,8 +19,6 @@ export interface Measurement {
 export interface FixedStreamState {
   data: FixedStream;
   fetchedStartTime: number | null;
-
-  // Values to be updated based on currently visible time range:
   minMeasurementValue: number | null;
   maxMeasurementValue: number | null;
   averageMeasurementValue: number | null;
@@ -28,10 +26,7 @@ export interface FixedStreamState {
   status: StatusEnum;
   error: ApiError | null;
   isLoading: boolean;
-
   lastSelectedTimeRange: FixedTimeRange;
-
-  // Dictionary: streamId -> array of measurements
   measurements: {
     [streamId: number]: Measurement[];
   };
@@ -290,7 +285,6 @@ export const selectIsLoading = (state: RootState) =>
 export const selectLastSelectedFixedTimeRange = (state: RootState) =>
   state.fixedStream.lastSelectedTimeRange;
 
-// Grab the array of measurements from the dictionary
 export const selectStreamMeasurements = (
   state: RootState,
   streamId: number | null

--- a/app/javascript/react/store/index.ts
+++ b/app/javascript/react/store/index.ts
@@ -19,7 +19,7 @@ import sessionFilterReducer from "./sessionFiltersSlice";
 import thresholdReducer from "./thresholdSlice";
 import timelapseReducer from "./timelapseSlice";
 
-export const store = configureStore({
+const store = configureStore({
   reducer: {
     cluster: clusterReducer,
     crowdMap: crowdMapReducer,

--- a/app/javascript/react/store/index.ts
+++ b/app/javascript/react/store/index.ts
@@ -19,7 +19,7 @@ import sessionFilterReducer from "./sessionFiltersSlice";
 import thresholdReducer from "./thresholdSlice";
 import timelapseReducer from "./timelapseSlice";
 
-const store = configureStore({
+export const store = configureStore({
   reducer: {
     cluster: clusterReducer,
     crowdMap: crowdMapReducer,


### PR DESCRIPTION
Changes made in this PR:
- The measurements shown in the graph are stored, which means that when navigating between pages, we no longer need to fetch additional data for the same time range.
- We have now retrieved just 2 days of measurements, accelerating the initial loading of the graph.
- Update minimum, maximum, and average values


Trello tasks:
https://trello.com/c/SoNoqkCD/2115-fixed-airbeam-pm25-view-station-slow-to-display
https://trello.com/c/KdOcpO2c/2120-mobile-device-fixed-govt-pm25-view-station-view-a-second-station-second-station-avg-min-max-are-inaccurate-they-are-the-same-as