### PR TITLE
Recalculate stream daily averages after measurement sync

### DIFF
--- a/app/controllers/api/v3/fixed_streaming/measurements_controller.rb
+++ b/app/controllers/api/v3/fixed_streaming/measurements_controller.rb
@@ -8,7 +8,8 @@ module Api
         def create
           result =
             ::FixedStreaming::Interactor.new.call(
-              params: params,
+              data: params[:data],
+              compression: params[:compression],
               user_id: current_user.id,
             )
 

--- a/app/services/fixed_streaming/measurements_creator.rb
+++ b/app/services/fixed_streaming/measurements_creator.rb
@@ -17,7 +17,7 @@ module FixedStreaming
         end
       import_result = measurements_repository.import(measurements: measurements)
 
-      [import_result, last_measurement(measurements)]
+      [import_result.num_inserts, measurements]
     end
 
     private
@@ -43,10 +43,6 @@ module FixedStreaming
       time_with_time_zone = time.in_time_zone.change(zone: time_zone)
 
       { value: value, time: time, time_with_time_zone: time_with_time_zone }
-    end
-
-    def last_measurement(measurements)
-      measurements.max_by(&:time)
     end
   end
 end

--- a/app/services/fixed_streaming/params_parser.rb
+++ b/app/services/fixed_streaming/params_parser.rb
@@ -1,15 +1,24 @@
 module FixedStreaming
   class ParamsParser
-    def initialize(fixed_sessions_repository: FixedSessionsRepository.new)
+    def initialize(
+      contract: Contract.new,
+      fixed_sessions_repository: FixedSessionsRepository.new
+    )
+      @contract = contract
       @fixed_sessions_repository = fixed_sessions_repository
     end
 
-    def call(params:, user_id:)
-      data = parsed_params(params)
+    def call(data:, compression:, user_id:)
+      data_flow, decoded_data = decode_data(data, compression)
+      validation_result = validate_data(decoded_data)
+
+      return validation_result if validation_result.failure?
+
+      data = validation_result.value
       session = session(user_id: user_id, session_uuid: data[:session_uuid])
 
       if session
-        Success.new({ session: session, data: data })
+        Success.new({ session: session, data: data, data_flow: data_flow })
       else
         Failure.new('session not found')
       end
@@ -17,17 +26,40 @@ module FixedStreaming
 
     private
 
-    attr_reader :fixed_sessions_repository
+    attr_reader :contract, :fixed_sessions_repository
 
-    def parsed_params(params)
-      if params[:compression]
-        decoded = Base64.decode64(params[:data])
+    def decode_data(data, compression)
+      data_flow = nil
+
+      if compression
+        data_flow = :sync
+        decoded = Base64.decode64(data)
         unzipped = AirCasting::GZip.inflate(decoded)
       else
-        unzipped = params[:data]
+        data_flow = :live
+        unzipped = data
       end
 
-      ActiveSupport::JSON.decode(unzipped).deep_symbolize_keys
+      [data_flow, ActiveSupport::JSON.decode(unzipped)]
+    end
+
+    def validate_data(data)
+      contract_result = contract.call(data)
+
+      if contract_result.failure?
+        return Failure.new(contract_result.errors.to_h)
+      end
+
+      data = contract_result.to_h
+      measurements =
+        data[:measurements].reject { |m| m[:time] > 48.hours.from_now }
+
+      if measurements.empty?
+        return Failure.new('no measurements with valid time found')
+      end
+
+      data[:measurements] = measurements
+      Success.new(data)
     end
 
     def session(user_id:, session_uuid:)

--- a/app/services/fixed_streaming/stream_daily_averages_recalculator.rb
+++ b/app/services/fixed_streaming/stream_daily_averages_recalculator.rb
@@ -1,0 +1,37 @@
+module FixedStreaming
+  class StreamDailyAveragesRecalculator
+    def initialize(updater: StreamDailyAverages::Updater.new)
+      @updater = updater
+    end
+
+    def call(measurements:, time_zone:, stream_id:)
+      dates_to_recalculate_averages =
+        measurement_datetimes_grouped_by_date(measurements, time_zone)
+
+      dates_to_recalculate_averages.each do |date|
+        updater.call(
+          stream_id: stream_id,
+          time_with_time_zone: date.in_time_zone(time_zone),
+        )
+      end
+    end
+
+    private
+
+    attr_reader :updater
+
+    # Due to our custom logic 00:00:00 is considered as the end of the previous day.
+    def measurement_datetimes_grouped_by_date(measurements, time_zone)
+      measurements
+        .map { |m| m.time_with_time_zone.in_time_zone(time_zone) }
+        .group_by do |datetime|
+          if datetime.hour == 0 && datetime.min == 0 && datetime.sec == 0
+            datetime.to_date.prev_day
+          else
+            datetime.to_date
+          end
+        end
+        .keys
+    end
+  end
+end

--- a/lib/aircasting/gzip.rb
+++ b/lib/aircasting/gzip.rb
@@ -11,5 +11,14 @@ module AirCasting
 
       result
     end
+
+    # used for testing purposes only
+    def self.deflate(string)
+      io = StringIO.new
+      gz = Zlib::GzipWriter.new(io)
+      gz.write(string)
+      gz.close
+      io.string
+    end
   end
 end

--- a/spec/requests/fixed_streaming_measurements.rb
+++ b/spec/requests/fixed_streaming_measurements.rb
@@ -172,8 +172,7 @@ describe 'POST api/v3/fixed_streaming/measurements' do
         params = { data: data, compression: true }.to_json
 
         post '/api/realtime/measurements', headers: headers, params: params
-        expect(response).to be_successful
-        binding.pry
+        expect(response).to be_bad_request
         expect(Measurement.count).to eq(0)
       end
     end

--- a/spec/services/fixed_streaming/params_parser_spec.rb
+++ b/spec/services/fixed_streaming/params_parser_spec.rb
@@ -1,0 +1,208 @@
+require 'rails_helper'
+
+RSpec.describe FixedStreaming::ParamsParser do
+  subject { described_class.new }
+
+  let(:user) { create(:user) }
+  let(:valid_data) do
+    {
+      measurement_type: 'Particulate Matter',
+      measurements: [
+        {
+          longitude: -73.976343,
+          latitude: 40.680356,
+          time: '2025-02-10T08:55:32',
+          timezone_offset: 0,
+          milliseconds: 0,
+          measured_value: 0,
+          value: 0,
+        },
+      ],
+      sensor_package_name: 'AirBeam3-94e686f5a350',
+      sensor_name: 'AirBeam3-PM1',
+      session_uuid: 'session-uuid',
+      measurement_short_type: 'PM',
+      unit_symbol: 'µg/m³',
+      threshold_high: 55,
+      threshold_low: 9,
+      threshold_medium: 35,
+      threshold_very_high: 150,
+      threshold_very_low: 0,
+      unit_name: 'microgram per cubic meter',
+    }
+  end
+
+  describe '#call' do
+    context 'when params are valid and session exists' do
+      let(:expected_parsed_data) do
+        {
+          measurement_type: 'Particulate Matter',
+          measurements: [
+            {
+              longitude: -73.976343,
+              latitude: 40.680356,
+              time: '2025-02-10T08:55:32',
+              value: 0,
+            },
+          ],
+          sensor_package_name: 'AirBeam3-94e686f5a350',
+          sensor_name: 'AirBeam3-PM1',
+          session_uuid: 'session-uuid',
+          measurement_short_type: 'PM',
+          unit_symbol: 'µg/m³',
+          threshold_high: 55,
+          threshold_low: 9,
+          threshold_medium: 35,
+          threshold_very_high: 150,
+          threshold_very_low: 0,
+          unit_name: 'microgram per cubic meter',
+        }
+      end
+
+      context 'with compression' do
+        it 'returns success with session, data, and data_flow' do
+          session = create(:fixed_session, user: user, uuid: 'session-uuid')
+          compressed_data =
+            Base64.encode64(AirCasting::GZip.deflate(valid_data.to_json))
+
+          result =
+            subject.call(
+              data: compressed_data,
+              compression: true,
+              user_id: user.id,
+            )
+
+          expect(result).to be_a(Success)
+          expect(result.value[:session]).to eq(session)
+          expect(result.value[:data]).to eq(expected_parsed_data)
+          expect(result.value[:data_flow]).to eq(:sync)
+        end
+      end
+
+      context 'without compression' do
+        it 'returns success with session, data, and data_flow' do
+          session = create(:fixed_session, user: user, uuid: 'session-uuid')
+
+          result =
+            subject.call(
+              data: valid_data.to_json,
+              compression: false,
+              user_id: user.id,
+            )
+
+          expect(result).to be_a(Success)
+          expect(result.value[:session]).to eq(session)
+          expect(result.value[:data]).to eq(expected_parsed_data)
+          expect(result.value[:data_flow]).to eq(:live)
+        end
+      end
+    end
+
+    context 'when some measurements have invalid time' do
+      it 'returns success with valid measurements only' do
+        session = create(:fixed_session, user: user, uuid: 'session-uuid')
+        invalid_data =
+          valid_data.merge(
+            measurements: [
+              {
+                longitude: -73.976343,
+                latitude: 40.680356,
+                time: Time.now + 49.hours,
+                timezone_offset: 0,
+                milliseconds: 0,
+                measured_value: 0,
+                value: 0,
+              },
+              {
+                longitude: -73.976343,
+                latitude: 40.680356,
+                time: '2025-02-10T08:55:32',
+                timezone_offset: 0,
+                milliseconds: 0,
+                measured_value: 0,
+                value: 0,
+              },
+            ],
+          )
+        compressed_data =
+          Base64.encode64(AirCasting::GZip.deflate(invalid_data.to_json))
+
+        result =
+          subject.call(
+            data: compressed_data,
+            compression: true,
+            user_id: user.id,
+          )
+
+        expect(result).to be_a(Success)
+        expect(result.value[:session]).to eq(session)
+        expect(result.value[:data][:measurements].size).to eq(1)
+        expect(result.value[:data][:measurements].first[:time]).to eq(
+          '2025-02-10T08:55:32',
+        )
+        expect(result.value[:data_flow]).to eq(:sync)
+      end
+    end
+
+    context 'when session does not exist' do
+      it 'returns failure with session not found error' do
+        result =
+          subject.call(
+            data: valid_data.to_json,
+            compression: false,
+            user_id: user.id,
+          )
+
+        expect(result).to be_a(Failure)
+        expect(result.errors).to eq('session not found')
+      end
+    end
+
+    context 'when params are invalid' do
+      context 'when required fields are missing' do
+        it 'returns failure with validation errors' do
+          invalid_data = valid_data.except(:measurement_type)
+
+          result =
+            subject.call(
+              data: invalid_data.to_json,
+              compression: false,
+              user_id: user.id,
+            )
+
+          expect(result).to be_a(Failure)
+          expect(result.errors).to eq(measurement_type: ['is missing'])
+        end
+      end
+
+      context 'when there is no measurements with valid time' do
+        it 'returns failure with validation errors' do
+          invalid_data =
+            valid_data.merge(
+              measurements: [
+                {
+                  longitude: -73.976343,
+                  latitude: 40.680356,
+                  time: (Time.now + 48.hours + 1.second).iso8601,
+                  timezone_offset: 0,
+                  milliseconds: 0,
+                  measured_value: 0,
+                  value: 0,
+                },
+              ],
+            )
+
+          result =
+            subject.call(
+              data: invalid_data.to_json,
+              compression: false,
+              user_id: user.id,
+            )
+
+          expect(result).to be_a(Failure)
+          expect(result.errors).to eq('no measurements with valid time found')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/fixed_streaming/stream_creator_spec.rb
+++ b/spec/services/fixed_streaming/stream_creator_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe FixedStreaming::StreamCreator do
+  subject { described_class.new }
+
+  describe '#call' do
+    let(:data) do
+      {
+        sensor_name: 'AirBeamMini-PM2.5',
+        unit_name: 'micrograms per cubic meter',
+        measurement_type: 'Particulate Matter',
+        measurement_short_type: 'PM',
+        unit_symbol: 'µg/m³',
+        threshold_very_low: 0.0,
+        threshold_low: 9.0,
+        threshold_medium: 35.0,
+        threshold_high: 55.0,
+        threshold_very_high: 150.0,
+        sensor_package_name: 'AirBeamMini:abc',
+      }
+    end
+
+    context 'threshold set for given sensor and unit symbol already exists' do
+      it 'creates stream and assign the existing threshold set to it' do
+        session = create(:fixed_session)
+        threshold_set =
+          create(
+            :threshold_set,
+            sensor_name: 'AirBeamMini-PM2.5',
+            unit_symbol: 'µg/m³',
+          )
+
+        result = subject.call(session: session, data: data)
+
+        expect(result.session).to eq(session)
+        expect(result.threshold_set).to eq(threshold_set)
+        expect(ThresholdSet.count).to eq(1)
+      end
+    end
+
+    context 'threshold set for given sensor and unit symbol does not exist' do
+      it 'creates threshold set and stream' do
+        session = create(:fixed_session)
+
+        expect { subject.call(session: session, data: data) }.to change {
+          ThresholdSet.count
+        }.by(1).and change { Stream.count }.by(1)
+      end
+    end
+  end
+end

--- a/spec/services/fixed_streaming/stream_daily_averages_recalculator_spec.rb
+++ b/spec/services/fixed_streaming/stream_daily_averages_recalculator_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe FixedStreaming::StreamDailyAveragesRecalculator do
+  subject { described_class.new }
+
+  describe '#call' do
+    it 'recalculates daily averages for the correct dates' do
+      stream = create(:stream)
+      stream_daily_average_17_06 =
+        create(
+          :stream_daily_average,
+          stream: stream,
+          date: Date.parse('2025-06-17'),
+          value: 1,
+        )
+      stream_daily_average_18_06 =
+        create(
+          :stream_daily_average,
+          stream: stream,
+          date: Date.parse('2025-06-18'),
+          value: 1,
+        )
+
+      measurements = [
+        create(
+          :measurement,
+          stream: stream,
+          time_with_time_zone: Time.parse('2025-06-17 01:00:00 -04:00'),
+          value: 10,
+        ),
+        create(
+          :measurement,
+          stream: stream,
+          time_with_time_zone: Time.parse('2025-06-17 10:30:00 -04:00'),
+          value: 20,
+        ),
+        create(
+          :measurement,
+          stream: stream,
+          time_with_time_zone: Time.parse('2025-06-18 02:00:00 -04:00'),
+          value: 30,
+        ),
+        create(
+          :measurement,
+          stream: stream,
+          time_with_time_zone: Time.parse('2025-06-18 12:45:00 -04:00'),
+          value: 40,
+        ),
+      ]
+
+      subject.call(
+        measurements: measurements,
+        time_zone: 'America/New_York',
+        stream_id: stream.id,
+      )
+
+      expect(stream_daily_average_17_06.reload.value).to eq(15.0)
+      expect(stream_daily_average_18_06.reload.value).to eq(35.0)
+    end
+
+    it 'creates new stream daily averages records for dates without existing averages' do
+      stream = create(:stream)
+      measurements = [
+        create(
+          :measurement,
+          stream: stream,
+          time_with_time_zone: Time.parse('2025-06-17 01:00:00 -04:00'),
+          value: 10,
+        ),
+      ]
+
+      subject.call(
+        measurements: measurements,
+        time_zone: 'America/New_York',
+        stream_id: stream.id,
+      )
+
+      stream_daily_average = StreamDailyAverage.first
+      expect(stream_daily_average).to have_attributes(
+        stream: stream,
+        date: Date.parse('2025-06-17'),
+        value: 10.0,
+      )
+    end
+
+    it 'treats 00:00:00 as the end of the previous day' do
+      stream = create(:stream)
+      measurements = [
+        create(
+          :measurement,
+          stream: stream,
+          time_with_time_zone: Time.parse('2025-06-17 00:00:00 -04:00'),
+          value: 10,
+        ),
+      ]
+
+      subject.call(
+        measurements: measurements,
+        time_zone: 'America/New_York',
+        stream_id: stream.id,
+      )
+
+      stream_daily_average = StreamDailyAverage.first
+      expect(stream_daily_average).to have_attributes(
+        stream: stream,
+        date: Date.parse('2025-06-16'),
+        value: 10,
+      )
+    end
+  end
+end


### PR DESCRIPTION
### How recalculation works
When new measurements are added during sync, we determine which dates need to be recalculated based on the timestamps of those measurements. For each affected date, we calculate the stream’s daily average using all measurements available in the database.

### Notes on time and time zones
- Stations are located in different time zones, which means the start and end of a "day" can vary depending on the station. That’s why we always include the time zone when fetching measurements for a specific date.
- In our system, midnight (00:00:00) is treated as the end of the previous day, not the start of a new one.