### PR TITLE
Improve syncing measurements for fixed session

### DIFF
--- a/app/controllers/api/v3/fixed_polling/sessions_controller.rb
+++ b/app/controllers/api/v3/fixed_polling/sessions_controller.rb
@@ -1,0 +1,21 @@
+module Api
+  module V3
+    module FixedPolling
+      class SessionsController < BaseController
+        before_action :authenticate_user_from_token!, only: :create
+        before_action :authenticate_user!, only: :create
+
+        def show
+          result =
+            ::FixedPolling::Interactor.new.call(params: params.to_unsafe_hash)
+
+          if result.success?
+            render json: result.value, status: :ok
+          else
+            render json: result.errors, status: :bad_request
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/fixed_polling/contract.rb
+++ b/app/services/fixed_polling/contract.rb
@@ -1,0 +1,20 @@
+module FixedPolling
+  class Contract < Dry::Validation::Contract
+    params do
+      required(:uuid).filled(:string)
+      required(:last_measurement_sync).filled(:date_time)
+
+      before(:key_coercer) do |result|
+        if result[:last_measurement_sync].is_a?(String)
+          begin
+            decoded = CGI.unescape(result[:last_measurement_sync])
+            result.update(last_measurement_sync: decoded)
+          rescue ArgumentError
+          end
+        end
+
+        result
+      end
+    end
+  end
+end

--- a/app/services/fixed_polling/interactor.rb
+++ b/app/services/fixed_polling/interactor.rb
@@ -1,0 +1,63 @@
+module FixedPolling
+  class Interactor
+    def initialize(
+      contract: Contract.new,
+      repository: Repository.new,
+      serializer: Serializer.new
+    )
+      @contract = contract
+      @repository = repository
+      @serializer = serializer
+    end
+
+    def call(params:)
+      validation_result = validate(params)
+
+      return validation_result if validation_result.is_a?(Failure)
+
+      session = session(validation_result[:uuid])
+      unless session
+        return Failure.new('session not found for UUID: session_uuid')
+      end
+
+      measurements =
+        fetch_measurements(session, validation_result[:last_measurement_sync])
+
+      Success.new(serialized_data(session, measurements))
+    end
+
+    private
+
+    attr_reader :contract, :repository, :serializer
+
+    def validate(params)
+      result = contract.call(params)
+      return Failure.new(result.errors.to_h) if result.failure?
+
+      result.to_h
+    end
+
+    def session(session_uuid)
+      repository.session(uuid: session_uuid)
+    end
+
+    def fetch_measurements(session, last_measurement_sync)
+      return [] if last_measurement_sync >= session.end_time_local
+
+      since = [last_measurement_sync, session.end_time_local - 24.hours].max
+
+      repository.measurements_grouped_by_stream_id(
+        stream_ids: session.stream_ids,
+        since: since,
+      )
+    end
+
+    def serialized_data(session, measurements)
+      serializer.call(
+        session: session,
+        tag_list: repository.tag_list(session: session),
+        measurements: measurements,
+      )
+    end
+  end
+end

--- a/app/services/fixed_polling/repository.rb
+++ b/app/services/fixed_polling/repository.rb
@@ -8,7 +8,7 @@ module FixedPolling
       session.tag_list
     end
 
-    def measurements_grouped_by_stream_id(stream_ids:, since:)
+    def measurements_grouped_by_stream_ids(stream_ids:, since:)
       Measurement
         .unscoped
         .where(stream_id: stream_ids)

--- a/app/services/fixed_polling/repository.rb
+++ b/app/services/fixed_polling/repository.rb
@@ -1,0 +1,19 @@
+module FixedPolling
+  class Repository
+    def session(uuid:)
+      FixedSession.includes(streams: :threshold_set).find_by(uuid: uuid)
+    end
+
+    def tag_list(session:)
+      session.tag_list
+    end
+
+    def measurements_grouped_by_stream_id(stream_ids:, since:)
+      Measurement
+        .unscoped
+        .where(stream_id: stream_ids)
+        .where('time > ?', since)
+        .group_by(&:stream_id)
+    end
+  end
+end

--- a/app/services/fixed_polling/serializer.rb
+++ b/app/services/fixed_polling/serializer.rb
@@ -18,11 +18,11 @@ module FixedPolling
     def serialized_streams(streams, measurements)
       streams.each_with_object({}) do |stream, hash|
         hash[stream.sensor_name.to_sym] =
-          serialize_stream(stream, measurements[stream.id])
+          serialized_stream(stream, measurements[stream.id])
       end
     end
 
-    def serialize_stream(stream, stream_measurements)
+    def serialized_stream(stream, stream_measurements)
       {
         sensor_name: stream.sensor_name,
         sensor_package_name: stream.sensor_package_name,
@@ -35,11 +35,11 @@ module FixedPolling
         threshold_medium: stream.threshold_set.threshold_medium,
         threshold_high: stream.threshold_set.threshold_high,
         threshold_very_high: stream.threshold_set.threshold_very_high,
-        measurements: serialize_measurements(stream_measurements),
+        measurements: serialized_measurements(stream_measurements),
       }
     end
 
-    def serialize_measurements(measurements)
+    def serialized_measurements(measurements)
       Array(measurements).map do |measurement|
         {
           value: measurement.value,

--- a/app/services/fixed_polling/serializer.rb
+++ b/app/services/fixed_polling/serializer.rb
@@ -1,0 +1,53 @@
+module FixedPolling
+  class Serializer
+    def call(session:, tag_list:, measurements:)
+      {
+        type: session.type,
+        uuid: session.uuid,
+        title: session.title,
+        tag_list: tag_list.join(' '),
+        start_time: session.start_time_local.iso8601(3),
+        end_time: session.end_time_local.iso8601(3),
+        version: session.version,
+        streams: serialized_streams(session.streams, measurements),
+      }
+    end
+
+    private
+
+    def serialized_streams(streams, measurements)
+      streams.each_with_object({}) do |stream, hash|
+        hash[stream.sensor_name.to_sym] =
+          serialize_stream(stream, measurements[stream.id])
+      end
+    end
+
+    def serialize_stream(stream, stream_measurements)
+      {
+        sensor_name: stream.sensor_name,
+        sensor_package_name: stream.sensor_package_name,
+        unit_name: stream.unit_name,
+        measurement_type: stream.measurement_type,
+        measurement_short_type: stream.measurement_short_type,
+        unit_symbol: stream.unit_symbol,
+        threshold_very_low: stream.threshold_set.threshold_very_low,
+        threshold_low: stream.threshold_set.threshold_low,
+        threshold_medium: stream.threshold_set.threshold_medium,
+        threshold_high: stream.threshold_set.threshold_high,
+        threshold_very_high: stream.threshold_set.threshold_very_high,
+        measurements: serialize_measurements(stream_measurements),
+      }
+    end
+
+    def serialize_measurements(measurements)
+      Array(measurements).map do |measurement|
+        {
+          value: measurement.value,
+          latitude: measurement.latitude.to_f,
+          longitude: measurement.longitude.to_f,
+          time: measurement.time.utc.iso8601(3),
+        }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
     end
 
     post 'realtime/measurements' => 'v3/fixed_streaming/measurements#create'
+    get 'realtime/sync_measurements' => 'v3/fixed_polling/sessions#show'
 
     get 'averages' => 'averages#index'
     get 'averages2' => 'averages#index2'
@@ -71,7 +72,6 @@ Rails.application.routes.draw do
     resources :sensors, only: %i[index]
 
     namespace :realtime do
-      get 'sync_measurements' => 'sessions#sync_measurements'
       resources :sessions, only: %i[create show]
     end
 

--- a/spec/requests/fixed_polling_sessions.rb
+++ b/spec/requests/fixed_polling_sessions.rb
@@ -1,0 +1,297 @@
+require 'rails_helper'
+
+describe 'GET /api/v3/fixed_polling/sessions' do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user) }
+  before { sign_in(user) }
+
+  context 'when last_measurement_sync is less than 24h before session end time' do
+    it 'returns session with streams and measurements since last_measurement_sync' do
+      last_measurement_time = Time.parse('2025-07-22T10:00:00')
+      session =
+        create(
+          :fixed_session,
+          uuid: 'abc123',
+          end_time_local: last_measurement_time,
+        )
+      stream_1 = create(:stream, session: session, sensor_name: 'PM1')
+      stream_2 = create(:stream, session: session, sensor_name: 'PM2.5')
+      new_measurement_1 =
+        create(:measurement, stream: stream_1, time: last_measurement_time)
+      new_measurement_2 =
+        create(:measurement, stream: stream_2, time: last_measurement_time)
+      old_measurement_1 =
+        create(
+          :measurement,
+          stream: stream_1,
+          time: last_measurement_time - 2.hours,
+        )
+      old_measurement_2 =
+        create(
+          :measurement,
+          stream: stream_2,
+          time: last_measurement_time - 2.hours,
+        )
+      last_measurement_sync = last_measurement_time - 1.hour
+
+      expected_response = {
+        type: session.type,
+        uuid: session.uuid,
+        title: session.title,
+        tag_list: session.tag_list.join(' '),
+        start_time: session.start_time_local.iso8601(3),
+        end_time: session.end_time_local.iso8601(3),
+        version: session.version,
+        streams: {
+          stream_1.sensor_name.to_sym => {
+            sensor_name: stream_1.sensor_name,
+            sensor_package_name: stream_1.sensor_package_name,
+            unit_name: stream_1.unit_name,
+            measurement_type: stream_1.measurement_type,
+            measurement_short_type: stream_1.measurement_short_type,
+            unit_symbol: stream_1.unit_symbol,
+            threshold_very_low: stream_1.threshold_set.threshold_very_low,
+            threshold_low: stream_1.threshold_set.threshold_low,
+            threshold_medium: stream_1.threshold_set.threshold_medium,
+            threshold_high: stream_1.threshold_set.threshold_high,
+            threshold_very_high: stream_1.threshold_set.threshold_very_high,
+            measurements: [
+              {
+                value: new_measurement_1.value,
+                latitude: new_measurement_1.latitude.to_f,
+                longitude: new_measurement_1.longitude.to_f,
+                time: new_measurement_1.time.utc.iso8601(3),
+              },
+            ],
+          },
+          stream_2.sensor_name.to_sym => {
+            sensor_name: stream_2.sensor_name,
+            sensor_package_name: stream_2.sensor_package_name,
+            unit_name: stream_2.unit_name,
+            measurement_type: stream_2.measurement_type,
+            measurement_short_type: stream_2.measurement_short_type,
+            unit_symbol: stream_2.unit_symbol,
+            threshold_very_low: stream_2.threshold_set.threshold_very_low,
+            threshold_low: stream_2.threshold_set.threshold_low,
+            threshold_medium: stream_2.threshold_set.threshold_medium,
+            threshold_high: stream_2.threshold_set.threshold_high,
+            threshold_very_high: stream_2.threshold_set.threshold_very_high,
+            measurements: [
+              {
+                value: new_measurement_2.value,
+                latitude: new_measurement_2.latitude.to_f,
+                longitude: new_measurement_2.longitude.to_f,
+                time: new_measurement_2.time.utc.iso8601(3),
+              },
+            ],
+          },
+        },
+      }
+
+      get '/api/realtime/sync_measurements',
+          params: {
+            uuid: 'abc123',
+            last_measurement_sync: CGI.escape(last_measurement_sync.to_s),
+          }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).deep_symbolize_keys).to eq(
+        expected_response,
+      )
+    end
+  end
+
+  context 'when last_measurement_sync is more than 24h before session end time' do
+    it 'returns session with streams and last 24 hours of measurements' do
+      last_measurement_time = Time.parse('2025-07-22T10:00:00')
+      session =
+        create(
+          :fixed_session,
+          uuid: 'abc123',
+          end_time_local: last_measurement_time,
+        )
+      stream_1 = create(:stream, session: session, sensor_name: 'PM1')
+      stream_2 = create(:stream, session: session, sensor_name: 'PM2.5')
+      last_24h_measurement_1 =
+        create(:measurement, stream: stream_1, time: last_measurement_time)
+      last_24h_measurement_2 =
+        create(:measurement, stream: stream_2, time: last_measurement_time)
+      older_measurement_1 =
+        create(
+          :measurement,
+          stream: stream_1,
+          time: last_measurement_time - 30.hours,
+        )
+      older_measurement_2 =
+        create(
+          :measurement,
+          stream: stream_2,
+          time: last_measurement_time - 30.hours,
+        )
+      last_measurement_sync = last_measurement_time - 50.hours
+
+      expected_response = {
+        type: session.type,
+        uuid: session.uuid,
+        title: session.title,
+        tag_list: session.tag_list.join(' '),
+        start_time: session.start_time_local.iso8601(3),
+        end_time: session.end_time_local.iso8601(3),
+        version: session.version,
+        streams: {
+          stream_1.sensor_name.to_sym => {
+            sensor_name: stream_1.sensor_name,
+            sensor_package_name: stream_1.sensor_package_name,
+            unit_name: stream_1.unit_name,
+            measurement_type: stream_1.measurement_type,
+            measurement_short_type: stream_1.measurement_short_type,
+            unit_symbol: stream_1.unit_symbol,
+            threshold_very_low: stream_1.threshold_set.threshold_very_low,
+            threshold_low: stream_1.threshold_set.threshold_low,
+            threshold_medium: stream_1.threshold_set.threshold_medium,
+            threshold_high: stream_1.threshold_set.threshold_high,
+            threshold_very_high: stream_1.threshold_set.threshold_very_high,
+            measurements: [
+              {
+                value: last_24h_measurement_1.value,
+                latitude: last_24h_measurement_1.latitude.to_f,
+                longitude: last_24h_measurement_1.longitude.to_f,
+                time: last_24h_measurement_1.time.utc.iso8601(3),
+              },
+            ],
+          },
+          stream_2.sensor_name.to_sym => {
+            sensor_name: stream_2.sensor_name,
+            sensor_package_name: stream_2.sensor_package_name,
+            unit_name: stream_2.unit_name,
+            measurement_type: stream_2.measurement_type,
+            measurement_short_type: stream_2.measurement_short_type,
+            unit_symbol: stream_2.unit_symbol,
+            threshold_very_low: stream_2.threshold_set.threshold_very_low,
+            threshold_low: stream_2.threshold_set.threshold_low,
+            threshold_medium: stream_2.threshold_set.threshold_medium,
+            threshold_high: stream_2.threshold_set.threshold_high,
+            threshold_very_high: stream_2.threshold_set.threshold_very_high,
+            measurements: [
+              {
+                value: last_24h_measurement_2.value,
+                latitude: last_24h_measurement_2.latitude.to_f,
+                longitude: last_24h_measurement_2.longitude.to_f,
+                time: last_24h_measurement_2.time.utc.iso8601(3),
+              },
+            ],
+          },
+        },
+      }
+
+      get '/api/realtime/sync_measurements',
+          params: {
+            uuid: 'abc123',
+            last_measurement_sync: CGI.escape(last_measurement_sync.to_s),
+          }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).deep_symbolize_keys).to eq(
+        expected_response,
+      )
+    end
+  end
+
+  context 'when session does not exists' do
+    it 'returns bad request' do
+      last_measurement_sync = Time.parse('2025-07-22T10:00:00')
+
+      get '/api/realtime/sync_measurements',
+          params: {
+            uuid: 'abc123',
+            last_measurement_sync: CGI.escape(last_measurement_sync.to_s),
+          }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  context 'when invalid params' do
+    it 'returns bad request' do
+      get '/api/realtime/sync_measurements',
+          params: {
+            uuid: '',
+            last_measurement_sync: 'e34',
+          }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(JSON.parse(response.body)).to eq(
+        {
+          'uuid' => ['must be filled'],
+          'last_measurement_sync' => ['must be a date time'],
+        },
+      )
+    end
+  end
+
+  context 'when there is no new measurements since last_measurement_sync' do
+    it 'returns session with streams and measurements since last_measurement_sync' do
+      last_measurement_time = Time.parse('2025-07-22 10:00')
+      session =
+        create(
+          :fixed_session,
+          uuid: 'abc123',
+          end_time_local: last_measurement_time,
+        )
+      stream_1 = create(:stream, session: session, sensor_name: 'PM1')
+      stream_2 = create(:stream, session: session, sensor_name: 'PM2.5')
+
+      expected_response = {
+        type: session.type,
+        uuid: session.uuid,
+        title: session.title,
+        tag_list: session.tag_list.join(' '),
+        start_time: session.start_time_local.iso8601(3),
+        end_time: session.end_time_local.iso8601(3),
+        version: session.version,
+        streams: {
+          stream_1.sensor_name.to_sym => {
+            sensor_name: stream_1.sensor_name,
+            sensor_package_name: stream_1.sensor_package_name,
+            unit_name: stream_1.unit_name,
+            measurement_type: stream_1.measurement_type,
+            measurement_short_type: stream_1.measurement_short_type,
+            unit_symbol: stream_1.unit_symbol,
+            threshold_very_low: stream_1.threshold_set.threshold_very_low,
+            threshold_low: stream_1.threshold_set.threshold_low,
+            threshold_medium: stream_1.threshold_set.threshold_medium,
+            threshold_high: stream_1.threshold_set.threshold_high,
+            threshold_very_high: stream_1.threshold_set.threshold_very_high,
+            measurements: [],
+          },
+          stream_2.sensor_name.to_sym => {
+            sensor_name: stream_2.sensor_name,
+            sensor_package_name: stream_2.sensor_package_name,
+            unit_name: stream_2.unit_name,
+            measurement_type: stream_2.measurement_type,
+            measurement_short_type: stream_2.measurement_short_type,
+            unit_symbol: stream_2.unit_symbol,
+            threshold_very_low: stream_2.threshold_set.threshold_very_low,
+            threshold_low: stream_2.threshold_set.threshold_low,
+            threshold_medium: stream_2.threshold_set.threshold_medium,
+            threshold_high: stream_2.threshold_set.threshold_high,
+            threshold_very_high: stream_2.threshold_set.threshold_very_high,
+            measurements: [],
+          },
+        },
+      }
+
+      get '/api/realtime/sync_measurements',
+          params: {
+            uuid: 'abc123',
+            last_measurement_sync: CGI.escape(last_measurement_time.to_s),
+          }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).deep_symbolize_keys).to eq(
+        expected_response,
+      )
+    end
+  end
+end

--- a/spec/services/fixed_polling/repository_spec.rb
+++ b/spec/services/fixed_polling/repository_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FixedPolling::Repository do
     end
   end
 
-  describe '#measurements_grouped_by_stream_id' do
+  describe '#measurements_grouped_by_stream_ids' do
     context 'measurements for given streams and time range exist' do
       it 'returns measurements grouped by stream_id' do
         stream_1 = create(:stream)
@@ -32,7 +32,7 @@ RSpec.describe FixedPolling::Repository do
         _other_measurement = create(:measurement, time: 1.hour.ago)
 
         result =
-          subject.measurements_grouped_by_stream_id(
+          subject.measurements_grouped_by_stream_ids(
             stream_ids: [stream_1.id, stream_2.id],
             since: 3.hours.ago,
           )
@@ -48,7 +48,7 @@ RSpec.describe FixedPolling::Repository do
       it 'returns an empty hash' do
         stream = create(:stream)
         result =
-          subject.measurements_grouped_by_stream_id(
+          subject.measurements_grouped_by_stream_ids(
             stream_ids: [stream],
             since: 10.minutes.ago,
           )

--- a/spec/services/fixed_polling/repository_spec.rb
+++ b/spec/services/fixed_polling/repository_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe FixedPolling::Repository do
+  subject { described_class.new }
+
+  describe '#session' do
+    it 'returns the session with loaded assocations' do
+      session = create(:fixed_session, uuid: 'test-uuid')
+      stream = create(:stream, session: session)
+
+      result = subject.session(uuid: 'test-uuid')
+
+      expect(result).to eq(session)
+      expect(result.association(:streams)).to be_loaded
+      expect(result.streams.first.association(:threshold_set)).to be_loaded
+    end
+  end
+
+  describe '#measurements_grouped_by_stream_id' do
+    context 'measurements for given streams and time range exist' do
+      it 'returns measurements grouped by stream_id' do
+        stream_1 = create(:stream)
+        stream_2 = create(:stream)
+        measurement_1_1 =
+          create(:measurement, stream: stream_1, time: 2.hours.ago)
+        measurement_1_2 =
+          create(:measurement, stream: stream_1, time: 1.hour.ago)
+        measurement_2_1 =
+          create(:measurement, stream: stream_2, time: 4.hours.ago)
+        measurement_2_2 =
+          create(:measurement, stream: stream_2, time: 1.hour.ago)
+        _other_measurement = create(:measurement, time: 1.hour.ago)
+
+        result =
+          subject.measurements_grouped_by_stream_id(
+            stream_ids: [stream_1.id, stream_2.id],
+            since: 3.hours.ago,
+          )
+
+        expect(result.keys).to match_array([stream_1.id, stream_2.id])
+        expect(result[stream_1.id]).to match_array(
+          [measurement_1_1, measurement_1_2],
+        )
+        expect(result[stream_2.id]).to match_array([measurement_2_2])
+      end
+    end
+    context 'measurements for given streams and time range do not exist' do
+      it 'returns an empty hash' do
+        stream = create(:stream)
+        result =
+          subject.measurements_grouped_by_stream_id(
+            stream_ids: [stream],
+            since: 10.minutes.ago,
+          )
+
+        expect(result).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Problem
Previously, when a user started a session and then turned off their device (e.g., for several months), the app would attempt to fetch all missing measurements upon returning. While it tried to limit the request to the last 24 hours of data, it was relying on an outdated session end_time, making the calculation inaccurate. As a result, the app often fetched far more data than necessary.

### Solution
This change improves the mechanism for syncing measurements across devices within a session by moving the logic for determining which measurements to fetch to the backend.

Specifically:

- If the `last_measurement_sync` timestamp is more than 24 hours before the session's `end_time`, we now fetch only the last 24 hours of measurements instead of the entire gap. This logic is handled entirely on the backend and does not rely on the mobile app to correctly calculate `last_measurement_sync`, which improves reliability in cases where the app’s local data may be outdated.
- If the session's end_time is less than or equal to the last_measurement_sync, we return only the session metadata without any measurements. This reduces unnecessary database calls, as we can determine based on the end_time that there are no new measurements to fetch, and therefore avoid querying the measurements table altogether.
