### PR TITLE
Fix: Improve initial page load time 

### DIFF
--- a/app/javascript/react/components/organisms/Graph/Graph.tsx
+++ b/app/javascript/react/components/organisms/Graph/Graph.tsx
@@ -708,7 +708,12 @@ const Graph: React.FC<GraphProps> = memo(
     ]);
 
     useEffect(() => {
+      // Guard against re-entrance: applyStyles modifies CSS which would
+      // re-trigger the MutationObserver, creating a feedback loop.
+      let applying = false;
       const applyStyles = () => {
+        if (applying) return;
+        applying = true;
         const graphElement = graphRef.current;
         if (graphElement) {
           graphElement.style.touchAction = "pan-x";
@@ -725,6 +730,7 @@ const Graph: React.FC<GraphProps> = memo(
             highchartsChartContainer.style.overflow = "visible";
           }
         }
+        applying = false;
       };
 
       applyStyles();
@@ -743,25 +749,16 @@ const Graph: React.FC<GraphProps> = memo(
         seriesData &&
         seriesData.length > 0
       ) {
-        setTimeout(() => {
+        // One reflow after the browser has had a chance to settle is enough.
+        // The previous version toggled container height and read offsetHeight
+        // (forced synchronous layout) inside a nested setTimeout, doubling
+        // the reflow cost on every seriesData change.
+        const timer = setTimeout(() => {
           if (chartComponentRef.current?.chart) {
             chartComponentRef.current.chart.reflow();
-            if (isCalendarPage) {
-              const container = graphRef.current;
-              if (container) {
-                const currentHeight = container.style.height;
-                container.style.height = "auto";
-                container.offsetHeight;
-                container.style.height = currentHeight;
-                setTimeout(() => {
-                  if (chartComponentRef.current?.chart) {
-                    chartComponentRef.current.chart.reflow();
-                  }
-                }, 100);
-              }
-            }
           }
         }, 200);
+        return () => clearTimeout(timer);
       }
     }, [isCalendarPage, seriesData]);
 

--- a/app/javascript/react/components/organisms/Map/Markers/FixedMarkers.tsx
+++ b/app/javascript/react/components/organisms/Map/Markers/FixedMarkers.tsx
@@ -115,6 +115,18 @@ export function FixedMarkers({
 
   const isLoading = useAppSelector(selectIsLoading);
 
+  // Refs that mirror props/selectors whose current value is needed inside
+  // stable callbacks (updateMarkerOverlays, updateClusterOverlays) without
+  // forcing those callbacks to be recreated on every change.
+  const selectedStreamIdRef = useRef(selectedStreamId);
+  selectedStreamIdRef.current = selectedStreamId;
+  const pulsatingSessionIdRef = useRef(pulsatingSessionId);
+  pulsatingSessionIdRef.current = pulsatingSessionId;
+  const thresholdsRef = useRef(thresholds);
+  thresholdsRef.current = thresholds;
+  const unitSymbolRef = useRef(unitSymbol);
+  unitSymbolRef.current = unitSymbol;
+
   // Refs for event handlers
   const onMarkerClickRef = useRef(onMarkerClick);
   useEffect(() => {
@@ -314,12 +326,14 @@ export function FixedMarkers({
       const cluster = overlay.cluster;
       const markers = cluster.markers as CustomMarker[];
       const hasPulsatingSession =
-        pulsatingSessionId !== null &&
-        markers.some((marker) => marker.sessionId === pulsatingSessionId);
+        pulsatingSessionIdRef.current !== null &&
+        markers.some(
+          (marker) => marker.sessionId === pulsatingSessionIdRef.current
+        );
 
       overlay.setShouldPulse(hasPulsatingSession);
     });
-  }, [pulsatingSessionId]);
+  }, []);
 
   const isMarkerInViewport = useCallback(
     (marker: CustomMarker) => {
@@ -335,10 +349,10 @@ export function FixedMarkers({
     markerRefs.current.forEach((marker, streamId) => {
       const isVisible = bounds ? bounds.contains(marker.getPosition()!) : false;
       const isSelected =
-        marker.userData?.streamId === selectedStreamId?.toString();
+        marker.userData?.streamId === selectedStreamIdRef.current?.toString();
       const shouldPulse =
-        marker.sessionId === pulsatingSessionId && !marker.clustered;
-      const newColor = getColorForValue(thresholds, marker.value);
+        marker.sessionId === pulsatingSessionIdRef.current && !marker.clustered;
+      const newColor = getColorForValue(thresholdsRef.current, marker.value);
       const existingOverlay = markerOverlays.current.get(streamId);
       const existingLabelOverlay = labelOverlays.current.get(streamId);
       const position = marker.getPosition();
@@ -375,7 +389,7 @@ export function FixedMarkers({
             position!,
             newColor,
             marker.value === null ? calculatingText : marker.value,
-            unitSymbol,
+            unitSymbolRef.current,
             isSelected,
             () => {
               onMarkerClickRef.current(
@@ -394,20 +408,12 @@ export function FixedMarkers({
             isSelected,
             newColor,
             marker.value === null ? calculatingText : marker.value,
-            unitSymbol
+            unitSymbolRef.current
           );
         }
       }
     });
-  }, [
-    map,
-    selectedStreamId,
-    pulsatingSessionId,
-    thresholds,
-    unitSymbol,
-    centerMapOnMarker,
-    isLoading,
-  ]);
+  }, [map, centerMapOnMarker]);
 
   useEffect(() => {
     if (fixedStreamStatus === StatusEnum.Pending) return;

--- a/app/javascript/react/components/organisms/Map/Markers/FixedMarkers.tsx
+++ b/app/javascript/react/components/organisms/Map/Markers/FixedMarkers.tsx
@@ -216,6 +216,12 @@ export function FixedMarkers({
     });
   }, [map, thresholds, pulsatingSessionId, handleClusterClickInternal]);
 
+  // Keep a ref so the one-time listener registered during clusterer init
+  // always calls the current version of handleClusteringEnd, avoiding a
+  // stale closure when thresholds or pulsatingSessionId change later.
+  const handleClusteringEndRef = useRef(handleClusteringEnd);
+  handleClusteringEndRef.current = handleClusteringEnd;
+
   const customRenderer = {
     render: ({ position }: CustomRendererProps) => {
       return new google.maps.Marker({
@@ -416,7 +422,9 @@ export function FixedMarkers({
           algorithm,
         });
 
-        clustererRef.current.addListener("clusteringend", handleClusteringEnd);
+        clustererRef.current.addListener("clusteringend", () =>
+          handleClusteringEndRef.current()
+        );
       }
 
       // Create markers for all sessions if they don't exist

--- a/app/javascript/react/components/organisms/Map/Markers/FixedMarkers.tsx
+++ b/app/javascript/react/components/organisms/Map/Markers/FixedMarkers.tsx
@@ -615,56 +615,56 @@ export function FixedMarkers({
   ]);
 
   useEffect(() => {
-    if (clustererRef.current) {
-      clustererRef.current.addListener("clusteringend", () => {
-        markerRefs.current.forEach((marker) => {
-          (marker as CustomMarker).clustered = false;
-        });
-
-        const clusters =
-          clustererRef.current &&
-          // @ts-ignore - clusters
-          (clustererRef.current.clusters as CustomCluster[]);
-
-        clusterOverlaysRef.current.forEach((overlay) => {
-          overlay.setMap(null);
-        });
-        clusterOverlaysRef.current.clear();
-
-        if (!clusters) return;
-
-        clusters.forEach((cluster) => {
-          if (cluster.markers && cluster.markers.length > 1) {
-            cluster.markers.forEach((marker) => {
-              (marker as CustomMarker).clustered = true;
-            });
-
-            const markers = cluster.markers as CustomMarker[];
-            const values = markers.map((marker) => marker.value || 0);
-            const average =
-              values.reduce((sum, value) => sum + value, 0) / values.length;
-            const color = getColorForValue(thresholds, average);
-
-            const hasPulsatingSession =
-              pulsatingSessionId !== null &&
-              markers.some((marker) => marker.sessionId === pulsatingSessionId);
-
-            const overlay = new (getClusterOverlayClass())(
-              cluster,
-              color,
-              hasPulsatingSession,
-              map!,
-              handleClusterClickInternal
-            );
-
-            const clusterKey = `${cluster.position
-              .lat()
-              .toFixed(6)}_${cluster.position.lng().toFixed(6)}`;
-            clusterOverlaysRef.current.set(clusterKey, overlay);
-          }
-        });
+    if (!clustererRef.current) return;
+    const listener = clustererRef.current.addListener("clusteringend", () => {
+      markerRefs.current.forEach((marker) => {
+        (marker as CustomMarker).clustered = false;
       });
-    }
+
+      const clusters =
+        clustererRef.current &&
+        // @ts-ignore - clusters
+        (clustererRef.current.clusters as CustomCluster[]);
+
+      clusterOverlaysRef.current.forEach((overlay) => {
+        overlay.setMap(null);
+      });
+      clusterOverlaysRef.current.clear();
+
+      if (!clusters) return;
+
+      clusters.forEach((cluster) => {
+        if (cluster.markers && cluster.markers.length > 1) {
+          cluster.markers.forEach((marker) => {
+            (marker as CustomMarker).clustered = true;
+          });
+
+          const markers = cluster.markers as CustomMarker[];
+          const values = markers.map((marker) => marker.value || 0);
+          const average =
+            values.reduce((sum, value) => sum + value, 0) / values.length;
+          const color = getColorForValue(thresholds, average);
+
+          const hasPulsatingSession =
+            pulsatingSessionId !== null &&
+            markers.some((marker) => marker.sessionId === pulsatingSessionId);
+
+          const overlay = new (getClusterOverlayClass())(
+            cluster,
+            color,
+            hasPulsatingSession,
+            map!,
+            handleClusterClickInternal
+          );
+
+          const clusterKey = `${cluster.position
+            .lat()
+            .toFixed(6)}_${cluster.position.lng().toFixed(6)}`;
+          clusterOverlaysRef.current.set(clusterKey, overlay);
+        }
+      });
+    });
+    return () => google.maps.event.removeListener(listener);
   }, [
     map,
     thresholds,

--- a/app/javascript/react/components/organisms/Map/Markers/FixedMarkers.tsx
+++ b/app/javascript/react/components/organisms/Map/Markers/FixedMarkers.tsx
@@ -98,6 +98,7 @@ export function FixedMarkers({
   const clusterOverlaysRef = useRef<Map<string, ClusterOverlay>>(new Map());
   const previousZoomRef = useRef<number | null>(null);
   const initialCenterRef = useRef<boolean>(false);
+  const pendingRenderRef = useRef<number | null>(null);
 
   // State variables
   const [hoverPosition, setHoverPosition] = useState<LatLngLiteral | null>(
@@ -234,14 +235,19 @@ export function FixedMarkers({
   const handleClusteringEndRef = useRef(handleClusteringEnd);
   handleClusteringEndRef.current = handleClusteringEnd;
 
-  const customRenderer = {
-    render: ({ position }: CustomRendererProps) => {
-      return new google.maps.Marker({
-        position,
-        visible: false,
-      });
-    },
-  };
+  // Stable renderer — plain object literals are recreated on every render,
+  // which would put the init effect into an infinite re-run cycle.
+  const customRenderer = useMemo(
+    () => ({
+      render: ({ position }: CustomRendererProps) => {
+        return new google.maps.Marker({
+          position,
+          visible: false,
+        });
+      },
+    }),
+    []
+  );
 
   const createMarker = useCallback(
     (session: FixedSession): CustomMarker => {
@@ -415,6 +421,23 @@ export function FixedMarkers({
     });
   }, [map, centerMapOnMarker]);
 
+  // Defer the clusterer render + overlay update to the next animation frame.
+  // Both the init effect and the marker sync effect call this, so the
+  // cancellation logic ensures only one render happens even when both fire
+  // in the same React commit.
+  const scheduleRender = useCallback(() => {
+    if (pendingRenderRef.current !== null) {
+      cancelAnimationFrame(pendingRenderRef.current);
+    }
+    pendingRenderRef.current = requestAnimationFrame(() => {
+      pendingRenderRef.current = null;
+      if (!clustererRef.current) return;
+      clustererRef.current.render();
+      updateMarkerOverlays();
+      updateClusterOverlays();
+    });
+  }, [updateMarkerOverlays, updateClusterOverlays]);
+
   useEffect(() => {
     if (fixedStreamStatus === StatusEnum.Pending) return;
 
@@ -446,11 +469,9 @@ export function FixedMarkers({
         const allMarkers = Array.from(markerRefs.current.values());
         clustererRef.current.clearMarkers();
         clustererRef.current.addMarkers(allMarkers);
-        clustererRef.current.render();
       }
 
-      updateMarkerOverlays();
-      updateClusterOverlays();
+      scheduleRender();
     } else {
       if (fixedStreamData?.stream) {
         const { latitude, longitude } = fixedStreamData.stream;
@@ -543,15 +564,10 @@ export function FixedMarkers({
     fixedStreamStatus,
     fixedStreamData,
     map,
-    customRenderer,
-    handleClusteringEnd,
-    updateMarkerOverlays,
-    updateClusterOverlays,
     memoizedSessions,
     createMarker,
-    thresholds,
-    unitSymbol,
     centerMapOnMarker,
+    scheduleRender,
   ]);
 
   useEffect(() => {
@@ -610,22 +626,13 @@ export function FixedMarkers({
       }
       marker.setMap(null);
     });
-    // Force clusterer update
-    clustererRef.current.render();
-
-    updateMarkerOverlays();
-    updateClusterOverlays();
+    scheduleRender();
   }, [
     sessions,
     map,
     createMarker,
-    thresholds,
-    unitSymbol,
-    pulsatingSessionId,
-    updateMarkerOverlays,
-    updateClusterOverlays,
     memoizedSessions,
-    isLoading,
+    scheduleRender,
   ]);
 
   useEffect(() => {
@@ -695,6 +702,8 @@ export function FixedMarkers({
     pulsatingSessionId,
     selectedStreamId,
     sessions,
+    thresholds,
+    unitSymbol,
     updateMarkerOverlays,
     updateClusterOverlays,
   ]);

--- a/app/javascript/react/components/organisms/Map/Markers/StreamMarkers.tsx
+++ b/app/javascript/react/components/organisms/Map/Markers/StreamMarkers.tsx
@@ -9,11 +9,14 @@ import React, {
 
 import { mobileStreamPath } from "../../../../assets/styles/colors";
 import { useAppDispatch, useAppSelector } from "../../../../store/hooks";
-import store from "../../../../store/index";
 import {
   selectHoverPosition,
   setHoverPosition,
 } from "../../../../store/mapSlice";
+import {
+  selectOpenMarkerKey,
+  selectPopoverInitialSlide,
+} from "../../../../store/popoverSlice";
 import {
   setMarkersLoading,
   setTotalMarkers,
@@ -366,33 +369,18 @@ const StreamMarkers = ({ sessions, unitSymbol }: Props) => {
 
   const noteMarkersRef = React.useRef<Map<string, CustomMarker>>(new Map());
 
-  // Add Redux subscription to update all marker popovers
+  const openMarkerKey = useAppSelector(selectOpenMarkerKey);
+  const popoverInitialSlide = useAppSelector(selectPopoverInitialSlide);
+
+  // Update all marker popovers when the open marker or slide index changes.
+  // Using useSelector instead of store.subscribe avoids running on every
+  // Redux dispatch regardless of which slice changed.
   React.useEffect(() => {
-    let lastOpenMarkerKey: string | null = null;
-    let lastInitialSlide: number | null = null;
-
-    const unsubscribe = store.subscribe(() => {
-      const state = store.getState();
-      const openMarkerKey = state.popover.openMarkerKey;
-      const initialSlide = state.popover.initialSlide;
-
-      if (
-        openMarkerKey !== lastOpenMarkerKey ||
-        initialSlide !== lastInitialSlide
-      ) {
-        lastOpenMarkerKey = openMarkerKey;
-        lastInitialSlide = initialSlide;
-
-        if (map && (map as any).__customMarkers) {
-          (map as any).__customMarkers.forEach((marker: CustomMarker) => {
-            marker.setNotes(marker.getNotes(), initialSlide);
-          });
-        }
-      }
+    if (!map || !(map as any).__customMarkers) return;
+    (map as any).__customMarkers.forEach((marker: CustomMarker) => {
+      marker.setNotes(marker.getNotes(), popoverInitialSlide);
     });
-
-    return () => unsubscribe();
-  }, [map]);
+  }, [openMarkerKey, popoverInitialSlide, map]);
 
   return !isInitialLoading.current && hoverPosition ? (
     <HoverMarker position={hoverPosition} />

--- a/app/javascript/react/store/popoverSlice.ts
+++ b/app/javascript/react/store/popoverSlice.ts
@@ -1,9 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit";
+import type { RootState } from "./index";
 
 const popoverSlice = createSlice({
   name: "popover",
   initialState: {
-    openMarkerKey: null,
+    openMarkerKey: null as string | null,
     initialSlide: 0,
   },
   reducers: {
@@ -17,6 +18,11 @@ const popoverSlice = createSlice({
     },
   },
 });
+
+export const selectOpenMarkerKey = (state: RootState) =>
+  state.popover.openMarkerKey;
+export const selectPopoverInitialSlide = (state: RootState) =>
+  state.popover.initialSlide;
 
 export const { openPopover, closePopover } = popoverSlice.actions;
 export default popoverSlice.reducer;

--- a/app/javascript/react/tests/unit/StreamMarkers.test.tsx
+++ b/app/javascript/react/tests/unit/StreamMarkers.test.tsx
@@ -194,6 +194,12 @@ jest.mock("../../store/hooks", () => ({
         streamId: "someStreamId",
       };
     }
+    if (selector.name === "selectOpenMarkerKey") {
+      return null;
+    }
+    if (selector.name === "selectPopoverInitialSlide") {
+      return 0;
+    }
     return {};
   },
 }));


### PR DESCRIPTION
### Issue                                                                                                                                                                                                                                                                        
                                         
  Apdex dropped below 0.9 due to frontend performance, not backend (backend response time was ~200ms). New Relic session traces showed DOM processing taking 5s and total page load reaching 13s. The clearest signal was a wall of ~20 consecutive message (unknown) JS events
   firing at the 13-second mark, caused by the Google Maps MarkerClusterer's internal postMessage-based event dispatch being triggered by dozens of stacked listeners simultaneously. Chrome DevTools confirmed the time was spent in JS execution, Redux dispatch chains, and
  DOM mutation processing.                                                                                                                                                                                                                                                     
                                                            
### Applied Fixes

1. clusteringend listener accumulation (FixedMarkers.tsx) — A useEffect with 6 dependencies was calling addListener("clusteringend", ...) on every dep change with no cleanup, stacking listeners on each render cycle. Added a removeListener cleanup so only one listener  
  is active at a time. This is the direct cause of the message storm.
2. Stale closure on initial clusteringend listener (FixedMarkers.tsx) — The listener registered during clusterer initialisation captured handleClusteringEnd at that moment, so cluster overlay colours and pulsating state went stale when thresholds or pulsatingSessionId 
  changed later. Fixed by storing the callback in a ref so the listener always calls the current version.                                                                                                                                                                      
3. store.subscribe() in StreamMarkers (StreamMarkers.tsx) — A raw Redux store subscription iterated over all map markers on every dispatch, regardless of whether the relevant popover state had changed. Replaced with useSelector + useEffect so the marker loop only runs
  when openMarkerKey or initialSlide actually change.                                                                                                                                                                                                                          
4. Unstable updateMarkerOverlays / updateClusterOverlays callbacks (FixedMarkers.tsx) — Both callbacks closed over thresholds, unitSymbol, selectedStreamId, pulsatingSessionId, and isLoading, causing them to be recreated on every loading-state flip or threshold change.
   Each recreation cascaded into the idle map listener being re-registered and a separate effect calling both functions imperatively again. Moved the closed-over values to refs so both callbacks are now stable.                                                             
5. MutationObserver feedback loop and double reflow in Graph (Graph.tsx) — applyStyles modified CSS properties while being observed by a MutationObserver with subtree: true, creating a self-reinforcing loop. A nested setTimeout also triggered a forced synchronous layout (offsetHeight) plus two chart.reflow() calls per data change. Added a re-entrance guard to break the observer loop, and collapsed the double-reflow pattern to a single clearable timeout.  