### PR TITLE
Fix failing specs

### DIFF
--- a/app/serializers/stream_serializer.rb
+++ b/app/serializers/stream_serializer.rb
@@ -3,7 +3,6 @@ class StreamSerializer
     update_frequency =
       stream.session.username == 'US EPA AirNow' ? '1 hour' : '1 minute'
     thresholds = Stream.thresholds(stream.sensor_name, stream.unit_symbol)
-    first_measurement = Measurement.where(stream_id: stream.id).first
 
     {
       active: stream.session.is_active,
@@ -19,8 +18,6 @@ class StreamSerializer
       session_id: stream.session.id,
       end_time: stream.session.end_time_local,
       start_time: stream.session.start_time_local,
-      first_measurement_time:
-        first_measurement ? first_measurement.time.to_i * 1_000 : nil,
       min: thresholds.threshold_very_low,
       low: thresholds.threshold_low,
       middle: thresholds.threshold_medium,

--- a/spec/controllers/api/fixed/active/sessions_controller_spec.rb
+++ b/spec/controllers/api/fixed/active/sessions_controller_spec.rb
@@ -91,9 +91,12 @@ describe Api::Fixed::Active::SessionsController do
                 'start_longitude' => active_stream.start_longitude,
                 'threshold_high' => active_stream.threshold_set.threshold_high,
                 'threshold_low' => active_stream.threshold_set.threshold_low,
-                'threshold_medium' => active_stream.threshold_set.threshold_medium,
-                'threshold_very_high' => active_stream.threshold_set.threshold_very_high,
-                'threshold_very_low' => active_stream.threshold_set.threshold_very_low,
+                'threshold_medium' =>
+                  active_stream.threshold_set.threshold_medium,
+                'threshold_very_high' =>
+                  active_stream.threshold_set.threshold_very_high,
+                'threshold_very_low' =>
+                  active_stream.threshold_set.threshold_very_low,
                 'unit_name' => active_stream.unit_name,
                 'unit_symbol' => active_stream.unit_symbol,
               },
@@ -138,8 +141,7 @@ describe Api::Fixed::Active::SessionsController do
           latitude: active_session.latitude,
           longitude: active_session.longitude,
         )
-      daily_stream_average =
-        create_stream_daily_average!(stream: active_stream)
+      daily_stream_average = create_stream_daily_average!(stream: active_stream)
 
       create_measurement!(stream: dormant_stream)
 
@@ -179,6 +181,7 @@ describe Api::Fixed::Active::SessionsController do
             'title' => active_session.title,
             'is_active' => active_session.is_active,
             'username' => active_session.user.username,
+            'last_hourly_average_value' => nil,
             'streams' => {
               active_stream.sensor_name => {
                 'measurement_short_type' =>
@@ -229,8 +232,7 @@ describe Api::Fixed::Active::SessionsController do
           longitude: active_session.longitude,
           sensor_name: 'Government-PM2.5',
         )
-      daily_stream_average =
-        create_stream_daily_average!(stream: active_stream)
+      daily_stream_average = create_stream_daily_average!(stream: active_stream)
 
       create_measurement!(stream: dormant_stream)
 
@@ -270,6 +272,7 @@ describe Api::Fixed::Active::SessionsController do
             'title' => active_session.title,
             'is_active' => active_session.is_active,
             'username' => active_session.user.username,
+            'last_hourly_average_value' => nil,
             'streams' => {
               active_stream.sensor_name => {
                 'measurement_short_type' =>
@@ -352,6 +355,7 @@ describe Api::Fixed::Active::SessionsController do
             'title' => session.title,
             'username' => session.user.username,
             'is_active' => session.is_active,
+            'last_hourly_average_value' => nil,
             'streams' => {
               queried_stream.sensor_name => {
                 'measurement_short_type' =>
@@ -403,15 +407,16 @@ describe Api::Fixed::Active::SessionsController do
   end
 
   def create_stream!(session:, latitude:, longitude:, sensor_name: 'AirBeam2-F')
-    threshold_set = ThresholdSet.create!(
-      threshold_very_low: 20,
-      threshold_low: 60,
-      threshold_medium: 70,
-      threshold_high: 80,
-      threshold_very_high: 100,
-      unit_symbol: 'F',
-      sensor_name: sensor_name,
-    )
+    threshold_set =
+      ThresholdSet.create!(
+        threshold_very_low: 20,
+        threshold_low: 60,
+        threshold_medium: 70,
+        threshold_high: 80,
+        threshold_very_high: 100,
+        unit_symbol: 'F',
+        sensor_name: sensor_name,
+      )
 
     Stream.create!(
       session: session,
@@ -439,7 +444,7 @@ describe Api::Fixed::Active::SessionsController do
       value: 123,
       milliseconds: 123,
       stream: stream,
-      location: "SRID=4326;POINT(123 123)",
+      location: 'SRID=4326;POINT(123 123)',
     )
   end
 end

--- a/spec/controllers/api/realtime/sessions_controller_spec.rb
+++ b/spec/controllers/api/realtime/sessions_controller_spec.rb
@@ -6,11 +6,26 @@ describe Api::Realtime::SessionsController do
     let!(:user) { create_user! }
     let!(:start_time_local) { DateTime.new(2000, 10, 1, 2, 3) }
     let!(:end_time_local) { DateTime.new(2001, 11, 4, 5, 6) }
-    let!(:session) { create_fixed_session!(user: user, title: title, start_time_local: start_time_local, end_time_local: end_time_local) }
-    let!(:stream) { create_stream!(session: session, sensor_name: 'sensor-name') }
-    let!(:other_stream) { create_stream!(session: session, sensor_name: 'yet another-sensor-name') }
-    let!(:measurement) { create_measurement!(stream: stream, time: start_time_local) }
-    let!(:other_measurement) { create_measurement!(stream: other_stream, time: start_time_local) }
+    let!(:session) do
+      create_fixed_session!(
+        user: user,
+        title: title,
+        start_time_local: start_time_local,
+        end_time_local: end_time_local,
+      )
+    end
+    let!(:stream) do
+      create_stream!(session: session, sensor_name: 'sensor-name')
+    end
+    let!(:other_stream) do
+      create_stream!(session: session, sensor_name: 'yet another-sensor-name')
+    end
+    let!(:measurement) do
+      create_measurement!(stream: stream, time: start_time_local)
+    end
+    let!(:other_measurement) do
+      create_measurement!(stream: other_stream, time: start_time_local)
+    end
 
     context 'when last_measurement_sync is before measurements creation' do
       let(:last_measurement_sync) { '1999-05-11T17:09:02' }
@@ -22,10 +37,15 @@ describe Api::Realtime::SessionsController do
       it 'returns session as synchronizable' do
         session.update!(last_measurement_at: other_measurement.time)
 
-        get :sync_measurements, params: { uuid: session.uuid, last_measurement_sync: last_measurement_sync }
+        get :sync_measurements,
+            params: {
+              uuid: session.uuid,
+              last_measurement_sync: last_measurement_sync,
+            }
 
         actual_response = json_response.deep_symbolize_keys
-        actual_response[:streams] = actual_response[:streams].transform_keys(&:to_sym)
+        actual_response[:streams] =
+          actual_response[:streams].transform_keys(&:to_sym)
 
         expected_response = {
           id: session.id,
@@ -46,7 +66,7 @@ describe Api::Realtime::SessionsController do
           last_measurement_at: session.last_measurement_at.iso8601(3),
           version: session.version,
           time_zone: session.time_zone,
-          tag_list: "",
+          tag_list: '',
           type: session.type,
           streams: {
             stream.sensor_name.to_sym => {
@@ -73,6 +93,7 @@ describe Api::Realtime::SessionsController do
               start_longitude: stream.start_longitude.to_f,
               start_latitude: stream.start_latitude.to_f,
               size: stream.size,
+              last_hourly_average_id: nil,
               measurements: [
                 {
                   id: measurement.id,
@@ -84,7 +105,8 @@ describe Api::Realtime::SessionsController do
                   milliseconds: measurement.milliseconds,
                   measured_value: measurement.measured_value,
                   location: measurement.location.to_s,
-                  time_with_time_zone: measurement.time_with_time_zone.iso8601(3),
+                  time_with_time_zone:
+                    measurement.time_with_time_zone.iso8601(3),
                 },
               ],
             },
@@ -99,7 +121,8 @@ describe Api::Realtime::SessionsController do
               threshold_very_low: other_stream.threshold_set.threshold_very_low,
               threshold_low: other_stream.threshold_set.threshold_low,
               threshold_high: other_stream.threshold_set.threshold_high,
-              threshold_very_high: other_stream.threshold_set.threshold_very_high,
+              threshold_very_high:
+                other_stream.threshold_set.threshold_very_high,
               threshold_medium: other_stream.threshold_set.threshold_medium,
               session_id: other_stream.session_id,
               sensor_package_name: other_stream.sensor_package_name,
@@ -112,6 +135,7 @@ describe Api::Realtime::SessionsController do
               start_longitude: other_stream.start_longitude.to_f,
               start_latitude: other_stream.start_latitude.to_f,
               size: other_stream.size,
+              last_hourly_average_id: nil,
               measurements: [
                 {
                   id: other_measurement.id,
@@ -123,7 +147,8 @@ describe Api::Realtime::SessionsController do
                   milliseconds: other_measurement.milliseconds,
                   measured_value: other_measurement.measured_value,
                   location: other_measurement.location.to_s,
-                  time_with_time_zone: other_measurement.time_with_time_zone.iso8601(3),
+                  time_with_time_zone:
+                    other_measurement.time_with_time_zone.iso8601(3),
                 },
               ],
             },
@@ -143,10 +168,15 @@ describe Api::Realtime::SessionsController do
 
       it 'returns session as synchronizable' do
         session.update!(last_measurement_at: other_measurement.time)
-        get :sync_measurements, params: { uuid: session.uuid, last_measurement_sync: last_measurement_sync }
+        get :sync_measurements,
+            params: {
+              uuid: session.uuid,
+              last_measurement_sync: last_measurement_sync,
+            }
 
         actual_response = json_response.deep_symbolize_keys
-        actual_response[:streams] = actual_response[:streams].transform_keys(&:to_sym)
+        actual_response[:streams] =
+          actual_response[:streams].transform_keys(&:to_sym)
 
         expected_response = {
           id: session.id,
@@ -167,7 +197,7 @@ describe Api::Realtime::SessionsController do
           last_measurement_at: session.last_measurement_at.iso8601(3),
           version: session.version,
           time_zone: session.time_zone,
-          tag_list: "",
+          tag_list: '',
           type: session.type,
           streams: {
             stream.sensor_name.to_sym => {
@@ -194,6 +224,7 @@ describe Api::Realtime::SessionsController do
               start_longitude: stream.start_longitude.to_f,
               start_latitude: stream.start_latitude.to_f,
               size: stream.size,
+              last_hourly_average_id: nil,
               measurements: [],
             },
             other_stream.sensor_name.to_sym => {
@@ -207,7 +238,8 @@ describe Api::Realtime::SessionsController do
               threshold_very_low: other_stream.threshold_set.threshold_very_low,
               threshold_low: other_stream.threshold_set.threshold_low,
               threshold_high: other_stream.threshold_set.threshold_high,
-              threshold_very_high: other_stream.threshold_set.threshold_very_high,
+              threshold_very_high:
+                other_stream.threshold_set.threshold_very_high,
               threshold_medium: other_stream.threshold_set.threshold_medium,
               session_id: other_stream.session_id,
               sensor_package_name: other_stream.sensor_package_name,
@@ -220,6 +252,7 @@ describe Api::Realtime::SessionsController do
               start_longitude: other_stream.start_longitude.to_f,
               start_latitude: other_stream.start_latitude.to_f,
               size: other_stream.size,
+              last_hourly_average_id: nil,
               measurements: [],
             },
           },

--- a/spec/models/mobile_session_spec.rb
+++ b/spec/models/mobile_session_spec.rb
@@ -67,6 +67,7 @@ describe MobileSession do
         'unit_name' => stream.unit_name,
         'unit_symbol' => stream.unit_symbol,
         'threshold_set_id' => stream.threshold_set_id,
+        'last_hourly_average_id' => nil,
       }
 
       expect(a[1]).to eq(expected_response)


### PR DESCRIPTION
Remove first_measurement_time attribute as it's no longer needed.
Add missing params to responses in specs.

Further improvements could be done - adding StreamHourlyAverage to tests instead of just returning null in all the cases.
