### PR TITLE
Change last update date to display end date in local time

### DIFF
--- a/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
+++ b/app/javascript/react/components/molecules/FixedStreamStationHeader/FixedStreamStationHeader.tsx
@@ -1,15 +1,15 @@
+import moment from "moment";
 import React from "react";
 import { useSelector } from "react-redux";
-import moment from "moment";
 
-import { ValueLabel } from "./atoms/ValueLabel";
-import { StationName } from "./atoms/StationName";
-import { DataSource } from "./atoms/DataSource";
-import { StreamUpdate } from "./atoms/StreamUpdate";
-import { StationActionButtons } from "./atoms/StationActionButtons";
 import { selectFixedStreamShortInfo } from "../../../store/fixedStreamSelectors";
-import * as S from "./FixedStreamStationHeader.style";
 import { DateFormat } from "../../../types/dateFormat";
+import { DataSource } from "./atoms/DataSource";
+import { StationActionButtons } from "./atoms/StationActionButtons";
+import { StationName } from "./atoms/StationName";
+import { StreamUpdate } from "./atoms/StreamUpdate";
+import { ValueLabel } from "./atoms/ValueLabel";
+import * as S from "./FixedStreamStationHeader.style";
 
 const FixedStreamStationHeader = () => {
   const {
@@ -27,8 +27,7 @@ const FixedStreamStationHeader = () => {
     endTime,
   } = useSelector(selectFixedStreamShortInfo);
 
-  const streamEndTime: string =
-    endTime ?? lastUpdate ?? moment().format(DateFormat.default);
+  const streamEndTime: string = endTime ?? moment().format(DateFormat.default);
 
   return (
     <S.GridContainer>

--- a/app/javascript/react/store/fixedStreamSelectors.ts
+++ b/app/javascript/react/store/fixedStreamSelectors.ts
@@ -58,7 +58,7 @@ const selectFixedStreamShortInfo = createSelector(
 
     const lastMeasurementDateLabel = moment(date).format("MMM D");
     const lastUpdate = moment
-      .utc(fixedStreamData.stream.lastUpdate)
+      .utc(fixedStreamData.stream.endTime)
 
       .format("HH:mm MMM D YYYY");
     const startTime = moment


### PR DESCRIPTION
Issue: for the government data we receive the last update date in local time, but for the Airbeams we receive that value in the UTC. It would be changed on the backend, for now we use `endTime` to display the last update.