### PR TITLE
Change text in the mobile/fixed filters desciption

### DIFF
--- a/app/javascript/react/locales/en/translation.json
+++ b/app/javascript/react/locales/en/translation.json
@@ -190,7 +190,7 @@
     "fixedSessions": "fixed",
     "editFilters": "edit filters",
     "showSessions": "show sessions",
-    "mobileFixedInfo": "The mobile tab displays measurements from mobile sessions. When recording mobile sessions, measurements are created, timestamped, and geolocated once per second. Average values for the duration of the session are displayed inside the session map markers. The fixed tab displays measurements from fixed sessions. When recording fixed sessions, geocoordinates are fixed to a set location. The most recent measurement is displayed inside the session map markers.",
+    "mobileFixedInfo": "The mobile tab displays measurements from mobile sessions. When recording mobile sessions, measurements are created, timestamped, and geolocated once per second. Average values for the duration of the session are displayed inside the mobile session map markers. The fixed tab displays measurements from fixed sessions. When recording fixed sessions, geocoordinates are fixed to a set location. The most recent 1 hr avg is displayed inside the fixed session map markers.",
 
     "profileNamesInfo": "Enter a profile name or names to filter the sessions by profile name.",
     "tagNamesInfo": "Enter a tag or tags to filter the sessions by tags. Tags are keywords assigned to sessions.",


### PR DESCRIPTION
Update the descirption for the "mobile/fixed" filters:

“ . . . Average values for the duration of the session are displayed inside the mobile session map markers”

“ . . . The most recent 1 hr avg is displayed inside the fixed session map markers.”