### PR TITLE
Add reuseMaps in GoogleMap component

### DIFF
--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -812,6 +812,7 @@ const Map = () => {
         styles={memoizedMapStyles}
         onZoomChanged={handleZoomChanged}
         tilt={0}
+        reuseMaps={true}
       >
         {fixedSessionsStatusFulfilled &&
           fixedSessionTypeSelected &&


### PR DESCRIPTION
Add `reuseMaps` to the Map component to reuse the same google.maps.Map instance instead of tearing it down and creating a new one each time its parent component re-mounts or re-renders. That helps with the problem of the map not loading sometimes.