### PR TITLE
Display the data on the graph from the selected day

### DIFF
--- a/app/javascript/react/components/DayView/DayView.tsx
+++ b/app/javascript/react/components/DayView/DayView.tsx
@@ -1,17 +1,22 @@
 import React from "react";
 
-import * as S from "./DayView.style";
 import { Thresholds } from "../../types/thresholds";
+import * as S from "./DayView.style";
 
 interface DayViewProps {
   value: number;
   date: Date;
   thresholdsValues: Thresholds;
+  onClick?: (date: Date) => void;
 }
 
-const DayView = ({ value, date, thresholdsValues }: DayViewProps) => {
+const DayView = ({ value, date, thresholdsValues, onClick }: DayViewProps) => {
+  const handleClick = () => {
+    onClick?.(date);
+  };
+
   return (
-    <S.Container>
+    <S.Container onClick={handleClick}>
       <S.DesktopLabel>{value} (µg/m)</S.DesktopLabel>
       <S.BackgroundBarContainer
         $value={value}

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -406,21 +406,28 @@ const Graph: React.FC<GraphProps> = React.memo(
     useEffect(() => {
       if (selectedDate && chartComponentRef.current?.chart) {
         const chart = chartComponentRef.current.chart;
-        const startTime = selectedDate.getTime();
-        const endTime = startTime + MILLISECONDS_IN_A_DAY;
+        const dayStart = selectedDate.getTime();
+        const dayEnd = dayStart + MILLISECONDS_IN_A_DAY;
 
-        // Set the extremes to show the selected day
-        chart.xAxis[0].setExtremes(startTime, endTime);
+        // Fetch more data for context, but don't display it yet
+        const fetchStart = dayStart - MILLISECONDS_IN_A_DAY * 2;
+        const fetchEnd = dayEnd + MILLISECONDS_IN_A_DAY * 2;
 
-        // If we're in fixed session mode and have a streamId, fetch data just for this day
-        if (fixedSessionTypeSelected && streamId) {
-          fetchMeasurementsIfNeeded(
-            startTime, // Start of the day
-            endTime // End of the day
-          );
+        // Check if we have data for this day
+        const hasDataForSelectedDay = measurements.some(
+          (measurement) =>
+            measurement.time >= fetchStart && measurement.time < fetchEnd
+        );
+
+        // If no data found for this day, fetch it
+        if (!hasDataForSelectedDay && fixedSessionTypeSelected && streamId) {
+          fetchMeasurementsIfNeeded(fetchStart, fetchEnd);
         }
+
+        // Always set the view to exactly the selected day
+        chart.xAxis[0].setExtremes(dayStart, dayEnd);
       }
-    }, [selectedDate, streamId, fixedSessionTypeSelected]);
+    }, [selectedDate, streamId, fixedSessionTypeSelected, measurements]);
 
     return (
       <S.Container

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -401,13 +401,6 @@ const Graph: React.FC<GraphProps> = React.memo(
 
     // Add this effect to handle initial data load
     useEffect(() => {
-      console.log("Initial data load effect:", {
-        hasChart: !!chartComponentRef.current?.chart,
-        streamId,
-        measurements: measurements.length,
-        lastSelectedTimeRange,
-      });
-
       if (
         chartComponentRef.current?.chart &&
         streamId &&
@@ -430,13 +423,6 @@ const Graph: React.FC<GraphProps> = React.memo(
           } else if (lastSelectedTimeRange === FixedTimeRange.Month) {
             dayStart = latestTime - MILLISECONDS_IN_A_MONTH;
           }
-
-          console.log("Updating initial extremes:", {
-            dayStart: new Date(dayStart),
-            dayEnd: new Date(dayEnd),
-            measurementsCount: measurements.length,
-            selectedRange: lastSelectedTimeRange,
-          });
 
           dispatch(
             updateFixedMeasurementExtremes({
@@ -468,13 +454,18 @@ const Graph: React.FC<GraphProps> = React.memo(
 
     // Modify the selectedDateTimestamp effect
     useEffect(() => {
-      console.log("selectedDateTimestamp effect triggered:", {
-        selectedDateTimestamp,
+      console.log("Calendar date selection effect:", {
+        selectedDateTimestamp: selectedDateTimestamp
+          ? new Date(selectedDateTimestamp)
+          : null,
         hasChart: !!chartComponentRef.current?.chart,
-        streamId,
+        savedTimeRanges: savedTimeRanges.map((range) => ({
+          start: new Date(range.start),
+          end: new Date(range.end),
+        })),
+        isFetching: isFetchingSelectedDayRef.current,
         isInitialMount: isInitialMount.current,
         isInitialCalendar: isInitialCalendarOpen.current,
-        measurementsCount: measurements.length,
       });
 
       if (selectedDateTimestamp && chartComponentRef.current?.chart) {
@@ -503,22 +494,10 @@ const Graph: React.FC<GraphProps> = React.memo(
           999
         ).getTime();
 
-        console.log("Time ranges calculated:", {
-          monthStart: new Date(monthStart),
-          monthEnd: new Date(monthEnd),
-          savedTimeRanges,
-        });
-
         // Even on initial load, we should update the extremes
         if (chart && streamId) {
           const dayStart = selectedDateTimestamp;
           const dayEnd = selectedDateTimestamp + MILLISECONDS_IN_A_DAY;
-
-          console.log("Updating extremes on load:", {
-            dayStart: new Date(dayStart),
-            dayEnd: new Date(dayEnd),
-            streamId,
-          });
 
           dispatch(
             updateFixedMeasurementExtremes({

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -1,6 +1,7 @@
 import HighchartsReact from "highcharts-react-official";
 import Highcharts, { Chart } from "highcharts/highstock";
 import NoDataToDisplay from "highcharts/modules/no-data-to-display";
+import moment from "moment";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { white } from "../../assets/styles/colors";
@@ -73,7 +74,7 @@ interface GraphProps {
   streamId: number | null;
   isCalendarPage: boolean;
   rangeDisplayRef?: React.RefObject<HTMLDivElement>;
-  selectedDate?: Date;
+  selectedDateTimestamp?: number;
 }
 
 const Graph: React.FC<GraphProps> = React.memo(
@@ -82,7 +83,7 @@ const Graph: React.FC<GraphProps> = React.memo(
     sessionType,
     isCalendarPage,
     rangeDisplayRef,
-    selectedDate,
+    selectedDateTimestamp,
   }) => {
     const dispatch = useAppDispatch();
     const { t } = useTranslation();
@@ -413,14 +414,12 @@ const Graph: React.FC<GraphProps> = React.memo(
     const isFetchingSelectedDayRef = useRef(false);
 
     useEffect(() => {
-      if (selectedDate && chartComponentRef.current?.chart) {
+      if (selectedDateTimestamp && chartComponentRef.current?.chart) {
         const chart = chartComponentRef.current.chart;
-        const dayStart = selectedDate.getTime();
-        const dayEnd = dayStart + MILLISECONDS_IN_A_DAY;
 
         // Get the start and end of the selected month
-        const selectedMonth = selectedDate.getMonth();
-        const selectedYear = selectedDate.getFullYear();
+        const selectedMonth = moment(selectedDateTimestamp).month();
+        const selectedYear = moment(selectedDateTimestamp).year();
 
         const monthStart = new Date(
           selectedYear,
@@ -464,10 +463,14 @@ const Graph: React.FC<GraphProps> = React.memo(
         }
 
         // Always set the view to exactly the selected day
-        chart.xAxis[0].setExtremes(dayStart, dayEnd);
+
+        chart.xAxis[0].setExtremes(
+          selectedDateTimestamp,
+          selectedDateTimestamp + MILLISECONDS_IN_A_DAY
+        );
       }
     }, [
-      selectedDate,
+      selectedDateTimestamp,
       streamId,
       fixedSessionTypeSelected,
       savedTimeRanges,

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -412,11 +412,11 @@ const Graph: React.FC<GraphProps> = React.memo(
         // Set the extremes to show the selected day
         chart.xAxis[0].setExtremes(startTime, endTime);
 
-        // If we're in fixed session mode and have a streamId, fetch data if needed
+        // If we're in fixed session mode and have a streamId, fetch data just for this day
         if (fixedSessionTypeSelected && streamId) {
           fetchMeasurementsIfNeeded(
-            startTime - MILLISECONDS_IN_A_DAY * 15, // Fetch 15 days before
-            endTime + MILLISECONDS_IN_A_DAY * 15 // Fetch 15 days after
+            startTime, // Start of the day
+            endTime // End of the day
           );
         }
       }

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -49,7 +49,6 @@ import {
   createFixedSeriesData,
   createMobileSeriesData,
 } from "./chartHooks/createGraphData";
-import { useChartUpdater } from "./chartHooks/useChartUpdater";
 import { useMeasurementsFetcher } from "./chartHooks/useMeasurementsFetcher";
 import * as S from "./Graph.style";
 import {
@@ -160,16 +159,6 @@ const Graph: React.FC<GraphProps> = React.memo(
     let chartData: GraphData = seriesData as GraphData;
 
     const { fetchMeasurementsIfNeeded } = useMeasurementsFetcher(streamId);
-
-    const { updateChartData } = useChartUpdater({
-      chartComponentRef,
-      seriesData,
-      isLoading,
-      lastSelectedTimeRange,
-      fixedSessionTypeSelected,
-      streamId,
-      rangeDisplayRef,
-    });
 
     useEffect(() => {
       // Reset to 24-hour range on component mount

--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -403,6 +403,8 @@ const Graph: React.FC<GraphProps> = React.memo(
       };
     }, [dispatch, fixedSessionTypeSelected, streamId]);
 
+    const isFetchingSelectedDayRef = useRef(false);
+
     useEffect(() => {
       if (selectedDate && chartComponentRef.current?.chart) {
         const chart = chartComponentRef.current.chart;
@@ -419,9 +421,19 @@ const Graph: React.FC<GraphProps> = React.memo(
             measurement.time >= fetchStart && measurement.time < fetchEnd
         );
 
-        // If no data found for this day, fetch it
-        if (!hasDataForSelectedDay && fixedSessionTypeSelected && streamId) {
+        // If no data found for this day and not already fetching, fetch it
+        if (
+          !hasDataForSelectedDay &&
+          fixedSessionTypeSelected &&
+          streamId &&
+          !isFetchingSelectedDayRef.current
+        ) {
+          isFetchingSelectedDayRef.current = true;
           fetchMeasurementsIfNeeded(fetchStart, fetchEnd);
+          // Reset the flag after a delay to allow for next potential fetch
+          setTimeout(() => {
+            isFetchingSelectedDayRef.current = false;
+          }, 1000);
         }
 
         // Always set the view to exactly the selected day

--- a/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
+++ b/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
@@ -1,74 +1,49 @@
 import { debounce } from "lodash";
-import { useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { fetchMeasurements } from "../../../store/fixedStreamSlice";
 import { useAppDispatch } from "../../../store/hooks";
-import {
-  MILLISECONDS_IN_A_DAY,
-  MILLISECONDS_IN_A_MONTH,
-} from "../../../utils/timeRanges";
 
 export const useMeasurementsFetcher = (streamId: number | null) => {
-  const isCurrentlyFetchingRef = useRef(false);
-  const isInitialFetchRef = useRef(true);
-  const lastFetchedStartRef = useRef<number | null>(null);
   const dispatch = useAppDispatch();
+  const isFetchingRef = useRef(false);
 
-  const fetchChunk = async (start: number, end: number) => {
-    if (!streamId) return;
-
-    try {
-      await dispatch(
-        fetchMeasurements({
-          streamId: Number(streamId),
-          startTime: Math.floor(start).toString(),
-          endTime: Math.floor(end).toString(),
-        })
-      ).unwrap();
-
-      // Update last fetched start time after successful fetch
-      lastFetchedStartRef.current = start;
-    } catch (error) {
-      console.error("Error fetching chunk:", error);
-    }
-  };
-
-  const fetchMeasurementsIfNeeded = debounce(
+  const fetchData = useCallback(
     async (start: number, end: number) => {
-      if (!streamId || isCurrentlyFetchingRef.current) return;
+      if (!streamId || isFetchingRef.current) return;
 
       try {
-        isCurrentlyFetchingRef.current = true;
-
-        // For initial fetch, load two days of data
-        if (isInitialFetchRef.current) {
-          await fetchChunk(end - MILLISECONDS_IN_A_DAY * 2, end);
-          isInitialFetchRef.current = false;
-          return;
-        }
-
-        // For subsequent fetches, check if we need to load more data
-        if (
-          lastFetchedStartRef.current === null ||
-          start < lastFetchedStartRef.current
-        ) {
-          // Calculate the fetch window
-          const fetchStart = Math.min(
-            start,
-            lastFetchedStartRef.current
-              ? lastFetchedStartRef.current - MILLISECONDS_IN_A_MONTH
-              : end - MILLISECONDS_IN_A_MONTH
-          );
-
-          const fetchEnd = lastFetchedStartRef.current || end;
-
-          await fetchChunk(fetchStart, fetchEnd);
-        }
-      } finally {
-        isCurrentlyFetchingRef.current = false;
+        isFetchingRef.current = true;
+        await dispatch(
+          fetchMeasurements({
+            streamId,
+            startTime: start.toString(),
+            endTime: end.toString(),
+          })
+        ).unwrap();
+        // Add 1 second cooldown
+        setTimeout(() => {
+          isFetchingRef.current = false;
+        }, 1000);
+      } catch (error) {
+        console.error("Error fetching measurements:", error);
+        isFetchingRef.current = false;
       }
     },
-    300
-  ) as (start: number, end: number) => Promise<void>;
+    [dispatch, streamId]
+  );
+
+  const fetchMeasurementsIfNeeded = useMemo(
+    () => async (start: number, end: number) => {
+      return new Promise<void>((resolve) => {
+        const debouncedFetch = debounce(async () => {
+          await fetchData(start, end);
+          resolve();
+        }, 300);
+        debouncedFetch();
+      });
+    },
+    [fetchData]
+  );
 
   return { fetchMeasurementsIfNeeded };
 };

--- a/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
+++ b/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
@@ -23,7 +23,7 @@ export const useMeasurementsFetcher = (streamId: number | null) => {
         // Add 1 second cooldown
         setTimeout(() => {
           isFetchingRef.current = false;
-        }, 1000);
+        }, 2000);
       } catch (error) {
         console.error("Error fetching measurements:", error);
         isFetchingRef.current = false;

--- a/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
+++ b/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
@@ -23,7 +23,7 @@ export const useMeasurementsFetcher = (streamId: number | null) => {
         // Add 1 second cooldown
         setTimeout(() => {
           isFetchingRef.current = false;
-        }, 2000);
+        }, 1000);
       } catch (error) {
         console.error("Error fetching measurements:", error);
         isFetchingRef.current = false;

--- a/app/javascript/react/components/Graph/graphConfig.ts
+++ b/app/javascript/react/components/Graph/graphConfig.ts
@@ -160,6 +160,7 @@ const getXAxisOptions = (
             0,
             0
           ).getTime();
+
           const monthEnd = new Date(
             maxDate.getFullYear(),
             maxDate.getMonth() + 1,

--- a/app/javascript/react/components/Graph/graphConfig.ts
+++ b/app/javascript/react/components/Graph/graphConfig.ts
@@ -74,7 +74,7 @@ const getXAxisOptions = (
 ): Highcharts.XAxisOptions => {
   let isFetchingData = false;
   let initialDataMin: number | null = null;
-  const fetchTimeout: NodeJS.Timeout | null = null;
+  let isFirstLoad = true;
 
   const handleSetExtremes = debounce(
     (e: Highcharts.AxisSetExtremesEventObject) => {
@@ -156,6 +156,11 @@ const getXAxisOptions = (
 
         if (initialDataMin === null && e.dataMin !== undefined) {
           initialDataMin = e.dataMin - MILLISECONDS_IN_A_MONTH;
+        }
+
+        if (isFirstLoad && !e.trigger?.includes("scrollbar")) {
+          isFirstLoad = false;
+          return;
         }
 
         if (

--- a/app/javascript/react/components/Modals/SessionDetailsModal/SessionInfo/SessionInfo.tsx
+++ b/app/javascript/react/components/Modals/SessionDetailsModal/SessionInfo/SessionInfo.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 
+import { selectIsLoading } from "../../../../store";
 import {
   selectFixedExtremes,
   selectFixedStreamShortInfo,
@@ -11,8 +12,6 @@ import {
 } from "../../../../store/mobileStreamSelectors";
 import { selectThresholds } from "../../../../store/thresholdSlice";
 import { SessionType, SessionTypes } from "../../../../types/filters";
-import { FixedStreamShortInfo } from "../../../../types/fixedStream";
-import { MobileStreamShortInfo } from "../../../../types/mobileStream";
 import useMobileDetection from "../../../../utils/useScreenSizeDetection";
 import * as S from "../SessionDetailsModal.style";
 import ModalDesktopHeader from "./ModalDesktopHeader";
@@ -37,16 +36,24 @@ const SessionInfo: React.FC<SessionInfoProps> = ({
   );
   const isMobile = useMobileDetection();
 
-  const streamShortInfo: MobileStreamShortInfo | FixedStreamShortInfo =
-    useAppSelector(
-      fixedSessionTypeSelected
-        ? selectFixedStreamShortInfo
-        : selectMobileStreamShortInfo
-    );
+  const streamShortInfo = useAppSelector(
+    fixedSessionTypeSelected
+      ? selectFixedStreamShortInfo
+      : selectMobileStreamShortInfo
+  );
   const extremes = useAppSelector(
     fixedSessionTypeSelected ? selectFixedExtremes : selectMobileExtremes
   );
   const thresholds = useAppSelector(selectThresholds);
+  const isLoading = useAppSelector(selectIsLoading);
+
+  console.log("SessionInfo render:", {
+    streamId,
+    fixedSessionTypeSelected,
+    extremes,
+    streamShortInfo,
+    isLoading,
+  });
 
   const toggleVisibility = () => setIsVisible(!isVisible);
 

--- a/app/javascript/react/components/Modals/SessionDetailsModal/SessionInfo/SessionInfo.tsx
+++ b/app/javascript/react/components/Modals/SessionDetailsModal/SessionInfo/SessionInfo.tsx
@@ -47,14 +47,6 @@ const SessionInfo: React.FC<SessionInfoProps> = ({
   const thresholds = useAppSelector(selectThresholds);
   const isLoading = useAppSelector(selectIsLoading);
 
-  console.log("SessionInfo render:", {
-    streamId,
-    fixedSessionTypeSelected,
-    extremes,
-    streamShortInfo,
-    isLoading,
-  });
-
   const toggleVisibility = () => setIsVisible(!isVisible);
 
   const commonProps = {

--- a/app/javascript/react/components/molecules/Calendar/Calendar.tsx
+++ b/app/javascript/react/components/molecules/Calendar/Calendar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { MovesKeys } from "../../../types/movesKeys";
 import isMobile from "../../../utils/useScreenSizeDetection";
-import { Month } from "./atoms/Month";
+import { Month } from "./atoms/Month/Month";
 import { ScrollCalendarButton } from "./atoms/ScrollCalendarButton/ScrollCalendarButton";
 import * as S from "./Calendar.style";
 import useCalendarHook from "./CalendarHook";
@@ -13,12 +13,14 @@ interface CalendarProps {
   streamId: number;
   minCalendarDate: string;
   maxCalendarDate: string;
+  onDaySelect?: (date: Date) => void;
 }
 
 const Calendar: React.FC<CalendarProps> = ({
   streamId,
   minCalendarDate,
   maxCalendarDate,
+  onDaySelect,
 }) => {
   const {
     threeMonthsData,
@@ -76,13 +78,17 @@ const Calendar: React.FC<CalendarProps> = ({
     </>
   );
 
+  const handleDayClick = (date: Date) => {
+    onDaySelect?.(date);
+  };
+
   const CalendarContent = () => (
     <>
       {isMobileView && <MobileSwipeComponent />}
       <S.ThreeMonths>
         {!isMobileView && <DesktopSwipeComponent />}
         {sortedThreeMonthsData.map((month) => (
-          <Month key={month.monthName} {...month} />
+          <Month key={month.monthName} {...month} onDayClick={handleDayClick} />
         ))}
       </S.ThreeMonths>
     </>

--- a/app/javascript/react/components/molecules/Calendar/Calendar.tsx
+++ b/app/javascript/react/components/molecules/Calendar/Calendar.tsx
@@ -13,7 +13,7 @@ interface CalendarProps {
   streamId: number;
   minCalendarDate: string;
   maxCalendarDate: string;
-  onDaySelect?: (date: Date) => void;
+  onDaySelect?: (timestampDate: number) => void;
 }
 
 const Calendar: React.FC<CalendarProps> = ({
@@ -78,8 +78,8 @@ const Calendar: React.FC<CalendarProps> = ({
     </>
   );
 
-  const handleDayClick = (date: Date) => {
-    onDaySelect?.(date);
+  const handleDayClick = (timestampDate: number) => {
+    onDaySelect?.(timestampDate);
   };
 
   const CalendarContent = () => (

--- a/app/javascript/react/components/molecules/Calendar/Calendar.tsx
+++ b/app/javascript/react/components/molecules/Calendar/Calendar.tsx
@@ -79,6 +79,12 @@ const Calendar: React.FC<CalendarProps> = ({
   );
 
   const handleDayClick = (timestampDate: number) => {
+    console.log("Calendar day clicked:", {
+      date: new Date(timestampDate),
+      streamId,
+      minDate: minCalendarDate,
+      maxDate: maxCalendarDate,
+    });
     onDaySelect?.(timestampDate);
   };
 

--- a/app/javascript/react/components/molecules/Calendar/EmptyCalendar.tsx
+++ b/app/javascript/react/components/molecules/Calendar/EmptyCalendar.tsx
@@ -1,11 +1,11 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
-import { Month } from "./atoms/Month";
-import { useTranslation } from "react-i18next";
-import HeaderToggle from "./HeaderToggle/HeaderToggle";
 import { selectThreeMonthsDailyAverage } from "../../../store/movingStreamSelectors";
+import { Month } from "./atoms/Month/Month";
 import * as S from "./Calendar.style";
+import HeaderToggle from "./HeaderToggle/HeaderToggle";
 
 const EmptyCalendar = () => {
   const threeMonthsData = useSelector(selectThreeMonthsDailyAverage);
@@ -17,13 +17,11 @@ const EmptyCalendar = () => {
         <HeaderToggle
           titleText={t("calendarHeader.calendarTitle")}
           componentToToggle={
-            <>
-              <S.ThreeMonths>
-                {threeMonthsData.map((month) => (
-                  <Month key={month.monthName} {...month} />
-                ))}
-              </S.ThreeMonths>
-            </>
+            <S.ThreeMonths>
+              {threeMonthsData.map((month) => (
+                <Month key={month.monthName} {...month} onDayClick={() => {}} />
+              ))}
+            </S.ThreeMonths>
           }
         />
       </S.CalendarContainer>

--- a/app/javascript/react/components/molecules/Calendar/atoms/Day/Day.style.tsx
+++ b/app/javascript/react/components/molecules/Calendar/atoms/Day/Day.style.tsx
@@ -29,7 +29,6 @@ const Day = styled(CalendarCell)<DayProps>`
   justify-content: space-between;
   text-align: center;
   margin: 0 0 0.6rem 0;
-  //TODO: Ask Iwona about the opacity
   background-color: ${(props) => props.$color};
   width: 100%;
 
@@ -81,4 +80,4 @@ const Value = styled.div`
   text-overflow: ellipsis;
 `;
 
-export { Day, DayNumber, Value, CalendarCell, ValueContainer };
+export { CalendarCell, Day, DayNumber, Value, ValueContainer };

--- a/app/javascript/react/components/molecules/Calendar/atoms/Day/Day.tsx
+++ b/app/javascript/react/components/molecules/Calendar/atoms/Day/Day.tsx
@@ -5,7 +5,7 @@ import * as S from "./Day.style";
 
 interface DayProps {
   dayNumber: string;
-  value: number;
+  value: number | null;
   isCurrentMonth: boolean;
   date: Date;
   min: number;
@@ -19,13 +19,15 @@ interface DayProps {
 const Day = ({ dayNumber, value, date, onClick, ...thresholds }: DayProps) => {
   return (
     <S.Day
-      $color={getColorForValue(thresholds, value)}
-      onClick={onClick}
-      style={{ cursor: "pointer" }}
+      $color={
+        value !== null ? getColorForValue(thresholds, value) : "transparent"
+      }
+      onClick={value !== null ? onClick : undefined}
+      style={{ cursor: value !== null ? "pointer" : "default" }}
     >
       <S.DayNumber $isVisible={true}>{dayNumber}</S.DayNumber>
-      <S.ValueContainer $isVisible={true}>
-        <S.Value>{value}</S.Value>
+      <S.ValueContainer $isVisible={value !== null}>
+        <S.Value>{value ?? ""}</S.Value>
       </S.ValueContainer>
     </S.Day>
   );

--- a/app/javascript/react/components/molecules/Calendar/atoms/Day/Day.tsx
+++ b/app/javascript/react/components/molecules/Calendar/atoms/Day/Day.tsx
@@ -1,15 +1,28 @@
 import React from "react";
 
 import { getColorForValue } from "../../../../../utils/thresholdColors";
-import { CalendarCellData } from "../../../../../types/movingStream";
-import { Thresholds } from "../../../../../types/thresholds";
 import * as S from "./Day.style";
 
-interface DayProps extends CalendarCellData, Thresholds {}
+interface DayProps {
+  dayNumber: string;
+  value: number;
+  isCurrentMonth: boolean;
+  date: Date;
+  min: number;
+  low: number;
+  middle: number;
+  high: number;
+  max: number;
+  onClick?: () => void;
+}
 
-const Day = ({ dayNumber, value, date, ...thresholds }: DayProps) => {
+const Day = ({ dayNumber, value, date, onClick, ...thresholds }: DayProps) => {
   return (
-    <S.Day $color={getColorForValue(thresholds, value)}>
+    <S.Day
+      $color={getColorForValue(thresholds, value)}
+      onClick={onClick}
+      style={{ cursor: "pointer" }}
+    >
       <S.DayNumber $isVisible={true}>{dayNumber}</S.DayNumber>
       <S.ValueContainer $isVisible={true}>
         <S.Value>{value}</S.Value>

--- a/app/javascript/react/components/molecules/Calendar/atoms/Day/Day.tsx
+++ b/app/javascript/react/components/molecules/Calendar/atoms/Day/Day.tsx
@@ -19,15 +19,13 @@ interface DayProps {
 const Day = ({ dayNumber, value, date, onClick, ...thresholds }: DayProps) => {
   return (
     <S.Day
-      $color={
-        value !== null ? getColorForValue(thresholds, value) : "transparent"
-      }
+      $color={getColorForValue(thresholds, value)}
       onClick={value !== null ? onClick : undefined}
       style={{ cursor: value !== null ? "pointer" : "default" }}
     >
       <S.DayNumber $isVisible={true}>{dayNumber}</S.DayNumber>
-      <S.ValueContainer $isVisible={value !== null}>
-        <S.Value>{value ?? ""}</S.Value>
+      <S.ValueContainer $isVisible={true}>
+        <S.Value>{value}</S.Value>
       </S.ValueContainer>
     </S.Day>
   );

--- a/app/javascript/react/components/molecules/Calendar/atoms/Month/Month.tsx
+++ b/app/javascript/react/components/molecules/Calendar/atoms/Month/Month.tsx
@@ -2,12 +2,24 @@ import React from "react";
 import { useSelector } from "react-redux";
 
 import { selectThresholds } from "../../../../../store/thresholdSlice";
-import { CalendarMonthlyData } from "../../../../../types/movingStream";
+import { CalendarCellData } from "../../../../../types/calendar";
 import { Day } from "../Day";
 import { DayNamesHeader } from "../DayNamesHeader";
 import * as S from "./Month.style";
 
-const Month = ({ monthName, dayNamesHeader, weeks }: CalendarMonthlyData) => {
+interface MonthProps {
+  monthName: string;
+  dayNamesHeader: string[];
+  weeks: CalendarCellData[][];
+  onDayClick?: (date: Date) => void;
+}
+
+export const Month: React.FC<MonthProps> = ({
+  monthName,
+  dayNamesHeader,
+  weeks,
+  onDayClick,
+}) => {
   const thresholds = useSelector(selectThresholds);
 
   return (
@@ -16,9 +28,15 @@ const Month = ({ monthName, dayNamesHeader, weeks }: CalendarMonthlyData) => {
       <S.MonthContent>
         <DayNamesHeader dayNamesHeader={dayNamesHeader} />
         {weeks.map((week) => (
-          <S.Week key={week[0].date}>
+          <S.Week key={week[0].date.toISOString()}>
             {week.map((day) => (
-              <Day key={day.date} {...day} {...thresholds} />
+              <Day
+                key={day.date.toISOString()}
+                {...day}
+                {...thresholds}
+                dayNumber={day.date.getDate().toString()}
+                onClick={() => onDayClick?.(day.date)}
+              />
             ))}
           </S.Week>
         ))}
@@ -27,4 +45,4 @@ const Month = ({ monthName, dayNamesHeader, weeks }: CalendarMonthlyData) => {
   );
 };
 
-export { Month };
+export type { MonthProps };

--- a/app/javascript/react/components/molecules/Calendar/atoms/Month/Month.tsx
+++ b/app/javascript/react/components/molecules/Calendar/atoms/Month/Month.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
+import moment from "moment";
 import { selectThresholds } from "../../../../../store/thresholdSlice";
 import { CalendarCellData } from "../../../../../types/calendar";
 import { Day } from "../Day";
@@ -11,7 +12,7 @@ interface MonthProps {
   monthName: string;
   dayNamesHeader: string[];
   weeks: CalendarCellData[][];
-  onDayClick?: (date: Date) => void;
+  onDayClick?: (timestampDate: number) => void;
 }
 
 export const Month: React.FC<MonthProps> = ({
@@ -21,6 +22,12 @@ export const Month: React.FC<MonthProps> = ({
   onDayClick,
 }) => {
   const thresholds = useSelector(selectThresholds);
+
+  const timestampDayStart = (date: Date) => {
+    const selectedDayWithoutTime = moment(date).format("YYYY-MM-DD");
+    const dayStart = new Date(selectedDayWithoutTime).getTime();
+    return dayStart;
+  };
 
   return (
     <S.Month>
@@ -35,7 +42,7 @@ export const Month: React.FC<MonthProps> = ({
                 {...day}
                 {...thresholds}
                 dayNumber={day.date.getDate().toString()}
-                onClick={() => onDayClick?.(day.date)}
+                onClick={() => onDayClick?.(timestampDayStart(day.date))}
               />
             ))}
           </S.Week>

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -88,25 +88,29 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
       fixedStreamData.stream.startTime &&
       streamEndTime
     ) {
-      const startMoment = moment(fixedStreamData.stream.startTime);
-      const endMoment = moment(streamEndTime);
+      if (movingCalendarData.data.length === 0) {
+        const startMoment = moment(fixedStreamData.stream.startTime);
+        const endMoment = moment(streamEndTime);
 
-      if (startMoment.isValid() && endMoment.isValid()) {
-        const formattedEndDate = endMoment.format("YYYY-MM-DD");
-        const newStartDate = endMoment
-          .clone()
-          .date(1)
-          .subtract(2, "months")
-          .format("YYYY-MM-DD");
+        if (startMoment.isValid() && endMoment.isValid()) {
+          const formattedEndDate = endMoment.format("YYYY-MM-DD");
+          const newStartDate = endMoment
+            .clone()
+            .date(1)
+            .subtract(2, "months")
+            .format("YYYY-MM-DD");
 
-        dispatch(
-          fetchNewMovingStream({
-            id: streamId,
-            startDate: newStartDate,
-            endDate: formattedEndDate,
-          })
-        );
+          dispatch(
+            fetchNewMovingStream({
+              id: streamId,
+              startDate: newStartDate,
+              endDate: formattedEndDate,
+            })
+          );
 
+          setInitialDataFetched(true);
+        }
+      } else {
         setInitialDataFetched(true);
       }
     }
@@ -114,7 +118,14 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
     if (fixedStreamData.stream) {
       dispatch(setDefaultThresholdsValues(fixedStreamData.stream));
     }
-  }, [fixedStreamData, streamId, isLoading, streamEndTime, initialDataFetched]);
+  }, [
+    fixedStreamData,
+    streamId,
+    isLoading,
+    streamEndTime,
+    initialDataFetched,
+    movingCalendarData.data.length,
+  ]);
 
   useEffect(() => {
     setInitialDataFetched(false);

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -56,7 +56,9 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
   const { formattedMinTime, formattedMaxTime } = formatTime(startTime, endTime);
   const [errorMessage, setErrorMessage] = useState("");
   const [initialDataFetched, setInitialDataFetched] = useState(false);
-  const [selectedDate, setSelectedDate] = useState<Date | undefined>();
+  const [selectedDateTimestamp, setSelectedDateTimestamp] = useState<
+    number | undefined
+  >();
 
   const calendarIsVisible =
     movingCalendarData.data.length &&
@@ -118,9 +120,8 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
     setInitialDataFetched(false);
   }, [streamId]);
 
-  const handleDaySelect = (date: Date) => {
-    console.log("Day selected:", date);
-    setSelectedDate(date);
+  const handleDaySelect = (timestampDate: number) => {
+    setSelectedDateTimestamp(timestampDate);
   };
 
   const renderMobileGraph = () => (
@@ -147,7 +148,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
               sessionType={SessionTypes.FIXED}
               isCalendarPage={true}
               rangeDisplayRef={rangeDisplayRef}
-              selectedDate={selectedDate}
+              selectedDateTimestamp={selectedDateTimestamp}
             />
             <MeasurementComponent />
           </>
@@ -224,7 +225,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
             sessionType={SessionTypes.FIXED}
             isCalendarPage={true}
             rangeDisplayRef={rangeDisplayRef}
-            selectedDate={selectedDate}
+            selectedDateTimestamp={selectedDateTimestamp}
           />
         }
       />

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -56,6 +56,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
   const { formattedMinTime, formattedMaxTime } = formatTime(startTime, endTime);
   const [errorMessage, setErrorMessage] = useState("");
   const [initialDataFetched, setInitialDataFetched] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>();
 
   const calendarIsVisible =
     movingCalendarData.data.length &&
@@ -117,6 +118,11 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
     setInitialDataFetched(false);
   }, [streamId]);
 
+  const handleDaySelect = (date: Date) => {
+    console.log("Day selected:", date);
+    setSelectedDate(date);
+  };
+
   const renderMobileGraph = () => (
     <S.GraphContainer $isMobile={isMobile}>
       <HeaderToggle
@@ -141,6 +147,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
               sessionType={SessionTypes.FIXED}
               isCalendarPage={true}
               rangeDisplayRef={rangeDisplayRef}
+              selectedDate={selectedDate}
             />
             <MeasurementComponent />
           </>
@@ -217,6 +224,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
             sessionType={SessionTypes.FIXED}
             isCalendarPage={true}
             rangeDisplayRef={rangeDisplayRef}
+            selectedDate={selectedDate}
           />
         }
       />
@@ -236,6 +244,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
               streamId={streamId}
               minCalendarDate={fixedStreamData.stream.startTime}
               maxCalendarDate={streamEndTime}
+              onDaySelect={handleDaySelect}
             />
           ) : (
             <EmptyCalendar />

--- a/app/javascript/react/store/fixedStreamSelectors.ts
+++ b/app/javascript/react/store/fixedStreamSelectors.ts
@@ -26,12 +26,6 @@ const selectFixedExtremes = createSelector(
       maxMeasurementValue,
     } = fixedStream;
 
-    console.log("selectFixedExtremes called:", {
-      rawMin: minMeasurementValue,
-      rawMax: maxMeasurementValue,
-      rawAvg: averageMeasurementValue,
-    });
-
     const min = isValidValue(minMeasurementValue)
       ? Math.round(minMeasurementValue!)
       : null;
@@ -41,8 +35,6 @@ const selectFixedExtremes = createSelector(
     const avg = isValidValue(averageMeasurementValue)
       ? Math.round(averageMeasurementValue!)
       : null;
-
-    console.log("selectFixedExtremes returning:", { min, max, avg });
 
     return {
       minMeasurementValue: min,

--- a/app/javascript/react/store/fixedStreamSelectors.ts
+++ b/app/javascript/react/store/fixedStreamSelectors.ts
@@ -26,6 +26,12 @@ const selectFixedExtremes = createSelector(
       maxMeasurementValue,
     } = fixedStream;
 
+    console.log("selectFixedExtremes called:", {
+      rawMin: minMeasurementValue,
+      rawMax: maxMeasurementValue,
+      rawAvg: averageMeasurementValue,
+    });
+
     const min = isValidValue(minMeasurementValue)
       ? Math.round(minMeasurementValue!)
       : null;
@@ -35,6 +41,8 @@ const selectFixedExtremes = createSelector(
     const avg = isValidValue(averageMeasurementValue)
       ? Math.round(averageMeasurementValue!)
       : null;
+
+    console.log("selectFixedExtremes returning:", { min, max, avg });
 
     return {
       minMeasurementValue: min,

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -246,15 +246,6 @@ const fixedStreamSlice = createSlice({
       }, [] as Array<{ start: number; end: number }>);
 
       state.fetchedTimeRanges[streamId] = mergedRanges;
-
-      console.log("Merged Time Ranges:", {
-        streamId,
-        newRange: { start: new Date(start), end: new Date(end) },
-        mergedRanges: mergedRanges.map((range) => ({
-          start: new Date(range.start),
-          end: new Date(range.end),
-        })),
-      });
     },
   },
   extraReducers: (builder) => {
@@ -306,20 +297,8 @@ const fixedStreamSlice = createSlice({
           (a, b) => a.time - b.time
         );
 
-        console.log("Raw timestamps:", {
-          startTime: action.meta.arg.startTime,
-          endTime: action.meta.arg.endTime,
-        });
-
         const startTime = Number(action.meta.arg.startTime);
         const endTime = Number(action.meta.arg.endTime);
-
-        console.log("Parsed timestamps:", {
-          startTime,
-          endTime,
-          startDate: new Date(startTime),
-          endDate: new Date(endTime),
-        });
 
         if (!state.fetchedTimeRanges[streamId]) {
           state.fetchedTimeRanges[streamId] = [];
@@ -329,18 +308,6 @@ const fixedStreamSlice = createSlice({
           state.fetchedTimeRanges[streamId].push({
             start: startTime,
             end: endTime,
-          });
-
-          console.log("Fetched New Time Range:", {
-            streamId,
-            range: {
-              start: new Date(startTime),
-              end: new Date(endTime),
-            },
-            allRanges: state.fetchedTimeRanges[streamId].map((range) => ({
-              start: new Date(range.start),
-              end: new Date(range.end),
-            })),
           });
         } else {
           console.error("Failed to parse timestamps:", {

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -30,9 +30,6 @@ export interface FixedStreamState {
   error: ApiError | null;
   isLoading: boolean;
   lastSelectedTimeRange: FixedTimeRange;
-  measurements: {
-    [streamId: number]: FixedMeasurement[];
-  };
   fetchedTimeRanges: {
     [streamId: number]: Array<{
       start: number;
@@ -75,7 +72,6 @@ const initialState: FixedStreamState = {
   error: null,
   isLoading: false,
   lastSelectedTimeRange: FixedTimeRange.Day,
-  measurements: {},
   fetchedTimeRanges: {},
 };
 
@@ -170,11 +166,6 @@ const fixedStreamSlice = createSlice({
     resetLastSelectedTimeRange(state) {
       state.lastSelectedTimeRange = FixedTimeRange.Day;
       localStorage.setItem("lastSelectedTimeRange", FixedTimeRange.Day);
-    },
-
-    resetStreamMeasurements(state, action: PayloadAction<number>) {
-      state.measurements[action.payload] = [];
-      state.fetchedTimeRanges[action.payload] = [];
     },
 
     updateStreamMeasurements(
@@ -338,7 +329,6 @@ export const {
   resetFixedStreamState,
   setLastSelectedTimeRange,
   resetLastSelectedTimeRange,
-  resetStreamMeasurements,
   updateStreamMeasurements,
   resetFixedMeasurementExtremes,
   resetTimeRange,

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -138,16 +138,8 @@ const fixedStreamSlice = createSlice({
       const { min, max } = action.payload;
       const allMeasurements = state.data.measurements || [];
 
-      console.log("updateFixedMeasurementExtremes called:", {
-        min: new Date(min),
-        max: new Date(max),
-        measurementsCount: allMeasurements.length,
-        streamId: action.payload.streamId,
-      });
-
       // Ensure we have valid timestamps
       if (!min || !max || isNaN(min) || isNaN(max)) {
-        console.log("Invalid timestamps, skipping extremes update");
         return;
       }
 
@@ -155,26 +147,12 @@ const fixedStreamSlice = createSlice({
         .filter((m) => m.time >= min && m.time <= max)
         .map((m) => m.value);
 
-      console.log("Filtered measurements:", {
-        filteredCount: values.length,
-        firstValue: values[0],
-        lastValue: values[values.length - 1],
-        timeRange: `${new Date(min)} - ${new Date(max)}`,
-      });
-
       if (values.length > 0) {
         state.minMeasurementValue = Math.min(...values);
         state.maxMeasurementValue = Math.max(...values);
         state.averageMeasurementValue =
           values.reduce((sum, value) => sum + value, 0) / values.length;
-
-        console.log("Updated extremes:", {
-          min: state.minMeasurementValue,
-          max: state.maxMeasurementValue,
-          avg: state.averageMeasurementValue,
-        });
       } else {
-        console.log("No measurements found in range");
         state.minMeasurementValue = null;
         state.maxMeasurementValue = null;
         state.averageMeasurementValue = null;

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -138,16 +138,43 @@ const fixedStreamSlice = createSlice({
       const { min, max } = action.payload;
       const allMeasurements = state.data.measurements || [];
 
+      console.log("updateFixedMeasurementExtremes called:", {
+        min: new Date(min),
+        max: new Date(max),
+        measurementsCount: allMeasurements.length,
+        streamId: action.payload.streamId,
+      });
+
+      // Ensure we have valid timestamps
+      if (!min || !max || isNaN(min) || isNaN(max)) {
+        console.log("Invalid timestamps, skipping extremes update");
+        return;
+      }
+
       const values = allMeasurements
         .filter((m) => m.time >= min && m.time <= max)
         .map((m) => m.value);
+
+      console.log("Filtered measurements:", {
+        filteredCount: values.length,
+        firstValue: values[0],
+        lastValue: values[values.length - 1],
+        timeRange: `${new Date(min)} - ${new Date(max)}`,
+      });
 
       if (values.length > 0) {
         state.minMeasurementValue = Math.min(...values);
         state.maxMeasurementValue = Math.max(...values);
         state.averageMeasurementValue =
           values.reduce((sum, value) => sum + value, 0) / values.length;
+
+        console.log("Updated extremes:", {
+          min: state.minMeasurementValue,
+          max: state.maxMeasurementValue,
+          avg: state.averageMeasurementValue,
+        });
       } else {
+        console.log("No measurements found in range");
         state.minMeasurementValue = null;
         state.maxMeasurementValue = null;
         state.averageMeasurementValue = null;

--- a/app/javascript/react/store/fixedStreamSlice.ts
+++ b/app/javascript/react/store/fixedStreamSlice.ts
@@ -329,6 +329,7 @@ export const {
   resetFixedStreamState,
   setLastSelectedTimeRange,
   resetLastSelectedTimeRange,
+
   updateStreamMeasurements,
   resetFixedMeasurementExtremes,
   resetTimeRange,

--- a/app/javascript/react/store/movingStreamSelectors.ts
+++ b/app/javascript/react/store/movingStreamSelectors.ts
@@ -29,9 +29,9 @@ const prepareCalendarDataCell = (
   value: number | null
 ): CalendarCellData => {
   return {
-    date: date.format("YYYY-MM-DD"),
-    dayNumber: date.format("D"),
-    value,
+    date: date.toDate(),
+    value: value ?? 0,
+    isCurrentMonth: true,
   };
 };
 
@@ -148,5 +148,14 @@ const selectMovingCalendarMinMax = createSelector(
     return { min, max };
   }
 );
+
+const mapStreamDailyAverageToCalendarCell = (
+  streamDailyAverage: StreamDailyAverage,
+  isCurrentMonth: boolean
+): CalendarCellData => ({
+  date: new Date(streamDailyAverage.date),
+  value: streamDailyAverage.value ?? 0,
+  isCurrentMonth,
+});
 
 export { selectMovingCalendarMinMax, selectThreeMonthsDailyAverage };

--- a/app/javascript/react/store/movingStreamSelectors.ts
+++ b/app/javascript/react/store/movingStreamSelectors.ts
@@ -30,7 +30,7 @@ const prepareCalendarDataCell = (
 ): CalendarCellData => {
   return {
     date: date.toDate(),
-    value: value ?? 0,
+    value: value ?? null,
     isCurrentMonth: true,
   };
 };

--- a/app/javascript/react/types/calendar.ts
+++ b/app/javascript/react/types/calendar.ts
@@ -1,0 +1,5 @@
+export interface CalendarCellData {
+  date: Date;
+  value: number | null;
+  isCurrentMonth: boolean;
+}

--- a/app/javascript/react/types/movingStream.ts
+++ b/app/javascript/react/types/movingStream.ts
@@ -1,12 +1,8 @@
+import { CalendarCellData } from "./calendar";
+
 interface StreamDailyAverage {
   date: string;
   value: number;
-}
-
-interface CalendarCellData {
-  date: string;
-  dayNumber: string;
-  value: number | null;
 }
 
 interface CalendarMonthlyData {
@@ -15,4 +11,4 @@ interface CalendarMonthlyData {
   weeks: CalendarCellData[][];
 }
 
-export type { StreamDailyAverage, CalendarCellData, CalendarMonthlyData };
+export type { CalendarCellData, CalendarMonthlyData, StreamDailyAverage };

--- a/app/javascript/react/utils/measurementsCalc.ts
+++ b/app/javascript/react/utils/measurementsCalc.ts
@@ -18,12 +18,23 @@ export const calculateMeasurementStats = (
   return { min, max, avg };
 };
 
-export const isNoData = (...values: (number | null | undefined)[]): boolean => {
-  return values.some((value) => value === undefined || value === null);
+export const isNoData = (
+  min: number | null,
+  max: number | null,
+  avg: number | null
+): boolean => {
+  return (
+    min === null ||
+    max === null ||
+    avg === null ||
+    isNaN(min) ||
+    isNaN(max) ||
+    isNaN(avg)
+  );
 };
 
-export const isValidValue = (value: number | null | undefined): boolean => {
-  return value !== null && value !== undefined && isFinite(value);
+export const isValidValue = (value: number | null): boolean => {
+  return value !== null && !isNaN(value) && isFinite(value);
 };
 
 export const formatTime = (minTime: string | null, maxTime: string | null) => {


### PR DESCRIPTION
**Changes made in this PR:**

- Added functionality to display data on the graph for the selected day on the calendar.
- When a user clicks on a day, the graph will show 24 hours of data for that specific day.
- If no data is available for the selected day, we will fetch data from a broader range to provide context, while still displaying the information specifically for the chosen day.

[Trello task ](https://trello.com/c/X4NQ3r10/1980-calendar-click-on-date-and-the-graph-updates-to-show-that-24-hr-period)