### PR TITLE
Disabe 3D view in satelite mode, change export sessions error copy

### DIFF
--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -811,6 +811,7 @@ const Map = () => {
         isFractionalZoomEnabled={true}
         styles={memoizedMapStyles}
         onZoomChanged={handleZoomChanged}
+        tilt={0}
       >
         {fixedSessionsStatusFulfilled &&
           fixedSessionTypeSelected &&

--- a/app/javascript/react/locales/en/translation.json
+++ b/app/javascript/react/locales/en/translation.json
@@ -100,7 +100,7 @@
     "emailPlaceholder": "email address",
     "confirmationMessage": "Exported sessions will be emailed within minutes. The email may end up in your spam folder.",
     "invalidEmailMessage": "Please enter a valid email address.",
-    "sessionLimitMessage": "You can't export more than {{limit}} sessions at a time. Use the time frame filter to chunk your exports or use our API.",
+    "sessionLimitMessage": "You can't export more than {{limit}} sessions at a time. Use the filters to chunk your exports or use our API.",
     "noResultsMessage": "No results to export"
   },
   "calendarPage": {


### PR DESCRIPTION
Set `tilt: 0` in the GoogleMap component to prevent 3D view in satellite mode.
Change export more than 100 sessions error copy.