### PR TITLE
Adjust time handling in measurements endpoint

### DIFF
--- a/app/services/api/to_measurements_array.rb
+++ b/app/services/api/to_measurements_array.rb
@@ -18,15 +18,12 @@ class Api::ToMeasurementsArray
   end
 
   def page
-    stream_id = form.to_h[:stream_ids]
-    stream = Stream.includes(:session).find(stream_id)
-
-    start_time = parsed_time(form.to_h[:start_time], stream.session.time_zone)
-    end_time = parsed_time(form.to_h[:end_time], stream.session.time_zone)
+    start_time = Time.at(form.to_h[:start_time] / 1_000)
+    end_time = Time.at(form.to_h[:end_time] / 1_000)
 
     Measurement
       .with_streams(form.to_h[:stream_ids].split(','))
-      .where(time_with_time_zone: start_time..end_time)
+      .where(time: start_time..end_time)
   end
 
   def all
@@ -40,9 +37,5 @@ class Api::ToMeasurementsArray
       latitude: measurement.latitude,
       longitude: measurement.longitude,
     }
-  end
-
-  def parsed_time(time, time_zone)
-    Time.at(time / 1_000).in_time_zone(time_zone)
   end
 end


### PR DESCRIPTION
Get back to assumption that parameters refer to measurements local time.