### PR TITLE
Fix dormant session graph not displayed

### DIFF
--- a/app/javascript/react/components/Graph/Graph.tsx
+++ b/app/javascript/react/components/Graph/Graph.tsx
@@ -37,7 +37,6 @@ import {
   mapIndexToTimeRange,
 } from "../../utils/getTimeRange";
 import { useMapParams } from "../../utils/mapParamsHandler";
-import { MILLISECONDS_IN_A_WEEK } from "../../utils/timeRanges";
 import useMobileDetection from "../../utils/useScreenSizeDetection";
 import { handleLoad } from "./chartEvents";
 import {
@@ -201,14 +200,6 @@ const Graph: React.FC<GraphProps> = React.memo(
         dispatch(resetLastSelectedMobileTimeRange());
       }
     }, []);
-
-    useEffect(() => {
-      if (streamId && fixedSessionTypeSelected && !measurements.length) {
-        // Only fetch if we don't have data for this stream
-        const now = Date.now();
-        fetchMeasurementsIfNeeded(now - MILLISECONDS_IN_A_WEEK, now);
-      }
-    }, [streamId, fixedSessionTypeSelected, measurements.length]);
 
     // Apply touch action to the graph container for mobile devices in Calendar page
     useEffect(() => {

--- a/app/javascript/react/components/Graph/chartHooks/createGraphData.ts
+++ b/app/javascript/react/components/Graph/chartHooks/createGraphData.ts
@@ -1,13 +1,16 @@
-import { Measurement } from "../../../store/fixedStreamSlice";
+import { FixedMeasurement } from "../../../store/fixedStreamSlice";
 import { LatLngLiteral } from "../../../types/googleMaps";
+import { Measurement } from "../../../types/mobileStream";
 import { FixedSession, MobileSession } from "../../../types/sessionType";
 
-export const isValidMeasurement = (m: Measurement): m is Measurement => {
+export const isValidMeasurement = (
+  m: FixedMeasurement
+): m is FixedMeasurement => {
   return m.time !== undefined && m.value !== undefined;
 };
 
 export const createFixedSeriesData = (
-  measurements: Measurement[] | undefined
+  measurements: FixedMeasurement[] | undefined
 ) =>
   measurements
     ?.filter(isValidMeasurement)

--- a/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
+++ b/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
@@ -6,7 +6,6 @@ import { MILLISECONDS_IN_A_MONTH } from "../../../utils/timeRanges";
 
 export const useMeasurementsFetcher = (streamId: number | null) => {
   const isCurrentlyFetchingRef = useRef(false);
-  const isInitialFetchRef = useRef(true);
   const lastFetchedStartRef = useRef<number | null>(null);
   const dispatch = useAppDispatch();
 

--- a/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
+++ b/app/javascript/react/components/Graph/chartHooks/useMeasurementsFetcher.ts
@@ -2,10 +2,7 @@ import { debounce } from "lodash";
 import { useRef } from "react";
 import { fetchMeasurements } from "../../../store/fixedStreamSlice";
 import { useAppDispatch } from "../../../store/hooks";
-import {
-  MILLISECONDS_IN_A_DAY,
-  MILLISECONDS_IN_A_MONTH,
-} from "../../../utils/timeRanges";
+import { MILLISECONDS_IN_A_MONTH } from "../../../utils/timeRanges";
 
 export const useMeasurementsFetcher = (streamId: number | null) => {
   const isCurrentlyFetchingRef = useRef(false);
@@ -38,13 +35,6 @@ export const useMeasurementsFetcher = (streamId: number | null) => {
 
       try {
         isCurrentlyFetchingRef.current = true;
-
-        // For initial fetch, load two days of data
-        if (isInitialFetchRef.current) {
-          await fetchChunk(end - MILLISECONDS_IN_A_DAY * 2, end);
-          isInitialFetchRef.current = false;
-          return;
-        }
 
         // For subsequent fetches, check if we need to load more data
         if (

--- a/app/javascript/react/components/Map/Map.tsx
+++ b/app/javascript/react/components/Map/Map.tsx
@@ -30,6 +30,7 @@ import {
 import {
   fetchFixedStreamById,
   resetFixedStreamState,
+  selectFixedData,
 } from "../../store/fixedStreamSlice";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import { selectIndoorSessionsList } from "../../store/indoorSessionsSelectors";
@@ -196,6 +197,8 @@ const Map = () => {
       return selectMobileSessionsList(state);
     }
   });
+
+  const fixedStreamData = useAppSelector(selectFixedData);
 
   const memoizedMapStyles = useMemo(() => mapStyles, []);
 
@@ -476,7 +479,11 @@ const Map = () => {
   }, [mapInstance, previousUserSettings]);
 
   useEffect(() => {
-    if (streamId && currentUserSettings === UserSettings.ModalView) {
+    if (
+      streamId &&
+      currentUserSettings === UserSettings.ModalView &&
+      !fixedStreamData.measurements.length
+    ) {
       fixedSessionTypeSelected
         ? dispatch(fetchFixedStreamById(streamId))
         : dispatch(fetchMobileStreamById(streamId));

--- a/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
+++ b/app/javascript/react/pages/CalendarPage/CalendarPage.tsx
@@ -67,7 +67,7 @@ const CalendarPage: React.FC<CalendarPageProps> = ({ children }) => {
     moment().format("YYYY-MM-DD");
 
   useEffect(() => {
-    if (streamId) {
+    if (streamId && !fixedStreamData.measurements.length) {
       dispatch(fetchFixedStreamById(streamId));
     }
   }, [streamId]);

--- a/app/javascript/react/types/fixedStream.ts
+++ b/app/javascript/react/types/fixedStream.ts
@@ -1,3 +1,5 @@
+import { FixedMeasurement } from "../store/fixedStreamSlice";
+
 interface StreamUpdate {
   lastUpdate: string | null;
   updateFrequency: string;
@@ -23,11 +25,6 @@ interface FixedStreamStationInfo extends StreamUpdate, DataSource {
   latitude: number;
   longitude: number;
   firstMeasurementTime: number;
-}
-
-interface FixedMeasurement {
-  time: number;
-  value: number;
 }
 
 interface StreamDailyAverage {

--- a/app/javascript/react/types/mobileStream.ts
+++ b/app/javascript/react/types/mobileStream.ts
@@ -46,4 +46,9 @@ interface MobileGraphData {
   measurementType: string;
 }
 
-export type { MobileGraphData, MobileStream, MobileStreamShortInfo };
+export type {
+  Measurement,
+  MobileGraphData,
+  MobileStream,
+  MobileStreamShortInfo,
+};

--- a/app/repositories/measurements_repository.rb
+++ b/app/repositories/measurements_repository.rb
@@ -1,6 +1,6 @@
 class MeasurementsRepository
   def from_last_24_hours(stream_id:)
-    Measurement.where(stream_id: stream_id).reorder(time: :desc).limit(2880)
+    Measurement.where(stream_id: stream_id).reorder(time: :desc).limit(1440)
   end
 
   def stream_daily_average_value(stream_id:, time_with_time_zone:)

--- a/app/repositories/measurements_repository.rb
+++ b/app/repositories/measurements_repository.rb
@@ -1,6 +1,6 @@
 class MeasurementsRepository
   def from_last_24_hours(stream_id:)
-    Measurement.where(stream_id: stream_id).reorder(time: :desc).limit(1440)
+    Measurement.where(stream_id: stream_id).reorder(time: :desc).limit(2880)
   end
 
   def stream_daily_average_value(stream_id:, time_with_time_zone:)


### PR DESCRIPTION
Change the logic for fetching Fixed Stream data.

1. At first load we fetch measurements using "/fixed_streams/" endpoint and store them (Two days of data).
2. When more data is needed, we fetch them (1 month of data) using "/measurements" endpoint and add it to the already fetched measurements in the store.
3. When going to the calendar and back we don't call "/fixed_streams/" as this data is already in the store.