### PR TITLE
Round latitude and longitude for AirNow sessions

### DIFF
--- a/app/services/air_now_streaming/repository.rb
+++ b/app/services/air_now_streaming/repository.rb
@@ -1,0 +1,16 @@
+module AirNowStreaming
+  class Repository
+    def air_now_streams
+      Stream
+        .includes(:session, :threshold_set)
+        .joins(session: :user)
+        .where(users: { username: air_now_username })
+    end
+
+    private
+
+    def air_now_username
+      'US EPA AirNow'
+    end
+  end
+end

--- a/app/services/data_fixes/air_now_sessions_lat_long_rounding.rb
+++ b/app/services/data_fixes/air_now_sessions_lat_long_rounding.rb
@@ -1,0 +1,55 @@
+module DataFixes
+  class AirNowSessionsLatLongRounding
+    def initialize(
+      logger: Logger.new(
+        Rails.root.join('log', 'air_now_sessions_lat_long_rounding.log'),
+      )
+    )
+      @logger = logger
+    end
+
+    def call
+      AirNowStreaming::Repository
+        .new
+        .air_now_streams
+        .find_each
+        .with_index do |stream, index|
+        session = stream.session
+
+        logger.info("Processing session #{index + 1} with ID: #{session.id}")
+
+        latitude = session.latitude.round(3)
+        longitude = session.longitude.round(3)
+
+        ActiveRecord::Base.transaction do
+          session.update!(latitude: latitude, longitude: longitude)
+          logger.info(
+            "Updated session ID: #{session.id} with rounded latitude: #{latitude}, longitude: #{longitude}",
+          )
+
+          stream.update!(
+            min_latitude: latitude,
+            min_longitude: longitude,
+            max_latitude: latitude,
+            max_longitude: longitude,
+            start_latitude: latitude,
+            start_longitude: longitude,
+          )
+          logger.info(
+            "Updated stream ID: #{stream.id} for session ID: #{session.id}",
+          )
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        logger.error(
+          "Failed to update session ID: #{session.id} - #{e.message}",
+        )
+      end
+
+      logger.info('Finished processing all sessions.')
+    end
+
+    private
+
+    attr_reader :logger
+  end
+end

--- a/lib/tasks/round_lat_long_of_air_now_sessions.rake
+++ b/lib/tasks/round_lat_long_of_air_now_sessions.rake
@@ -1,0 +1,4 @@
+desc 'Round latitude and longitude of AirNow sessions'
+task round_lat_long_of_air_now_sessions: :environment do
+  DataFixes::AirNowSessionsLatLongRounding.new.call
+end

--- a/spec/services/air_now_streaming/repository_spec.rb
+++ b/spec/services/air_now_streaming/repository_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe AirNowStreaming::Repository do
+  subject { described_class.new }
+
+  describe '#air_now_streams' do
+    it 'returns streams associated through sessions with the US EPA AirNow user' do
+      user = create(:user, username: 'US EPA AirNow')
+      session_1 = create(:fixed_session, user: user)
+      session_2 = create(:fixed_session, user: user)
+      stream_1 = create(:stream, session: session_1)
+      stream_2 = create(:stream, session: session_2)
+      other_user = create(:user, username: 'Other User')
+      create(:fixed_session, user: other_user)
+
+      result = subject.air_now_streams
+
+      expect(result).to match_array([stream_1, stream_2])
+    end
+  end
+end

--- a/spec/services/data_fixes/air_now_sessions_lat_long_rounding_spec.rb
+++ b/spec/services/data_fixes/air_now_sessions_lat_long_rounding_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe DataFixes::AirNowSessionsLatLongRounding do
+  subject { described_class.new }
+
+  let!(:user) { create(:user, username: 'US EPA AirNow') }
+  let!(:session1) do
+    create(
+      :fixed_session,
+      user: user,
+      latitude: 44.941101,
+      longitude: -105.837799,
+    )
+  end
+  let!(:session2) do
+    create(
+      :fixed_session,
+      user: user,
+      latitude: 44.941567,
+      longitude: -105.837123,
+    )
+  end
+  let!(:stream1) do
+    create(
+      :stream,
+      session: session1,
+      min_latitude: 44.941101,
+      min_longitude: -105.837799,
+    )
+  end
+  let!(:stream2) do
+    create(
+      :stream,
+      session: session2,
+      min_latitude: 44.941567,
+      min_longitude: -105.837123,
+    )
+  end
+
+  describe '#call' do
+    it 'rounds latitude and longitude to 3 decimal places for sessions and updates streams' do
+      subject.call
+
+      expect(session1.reload.latitude).to eq(44.941)
+      expect(session1.reload.longitude).to eq(-105.838)
+      expect(session2.reload.latitude).to eq(44.942)
+      expect(session2.reload.longitude).to eq(-105.837)
+
+      expect(stream1.reload.min_latitude).to eq(44.941)
+      expect(stream1.reload.min_longitude).to eq(-105.838)
+      expect(stream1.reload.max_latitude).to eq(44.941)
+      expect(stream1.reload.max_longitude).to eq(-105.838)
+      expect(stream1.reload.start_latitude).to eq(44.941)
+      expect(stream1.reload.start_longitude).to eq(-105.838)
+
+      expect(stream2.reload.min_latitude).to eq(44.942)
+      expect(stream2.reload.min_longitude).to eq(-105.837)
+      expect(stream2.reload.max_latitude).to eq(44.942)
+      expect(stream2.reload.max_longitude).to eq(-105.837)
+      expect(stream2.reload.start_latitude).to eq(44.942)
+      expect(stream2.reload.start_longitude).to eq(-105.837)
+    end
+
+    it 'does not update sessions or streams if no rounding is needed' do
+      session3 =
+        create(
+          :fixed_session,
+          user: user,
+          latitude: 44.941,
+          longitude: -105.838,
+        )
+      stream3 =
+        create(
+          :stream,
+          session: session3,
+          min_latitude: 44.941,
+          min_longitude: -105.838,
+        )
+
+      subject.call
+
+      expect(session3.reload.latitude).to eq(44.941)
+      expect(session3.reload.longitude).to eq(-105.838)
+      expect(stream3.reload.min_latitude).to eq(44.941)
+      expect(stream3.reload.min_longitude).to eq(-105.838)
+    end
+  end
+end


### PR DESCRIPTION
When importing AirNow stations, the latitude and longitude values can vary slightly. From our experience, rounding to three decimal places ensures that measurements are matched correctly to existing sessions.

To simplify management, we're planning to round these values during import and use the rounded versions throughout.
As a prerequisite, this PR includes a script to round the values already stored in the database.
