### PR TITLE
Switch to new approach for AirNow import

### DIFF
--- a/app/services/air_now_streaming/streams_updater.rb
+++ b/app/services/air_now_streaming/streams_updater.rb
@@ -42,23 +42,17 @@ module AirNowStreaming
     end
 
     def check_session_end_timestamps(session, measurements)
-      #temproary flag, to be removed when AirNow integration is fully switched
-      #right now data from AirNow is fetched twice at different times and sessions end timestamps would be wrongly updated
-      air_now_integration_fully_switched = false
+      last_measurement = measurements.max_by { |m| m[:time] }
 
-      if air_now_integration_fully_switched
-        last_measurement = measurements.max_by { |m| m[:time] }
+      return unless last_measurement[:time] > session.end_time_local
 
-        return unless last_measurement[:time] > session.end_time_local
-
-        {
-          id: session.id,
-          end_time_local: last_measurement[:time],
-          last_measurement_at: last_measurement[:time_with_time_zone],
-          updated_at: Time.current,
-          type: 'FixedSession',
-        }
-      end
+      {
+        id: session.id,
+        end_time_local: last_measurement[:time],
+        last_measurement_at: last_measurement[:time_with_time_zone],
+        updated_at: Time.current,
+        type: 'FixedSession',
+      }
     end
 
     def update_sessions(session_rows_to_update)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -17,13 +17,8 @@
     class: "ThresholdAlertsWorker"
     queue: critical
 
-  airnow_import_measurements:
-    cron: "56 * * * *"
-    class: AirNowImportMeasurementsWorker
-    queue: slow
-
   airnow_import:
-    cron: "26 * * * *"
+    cron: "26,56 * * * *"
     class: AirNowImportWorker
     queue: slow
 

--- a/spec/services/air_now_streaming/interactor_spec.rb
+++ b/spec/services/air_now_streaming/interactor_spec.rb
@@ -46,17 +46,16 @@ RSpec.describe AirNowStreaming::Interactor do
                         :count,
                       ).by(1).and change(FixedMeasurement, :count).by(3)
 
-      # TODO: Uncomment when AirNow integration is fully switched to fixed measurements
-      # session.reload
-      # expect(session.start_time_local).to eq(
-      #   Time.zone.parse('2025-07-24T05:00:00'),
-      # )
-      # expect(session.end_time_local).to eq(
-      #   Time.zone.parse('2025-07-24T07:00:00'),
-      # )
-      # expect(session.last_measurement_at).to eq(
-      #   Time.zone.parse('2025-07-24T10:00:00'),
-      # )
+      session.reload
+      expect(session.start_time_local).to eq(
+        Time.zone.parse('2025-07-24T05:00:00'),
+      )
+      expect(session.end_time_local).to eq(
+        Time.zone.parse('2025-07-24T07:00:00'),
+      )
+      expect(session.last_measurement_at).to eq(
+        Time.zone.parse('2025-07-24T10:00:00'),
+      )
 
       created_session = Session.find_by(latitude: 44.647, longitude: -63.574)
       expect(created_session.title).to eq('JOHNSTON BUILDING')

--- a/spec/services/air_now_streaming/streams_updater_spec.rb
+++ b/spec/services/air_now_streaming/streams_updater_spec.rb
@@ -60,23 +60,22 @@ RSpec.describe AirNowStreaming::StreamsUpdater do
         subject.call(measurements_to_create: measurements_to_create)
       }.to change(FixedMeasurement, :count).by(3)
 
-      # TODO: Uncomment when AirNow integration is fully switched to fixed measurements
-      # session_1.reload
-      # session_2.reload
+      session_1.reload
+      session_2.reload
 
-      # expect(session_1.end_time_local).to eq(
-      #   Time.zone.parse('2025-07-24T07:00:00'),
-      # )
-      # expect(session_1.last_measurement_at).to eq(
-      #   Time.zone.parse('2025-07-24T10:00:00'),
-      # )
+      expect(session_1.end_time_local).to eq(
+        Time.zone.parse('2025-07-24T07:00:00'),
+      )
+      expect(session_1.last_measurement_at).to eq(
+        Time.zone.parse('2025-07-24T10:00:00'),
+      )
 
-      # expect(session_2.end_time_local).to eq(
-      #   Time.zone.parse('2025-07-24T08:00:00'),
-      # )
-      # expect(session_2.last_measurement_at).to eq(
-      #   Time.zone.parse('2025-07-24T11:00:00'),
-      # )
+      expect(session_2.end_time_local).to eq(
+        Time.zone.parse('2025-07-24T08:00:00'),
+      )
+      expect(session_2.last_measurement_at).to eq(
+        Time.zone.parse('2025-07-24T11:00:00'),
+      )
     end
 
     context 'when measurement time is before session end time' do


### PR DESCRIPTION
Switch completely to new approach for importing AirNow measurements. Configure cron job to run twice per hour - at minute 26 and 56 of every hour.