### PR TITLE
Change timeframe for mobile sessions

### DIFF
--- a/app/javascript/react/components/molecules/SessionFilters/SessionFilters.style.tsx
+++ b/app/javascript/react/components/molecules/SessionFilters/SessionFilters.style.tsx
@@ -276,9 +276,10 @@ const CrowdMapGridSizeWrapper = styled.div<{ $isVisible: boolean }>`
 
 const SectionButtonsContainer = styled.div`
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   justify-content: space-between;
   grid-gap: 0.8rem;
+  align-items: center;
 `;
 
 const SectionButton = styled(Button)<{ $isActive: boolean }>`
@@ -666,6 +667,29 @@ const DormantYearPickerWrapper = styled.div`
   grid-gap: 0.4rem;
 `;
 
+const ChevronButton = styled.button<{
+  $isDisabled: boolean;
+  $rotated?: boolean;
+}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  background-color: transparent;
+  cursor: ${(props) => (props.$isDisabled ? "not-allowed" : "pointer")};
+  opacity: ${(props) => (props.$isDisabled ? 0.5 : 1)};
+  transition: background-color 0.4s ease, color 0.3s ease;
+  height: 25px;
+  padding: 0;
+
+  img {
+    width: 1rem;
+    height: 1rem;
+    transition: transform 0.2s ease;
+    transform: ${(props) => (props.$rotated ? "rotate(180deg)" : "none")};
+  }
+`;
+
 export {
   BackButton,
   BasicParameterButton,
@@ -674,6 +698,7 @@ export {
   ButtonSpan,
   ButtonsWrapper,
   ChevronBackButton,
+  ChevronButton,
   ChevronIcon,
   CloseSelectedItemButton,
   CrowdMapGridSizeWrapper,

--- a/app/javascript/react/components/molecules/SessionFilters/YearPickerButtons.tsx
+++ b/app/javascript/react/components/molecules/SessionFilters/YearPickerButtons.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
+import chevronRight from "../../../assets/icons/chevronRight.svg";
 import { useAppDispatch } from "../../../store/hooks";
 import { setFetchingData } from "../../../store/mapSlice";
 import { useMapParams } from "../../../utils/mapParamsHandler";
@@ -11,37 +13,118 @@ export const beginningOfTheYear = (year: number): number =>
 export const endOfTheYear = (year: number): number =>
   new Date(`${year}-12-31T23:59:59Z`).getTime() / 1000;
 
-export const getLastFiveYears = (): number[] => {
+// The earliest year available in the app
+export const EARLIEST_YEAR = 2012;
+
+// Updated function to replace getLastFiveYears
+export const getAvailableYears = (count: number = 5): number[] => {
   const currentYear = new Date().getFullYear();
   const years: number[] = [];
 
-  for (let i = 0; i < 5; i++) {
-    years.push(currentYear - i);
+  for (let i = 0; i < count; i++) {
+    const year = currentYear - i;
+    if (year >= EARLIEST_YEAR) {
+      years.push(year);
+    }
   }
 
   return years;
 };
 
+// Keep the original function for backward compatibility
+export const getLastFiveYears = (): number[] => {
+  return getAvailableYears(5);
+};
+
 const YearPickerButtons = () => {
   const dispatch = useAppDispatch();
   const { timeFrom, updateTime } = useMapParams();
-
-  const handleYear = useCallback(
-    (year: number) => {
-      updateTime(year);
-      dispatch(setFetchingData(true));
-    },
-    [dispatch, updateTime]
-  );
+  const { t } = useTranslation();
 
   const timestampToYear = (timestamp: string): number => {
     const date = new Date(Number(timestamp) * 1000);
     return date.getUTCFullYear();
   };
 
+  const [centerYear, setCenterYear] = useState(new Date().getFullYear());
+
+  useEffect(() => {
+    if (timeFrom) {
+      const selectedYear = timestampToYear(timeFrom);
+      // Ensure we don't go before EARLIEST_YEAR
+      const safeYear = Math.max(selectedYear, EARLIEST_YEAR);
+      // Only update centerYear on initial load to prevent visibility shifting
+      setCenterYear(safeYear);
+    }
+  }, []);
+
+  const handleYear = useCallback(
+    (year: number) => {
+      // Only update the time param, don't change which years are visible
+      updateTime(year);
+      dispatch(setFetchingData(true));
+    },
+    [dispatch, updateTime]
+  );
+
+  const handlePreviousYears = () => {
+    console.log("handlePreviousYears", centerYear);
+    if (centerYear > EARLIEST_YEAR) {
+      setCenterYear((prev) => Math.max(prev - 1, EARLIEST_YEAR));
+    }
+  };
+
+  const handleNextYears = () => {
+    const currentDate = new Date();
+    if (centerYear < currentDate.getFullYear()) {
+      setCenterYear((prev) => Math.min(prev + 1, currentDate.getFullYear()));
+    }
+  };
+
+  const isPreviousDisabled = centerYear <= EARLIEST_YEAR;
+  const isNextDisabled = centerYear >= new Date().getFullYear();
+
+  const getVisibleYears = () => {
+    const years: number[] = [];
+    const currentDate = new Date();
+    const latestYear = currentDate.getFullYear();
+
+    // Ensure centerYear doesn't go below EARLIEST_YEAR
+    const adjustedCenterYear = Math.max(centerYear, EARLIEST_YEAR);
+
+    for (let i = 0; i < 4; i++) {
+      const year = adjustedCenterYear - i;
+      // Don't add years earlier than EARLIEST_YEAR
+      if (year >= EARLIEST_YEAR) {
+        years.push(year);
+      }
+    }
+
+    // If we have fewer than 4 years, add years from the future if possible
+    while (years.length < 4 && years[0] < latestYear) {
+      const nextYear: number = years[0] + 1;
+      if (nextYear <= latestYear) {
+        years.unshift(nextYear);
+      } else {
+        break;
+      }
+    }
+
+    return years;
+  };
+
   return (
     <S.SectionButtonsContainer>
-      {getLastFiveYears().map((year) => (
+      <S.ChevronButton
+        onClick={handleNextYears}
+        disabled={isNextDisabled}
+        $isDisabled={isNextDisabled}
+        $rotated
+      >
+        <img src={chevronRight} alt={t("filters.previousYear")} />
+      </S.ChevronButton>
+
+      {getVisibleYears().map((year) => (
         <S.SectionButton
           key={year}
           onClick={() => handleYear(year)}
@@ -50,6 +133,14 @@ const YearPickerButtons = () => {
           {year}
         </S.SectionButton>
       ))}
+
+      <S.ChevronButton
+        onClick={handlePreviousYears}
+        disabled={isPreviousDisabled}
+        $isDisabled={isPreviousDisabled}
+      >
+        <img src={chevronRight} alt={t("filters.nextYear")} />
+      </S.ChevronButton>
     </S.SectionButtonsContainer>
   );
 };

--- a/app/javascript/react/components/molecules/SessionFilters/YearPickerButtons.tsx
+++ b/app/javascript/react/components/molecules/SessionFilters/YearPickerButtons.tsx
@@ -60,7 +60,6 @@ const YearPickerButtons = () => {
 
   const handleYear = useCallback(
     (year: number) => {
-      // Only update the time param, don't change which years are visible
       updateTime(year);
       dispatch(setFetchingData(true));
     },
@@ -68,7 +67,6 @@ const YearPickerButtons = () => {
   );
 
   const handlePreviousYears = () => {
-    console.log("handlePreviousYears", centerYear);
     if (centerYear > EARLIEST_YEAR) {
       setCenterYear((prev) => Math.max(prev - 1, EARLIEST_YEAR));
     }
@@ -89,12 +87,10 @@ const YearPickerButtons = () => {
     const currentDate = new Date();
     const latestYear = currentDate.getFullYear();
 
-    // Ensure centerYear doesn't go below EARLIEST_YEAR
     const adjustedCenterYear = Math.max(centerYear, EARLIEST_YEAR);
 
     for (let i = 0; i < 4; i++) {
       const year = adjustedCenterYear - i;
-      // Don't add years earlier than EARLIEST_YEAR
       if (year >= EARLIEST_YEAR) {
         years.push(year);
       }

--- a/app/javascript/react/components/molecules/SessionFilters/YearPickerButtons.tsx
+++ b/app/javascript/react/components/molecules/SessionFilters/YearPickerButtons.tsx
@@ -14,7 +14,7 @@ export const endOfTheYear = (year: number): number =>
   new Date(`${year}-12-31T23:59:59Z`).getTime() / 1000;
 
 // The earliest year available in the app
-export const EARLIEST_YEAR = 2012;
+export const EARLIEST_YEAR = 2011;
 
 // Updated function to replace getLastFiveYears
 export const getAvailableYears = (count: number = 5): number[] => {

--- a/app/javascript/react/components/organisms/Graph/Graph.tsx
+++ b/app/javascript/react/components/organisms/Graph/Graph.tsx
@@ -318,27 +318,13 @@ const Graph: React.FC<GraphProps> = memo(
             rangeStart = startTime;
             rangeEnd = endTime;
 
-            // Force a data fetch for the entire session when "All" is clicked
+            // Update UI to show the full range without fetching data
             if (chartComponentRef.current?.chart) {
               const chart = chartComponentRef.current.chart;
-
-              // First update UI to show the full range
               updateRangeDisplay(rangeDisplayRef, rangeStart, rangeEnd, false);
-
-              // Then fetch all data with our special trigger
-              fetchMeasurementsIfNeeded(
-                startTime,
-                endTime,
-                false,
-                false,
-                "allButtonClicked"
-              ).then(() => {
-                // Once complete, ensure we're showing the full range
-                chart.xAxis[0].setExtremes(rangeStart, rangeEnd, true, false, {
-                  trigger: "allButtonClicked",
-                });
+              chart.xAxis[0].setExtremes(rangeStart, rangeEnd, true, false, {
+                trigger: "allButtonClicked",
               });
-
               return;
             }
           } else {

--- a/app/javascript/react/components/organisms/Graph/chartHooks/useChartUpdater.ts
+++ b/app/javascript/react/components/organisms/Graph/chartHooks/useChartUpdater.ts
@@ -6,10 +6,7 @@ import {
   updateFixedMeasurementExtremes,
 } from "../../../../store/fixedStreamSlice";
 import { useAppDispatch, useAppSelector } from "../../../../store/hooks";
-import {
-  resetMobileMeasurementExtremes,
-  updateMobileMeasurementExtremes,
-} from "../../../../store/mobileStreamSlice";
+import { updateMobileMeasurementExtremes } from "../../../../store/mobileStreamSlice";
 
 interface UseChartUpdaterProps {
   chartComponentRef: React.RefObject<{
@@ -127,8 +124,6 @@ export const useChartUpdater = ({
       dispatch(resetTimeRange());
       if (fixedSessionTypeSelected && streamId) {
         dispatch(resetFixedMeasurementExtremes());
-      } else {
-        dispatch(resetMobileMeasurementExtremes());
       }
     };
   }, [fixedSessionTypeSelected, streamId, dispatch]);

--- a/app/javascript/react/components/organisms/Graph/graphConfig.ts
+++ b/app/javascript/react/components/organisms/Graph/graphConfig.ts
@@ -306,13 +306,15 @@ const getXAxisOptions = (
       const now = Date.now();
       const fetchStart = Math.max(sessionStartTime || 0, e.min - padding);
       const fetchEnd = Math.min(sessionEndTime || now, e.max + padding);
-      await fetchMeasurementsIfNeeded(
-        fetchStart,
-        fetchEnd,
-        false,
-        false,
-        effectiveTrigger
-      );
+      if (fixedSessionTypeSelected) {
+        await fetchMeasurementsIfNeeded(
+          fetchStart,
+          fetchEnd,
+          false,
+          false,
+          effectiveTrigger
+        );
+      }
     }
   };
 

--- a/app/javascript/react/components/organisms/Modals/SessionDetailsModal/SessionInfo/ModalMobileHeader.tsx
+++ b/app/javascript/react/components/organisms/Modals/SessionDetailsModal/SessionInfo/ModalMobileHeader.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import toggleIcon from "../../../../../assets/icons/toggleIcon.svg";
-import { selectIsLoading } from "../../../../../store";
-import { useAppSelector } from "../../../../../store/hooks";
 import { MobileStreamShortInfo as StreamShortInfo } from "../../../../../types/mobileStream";
 import { Thresholds } from "../../../../../types/thresholds";
 import { isNoData } from "../../../../../utils/measurementsCalc";
@@ -34,7 +32,6 @@ const ModalMobileHeader: React.FC<ModalMobileHeaderProps> = ({
   isMobile,
 }) => {
   const { t } = useTranslation();
-  const isLoading = useAppSelector(selectIsLoading);
 
   const { minMeasurementValue, maxMeasurementValue, averageValue } = extremes;
   const noData = isNoData(
@@ -42,6 +39,11 @@ const ModalMobileHeader: React.FC<ModalMobileHeaderProps> = ({
     maxMeasurementValue,
     averageValue
   );
+
+  console.log("noData", noData);
+  console.log("minMeasurementValue", minMeasurementValue);
+  console.log("maxMeasurementValue", maxMeasurementValue);
+  console.log("averageValue", averageValue);
   return (
     <S.ModalMobileHeader>
       <S.HeaderWrapper onClick={toggleVisibility}>

--- a/app/javascript/react/components/organisms/Modals/SessionDetailsModal/SessionInfo/ModalMobileHeader.tsx
+++ b/app/javascript/react/components/organisms/Modals/SessionDetailsModal/SessionInfo/ModalMobileHeader.tsx
@@ -40,10 +40,6 @@ const ModalMobileHeader: React.FC<ModalMobileHeaderProps> = ({
     averageValue
   );
 
-  console.log("noData", noData);
-  console.log("minMeasurementValue", minMeasurementValue);
-  console.log("maxMeasurementValue", maxMeasurementValue);
-  console.log("averageValue", averageValue);
   return (
     <S.ModalMobileHeader>
       <S.HeaderWrapper onClick={toggleVisibility}>

--- a/app/javascript/react/components/organisms/Modals/SessionDetailsModal/SessionInfo/SessionInfo.tsx
+++ b/app/javascript/react/components/organisms/Modals/SessionDetailsModal/SessionInfo/SessionInfo.tsx
@@ -50,12 +50,14 @@ const SessionInfo: React.FC<SessionInfoProps> = ({
 
   const toggleVisibility = () => setIsVisible(!isVisible);
 
+  console.log("streamShortInfo", streamShortInfo);
+
   const commonProps = {
     streamShortInfo,
     thresholds,
     extremes,
   };
-
+  console.log("extremes", extremes);
   if (isMobile) {
     return (
       <S.InfoContainer>

--- a/app/javascript/react/components/organisms/Modals/SessionDetailsModal/SessionInfo/SessionInfo.tsx
+++ b/app/javascript/react/components/organisms/Modals/SessionDetailsModal/SessionInfo/SessionInfo.tsx
@@ -50,14 +50,12 @@ const SessionInfo: React.FC<SessionInfoProps> = ({
 
   const toggleVisibility = () => setIsVisible(!isVisible);
 
-  console.log("streamShortInfo", streamShortInfo);
-
   const commonProps = {
     streamShortInfo,
     thresholds,
     extremes,
   };
-  console.log("extremes", extremes);
+
   if (isMobile) {
     return (
       <S.InfoContainer>

--- a/app/javascript/react/utils/mapParamsHandler.ts
+++ b/app/javascript/react/utils/mapParamsHandler.ts
@@ -7,7 +7,7 @@ import { getSensorUnitSymbol } from "../components/molecules/SessionFilters/Sens
 import {
   beginningOfTheYear,
   endOfTheYear,
-  getLastFiveYears,
+  getAvailableYears,
 } from "../components/molecules/SessionFilters/YearPickerButtons";
 import { MAP_CONFIGS } from "../components/organisms/Map/mapUtils/mapConfigs";
 import { FALSE, TRUE } from "../const/booleans";
@@ -285,11 +285,11 @@ export const useMapParams = () => {
         { key: UrlParamsTypes.isActive, value: TRUE },
         {
           key: UrlParamsTypes.timeFrom,
-          value: beginningOfTheYear(getLastFiveYears()[0]).toString(),
+          value: beginningOfTheYear(getAvailableYears()[0]).toString(),
         },
         {
           key: UrlParamsTypes.timeTo,
-          value: endOfTheYear(getLastFiveYears()[0]).toString(),
+          value: endOfTheYear(getAvailableYears()[0]).toString(),
         },
       ]);
     },
@@ -369,11 +369,11 @@ export const useMapParams = () => {
   );
   const timeFrom = getParam(
     UrlParamsTypes.timeFrom,
-    beginningOfTheYear(getLastFiveYears()[0]).toString()
+    beginningOfTheYear(getAvailableYears()[0]).toString()
   )!;
   const timeTo = getParam(
     UrlParamsTypes.timeTo,
-    endOfTheYear(getLastFiveYears()[0]).toString()
+    endOfTheYear(getAvailableYears()[0]).toString()
   )!;
   const unitSymbol = getParam(
     UrlParamsTypes.unitSymbol,


### PR DESCRIPTION
Changes made in this PR:

- Enable user to return to 2011 using year picker
- Enhance data retrieval in graph for mobile sessions