### PR TITLE
Change the width of the Session List Containter on Firefox

### DIFF
--- a/app/javascript/react/components/SessionsListView/SessionsListView.style.tsx
+++ b/app/javascript/react/components/SessionsListView/SessionsListView.style.tsx
@@ -48,10 +48,6 @@ const SessionListContainer = styled.div`
   top: 5rem;
   max-height: calc(100vh - 22rem);
 
-  @-moz-document url-prefix() {
-    width: calc(100% + 2rem);
-  }
-
   &::-webkit-scrollbar-button:end:decrement {
     padding-bottom: 1rem;
   }


### PR DESCRIPTION
The scrollbar on the Firefox in browser was obscure, because of the width of the Session List Container.