### PR TITLE
Feat: info banner

### DIFF
--- a/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.style.tsx
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.style.tsx
@@ -1,0 +1,221 @@
+import styled, { css, keyframes } from "styled-components";
+
+import {
+  acBlue,
+  acBlueDark,
+  gray100,
+  gray300,
+  gray400,
+  white,
+} from "../../../../assets/styles/colors";
+import { media } from "../../../../utils/media";
+
+const rise = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(1.6rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const BannerWrapper = styled.aside<{ $compact: boolean }>`
+  position: fixed;
+  left: 1.6rem;
+  bottom: 1.6rem;
+  width: 34rem;
+  max-width: calc(100vw - 3.2rem);
+  background: ${white};
+  border-radius: 1.2rem;
+  overflow: hidden;
+  box-shadow: 0 0.6rem 2.4rem rgba(12, 40, 60, 0.18);
+  z-index: 1000;
+  display: flex;
+  animation: ${rise} 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+
+  ${({ $compact }) =>
+    $compact
+      ? css`
+          flex-direction: row;
+          align-items: stretch;
+        `
+      : css`
+          flex-direction: column;
+        `}
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+
+  @media ${media.mobile} {
+    left: 1.2rem;
+    right: 1.2rem;
+    bottom: 1.2rem;
+    width: auto;
+    max-width: none;
+  }
+`;
+
+// --- Image variant --------------------------------------------------------
+
+const Thumb = styled.div`
+  position: relative;
+  width: 100%;
+  height: 12rem;
+  overflow: hidden;
+  background: ${gray100};
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+`;
+
+// --- Compact (text-only) variant ------------------------------------------
+
+const Accent = styled.div`
+  flex: 0 0 0.6rem;
+  background: ${acBlue};
+`;
+
+// --- Shared ----------------------------------------------------------------
+
+const HabitatBadge = styled.div<{ $onImage?: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: ${({ $onImage }) => ($onImage ? gray400 : gray300)};
+
+  img {
+    height: 1.6rem;
+    width: auto;
+    display: block;
+  }
+
+  ${({ $onImage }) =>
+    $onImage &&
+    css`
+      position: absolute;
+      top: 1rem;
+      left: 1rem;
+      background: rgba(255, 255, 255, 0.94);
+      border-radius: 2rem;
+      padding: 0.4rem 0.9rem;
+      box-shadow: 0 0.1rem 0.4rem rgba(0, 0, 0, 0.15);
+      z-index: 2;
+    `}
+`;
+
+const CloseButton = styled.button<{ $onImage?: boolean }>`
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  border-radius: 50%;
+  width: 2.6rem;
+  height: 2.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${({ $onImage }) =>
+    $onImage ? "rgba(255, 255, 255, 0.9)" : gray100};
+  box-shadow: ${({ $onImage }) =>
+    $onImage ? "0 0.1rem 0.4rem rgba(0, 0, 0, 0.2)" : "none"};
+
+  img {
+    width: 1.2rem;
+    height: 1.2rem;
+    object-fit: contain;
+  }
+
+  &:hover {
+    background: ${({ $onImage }) =>
+      $onImage ? white : "rgba(0, 0, 0, 0.06)"};
+  }
+
+  ${({ $onImage }) =>
+    $onImage &&
+    css`
+      position: absolute;
+      top: 0.9rem;
+      right: 0.9rem;
+      z-index: 3;
+    `}
+
+  body:not(.user-is-tabbing) &:focus-visible {
+    outline: none;
+  }
+`;
+
+const Body = styled.div`
+  padding: 1.4rem 1.6rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  flex: 1;
+  min-width: 0;
+`;
+
+const TopRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+`;
+
+const Kicker = styled.p`
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: ${acBlue};
+`;
+
+const Title = styled.p`
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: ${gray400};
+  overflow-wrap: break-word;
+`;
+
+const ReadLink = styled.a`
+  align-self: flex-start;
+  margin-top: 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: ${acBlue};
+  color: ${white};
+  text-decoration: none;
+  font-size: 1.4rem;
+  font-weight: 700;
+  padding: 0.9rem 1.6rem;
+  border-radius: 0.8rem;
+  transition: background 0.15s;
+
+  &:hover {
+    background: ${acBlueDark};
+  }
+`;
+
+export {
+  Accent,
+  BannerWrapper,
+  Body,
+  CloseButton,
+  HabitatBadge,
+  Kicker,
+  ReadLink,
+  Thumb,
+  Title,
+  TopRow,
+};

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.style.tsx
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.style.tsx
@@ -82,6 +82,74 @@ const Accent = styled.div`
   background: ${acBlue};
 `;
 
+// --- Minimal variant (A/B "minimal") --------------------------------------
+// A single clickable card: no image, no button. The whole surface is the
+// click target via a stretched link (MinimalLink::after covers the card).
+
+const MinimalBanner = styled.aside`
+  position: fixed;
+  left: 1.6rem;
+  bottom: 1.6rem;
+  width: 34rem;
+  max-width: calc(100vw - 3.2rem);
+  background: ${white};
+  border-radius: 1.2rem;
+  overflow: hidden;
+  box-shadow: 0 0.6rem 2.4rem rgba(12, 40, 60, 0.18);
+  z-index: 1000;
+  display: flex;
+  align-items: stretch;
+  cursor: pointer;
+  transition: box-shadow 0.15s ease, transform 0.15s ease, background 0.15s ease;
+  animation: ${rise} 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+
+  &:hover {
+    background: ${gray100};
+    box-shadow: 0 0.9rem 3rem rgba(12, 40, 60, 0.26);
+    transform: translateY(-0.2rem);
+  }
+
+  &:hover p:last-of-type,
+  &:focus-within p:last-of-type {
+    text-decoration: underline;
+    text-decoration-color: ${acBlue};
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    transition: none;
+    &:hover {
+      transform: none;
+    }
+  }
+
+  @media ${media.mobile} {
+    left: 1.2rem;
+    right: 1.2rem;
+    bottom: 1.2rem;
+    width: auto;
+    max-width: none;
+  }
+`;
+
+// Invisible anchor whose ::after overlay makes the entire card clickable.
+// The close button sits above this overlay (higher z-index) so it stays usable.
+const MinimalLink = styled.a`
+  text-decoration: none;
+  color: inherit;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
+
+  body:not(.user-is-tabbing) &:focus-visible {
+    outline: none;
+  }
+`;
+
 // --- Shared ----------------------------------------------------------------
 
 const HabitatBadge = styled.div<{ $onImage?: boolean }>`
@@ -169,6 +237,13 @@ const TopRow = styled.div`
   gap: 0.8rem;
 `;
 
+// Same as TopRow but lifted above the minimal variant's stretched-link overlay
+// so the close button remains clickable.
+const MinimalTop = styled(TopRow)`
+  position: relative;
+  z-index: 2;
+`;
+
 const Kicker = styled.p`
   margin: 0;
   font-size: 1.15rem;
@@ -214,6 +289,9 @@ export {
   CloseButton,
   HabitatBadge,
   Kicker,
+  MinimalBanner,
+  MinimalLink,
+  MinimalTop,
   ReadLink,
   Thumb,
   Title,

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.tsx
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import closeIcon from "../../../../assets/icons/closeButton.svg";
 import habitatMapLogo from "../../../../assets/icons/habitatMapLogo.svg";
+import { trackBannerEvent } from "../../../../utils/trackBannerEvent";
 import { BannerVariant, BlogPost } from "./config";
 import {
   pickPost,
@@ -11,6 +12,7 @@ import {
   recordDismissed,
   recordShown,
   shouldShow,
+  withRef,
 } from "./logic";
 import * as S from "./InfoBanner.style";
 
@@ -29,22 +31,39 @@ const InfoBanner: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (post && !recorded.current) {
+    if (post && variant && !recorded.current) {
       recorded.current = true;
       recordShown(post);
+      trackBannerEvent({
+        event: "info_banner_shown",
+        variant,
+        postSlug: post.slug,
+      });
     }
-  }, [post]);
+  }, [post, variant]);
 
   if (!post || !variant) return null;
 
   const handleDismiss = () => {
     recordDismissed();
+    trackBannerEvent({
+      event: "info_banner_dismissed",
+      variant,
+      postSlug: post.slug,
+    });
     setPost(null);
   };
 
   const handleClick = () => {
     recordClicked();
+    trackBannerEvent({
+      event: "info_banner_clicked",
+      variant,
+      postSlug: post.slug,
+    });
   };
+
+  const href = withRef(post.url, variant, post.slug);
 
   const logo = (
     <img src={habitatMapLogo} alt={t("infoBanner.habitatMapAlt")} />
@@ -75,7 +94,7 @@ const InfoBanner: React.FC = () => {
           </S.MinimalTop>
           <S.Kicker>{t("infoBanner.kicker")}</S.Kicker>
           <S.MinimalLink
-            href={post.url}
+            href={href}
             target="_blank"
             rel="noopener noreferrer"
             onClick={handleClick}
@@ -116,7 +135,7 @@ const InfoBanner: React.FC = () => {
         <S.Kicker>{t("infoBanner.kicker")}</S.Kicker>
         <S.Title>{post.title}</S.Title>
         <S.ReadLink
-          href={post.url}
+          href={href}
           target="_blank"
           rel="noopener noreferrer"
           onClick={handleClick}

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.tsx
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.tsx
@@ -3,9 +3,10 @@ import { useTranslation } from "react-i18next";
 
 import closeIcon from "../../../../assets/icons/closeButton.svg";
 import habitatMapLogo from "../../../../assets/icons/habitatMapLogo.svg";
-import { BlogPost } from "./config";
+import { BannerVariant, BlogPost } from "./config";
 import {
   pickPost,
+  pickVariant,
   recordClicked,
   recordDismissed,
   recordShown,
@@ -17,10 +18,12 @@ const InfoBanner: React.FC = () => {
   const { t } = useTranslation();
   // Decide once on mount so the roll/pick is stable for this page load.
   const [post, setPost] = useState<BlogPost | null>(null);
+  const [variant, setVariant] = useState<BannerVariant | null>(null);
   const recorded = useRef(false);
 
   useEffect(() => {
     if (shouldShow()) {
+      setVariant(pickVariant());
       setPost(pickPost());
     }
   }, []);
@@ -32,7 +35,7 @@ const InfoBanner: React.FC = () => {
     }
   }, [post]);
 
-  if (!post) return null;
+  if (!post || !variant) return null;
 
   const handleDismiss = () => {
     recordDismissed();
@@ -43,20 +46,49 @@ const InfoBanner: React.FC = () => {
     recordClicked();
   };
 
-  const hasImage = Boolean(post.image);
-
   const logo = (
     <img src={habitatMapLogo} alt={t("infoBanner.habitatMapAlt")} />
   );
-  const closeButton = (
+
+  const closeButton = (onImage: boolean) => (
     <S.CloseButton
-      $onImage={hasImage}
+      $onImage={onImage}
       onClick={handleDismiss}
       aria-label={t("infoBanner.dismiss")}
     >
       <img src={closeIcon} alt="" />
     </S.CloseButton>
   );
+
+  // --- Minimal variant: whole card is one clickable link, no image/button ---
+  if (variant === "minimal") {
+    return (
+      <S.MinimalBanner
+        role="complementary"
+        aria-label={t("infoBanner.ariaLabel")}
+      >
+        <S.Accent />
+        <S.Body>
+          <S.MinimalTop>
+            <S.HabitatBadge>{logo}</S.HabitatBadge>
+            {closeButton(false)}
+          </S.MinimalTop>
+          <S.Kicker>{t("infoBanner.kicker")}</S.Kicker>
+          <S.MinimalLink
+            href={post.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleClick}
+          >
+            <S.Title>{post.title}</S.Title>
+          </S.MinimalLink>
+        </S.Body>
+      </S.MinimalBanner>
+    );
+  }
+
+  // --- Full variant (default): image when available + read-more button ------
+  const hasImage = Boolean(post.image);
 
   return (
     <S.BannerWrapper
@@ -68,7 +100,7 @@ const InfoBanner: React.FC = () => {
         <S.Thumb>
           <img src={post.image} alt="" decoding="async" />
           <S.HabitatBadge $onImage>{logo}</S.HabitatBadge>
-          {closeButton}
+          {closeButton(true)}
         </S.Thumb>
       ) : (
         <S.Accent />
@@ -78,7 +110,7 @@ const InfoBanner: React.FC = () => {
         {!hasImage && (
           <S.TopRow>
             <S.HabitatBadge>{logo}</S.HabitatBadge>
-            {closeButton}
+            {closeButton(false)}
           </S.TopRow>
         )}
         <S.Kicker>{t("infoBanner.kicker")}</S.Kicker>

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.tsx
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import closeIcon from "../../../../assets/icons/closeButton.svg";
+import habitatMapLogo from "../../../../assets/icons/habitatMapLogo.svg";
+import { BlogPost } from "./config";
+import {
+  pickPost,
+  recordClicked,
+  recordDismissed,
+  recordShown,
+  shouldShow,
+} from "./logic";
+import * as S from "./InfoBanner.style";
+
+const InfoBanner: React.FC = () => {
+  const { t } = useTranslation();
+  // Decide once on mount so the roll/pick is stable for this page load.
+  const [post, setPost] = useState<BlogPost | null>(null);
+  const recorded = useRef(false);
+
+  useEffect(() => {
+    if (shouldShow()) {
+      setPost(pickPost());
+    }
+  }, []);
+
+  useEffect(() => {
+    if (post && !recorded.current) {
+      recorded.current = true;
+      recordShown(post);
+    }
+  }, [post]);
+
+  if (!post) return null;
+
+  const handleDismiss = () => {
+    recordDismissed();
+    setPost(null);
+  };
+
+  const handleClick = () => {
+    recordClicked();
+  };
+
+  const hasImage = Boolean(post.image);
+
+  const logo = (
+    <img src={habitatMapLogo} alt={t("infoBanner.habitatMapAlt")} />
+  );
+  const closeButton = (
+    <S.CloseButton
+      $onImage={hasImage}
+      onClick={handleDismiss}
+      aria-label={t("infoBanner.dismiss")}
+    >
+      <img src={closeIcon} alt="" />
+    </S.CloseButton>
+  );
+
+  return (
+    <S.BannerWrapper
+      $compact={!hasImage}
+      role="complementary"
+      aria-label={t("infoBanner.ariaLabel")}
+    >
+      {hasImage ? (
+        <S.Thumb>
+          <img src={post.image} alt="" decoding="async" />
+          <S.HabitatBadge $onImage>{logo}</S.HabitatBadge>
+          {closeButton}
+        </S.Thumb>
+      ) : (
+        <S.Accent />
+      )}
+
+      <S.Body>
+        {!hasImage && (
+          <S.TopRow>
+            <S.HabitatBadge>{logo}</S.HabitatBadge>
+            {closeButton}
+          </S.TopRow>
+        )}
+        <S.Kicker>{t("infoBanner.kicker")}</S.Kicker>
+        <S.Title>{post.title}</S.Title>
+        <S.ReadLink
+          href={post.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleClick}
+        >
+          {t("infoBanner.readMore")}
+        </S.ReadLink>
+      </S.Body>
+    </S.BannerWrapper>
+  );
+};
+
+export { InfoBanner };

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.tsx
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/InfoBanner.tsx
@@ -35,35 +35,30 @@ const InfoBanner: React.FC = () => {
       recorded.current = true;
       recordShown(post);
       trackBannerEvent({
-        event: "info_banner_shown",
+        event: "banner_shown",
         variant,
-        postSlug: post.slug,
+        postSlug: post.postSlug,
       });
     }
   }, [post, variant]);
 
   if (!post || !variant) return null;
 
+  // Canonical join key shared with HabitatMap (= their page.slug).
+  const postSlug = post.postSlug;
+
   const handleDismiss = () => {
     recordDismissed();
-    trackBannerEvent({
-      event: "info_banner_dismissed",
-      variant,
-      postSlug: post.slug,
-    });
+    trackBannerEvent({ event: "banner_dismissed", variant, postSlug });
     setPost(null);
   };
 
   const handleClick = () => {
     recordClicked();
-    trackBannerEvent({
-      event: "info_banner_clicked",
-      variant,
-      postSlug: post.slug,
-    });
+    trackBannerEvent({ event: "banner_clicked", variant, postSlug });
   };
 
-  const href = withRef(post.url, variant, post.slug);
+  const href = withRef(post.url, variant, postSlug);
 
   const logo = (
     <img src={habitatMapLogo} alt={t("infoBanner.habitatMapAlt")} />

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
@@ -31,7 +31,23 @@ export const STORAGE_KEYS = {
   dismissedAt: "ac_blog_dismissed_at",
   clickedAt: "ac_blog_clicked_at",
   lastSlug: "ac_blog_last_slug",
+  variant: "ac_blog_ab_variant",
 } as const;
+
+// ---------------------------------------------------------------------------
+// A/B test — two banner presentations.
+//   "full"    = image (when the post has one) + a "read more" button.
+//   "minimal" = no image, no button; kicker + title only, the whole card is
+//               one clickable link with a hover affordance.
+// The variant is rolled ONCE per user and persisted (STORAGE_KEYS.variant) so
+// every subsequent show is the same variant — clean per-user close/click rates
+// and clean downstream conversion attribution.
+// ---------------------------------------------------------------------------
+
+export type BannerVariant = "full" | "minimal";
+
+/** Probability (0–1) that a new user is assigned the "minimal" variant. */
+export const AB_SPLIT_MINIMAL = 0.5;
 
 export interface BlogPost {
   /** Stable id used to avoid showing the same post twice in a row. */

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
@@ -31,7 +31,6 @@ export const STORAGE_KEYS = {
   dismissedAt: "ac_blog_dismissed_at",
   clickedAt: "ac_blog_clicked_at",
   lastSlug: "ac_blog_last_slug",
-  variant: "ac_blog_ab_variant",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -39,14 +38,14 @@ export const STORAGE_KEYS = {
 //   "full"    = image (when the post has one) + a "read more" button.
 //   "minimal" = no image, no button; kicker + title only, the whole card is
 //               one clickable link with a hover affordance.
-// The variant is rolled ONCE per user and persisted (STORAGE_KEYS.variant) so
-// every subsequent show is the same variant — clean per-user close/click rates
-// and clean downstream conversion attribution.
+// The variant is rolled fresh on every show (NOT persisted) — a returning user
+// may see a different version across visits, keeping the split ~50/50 across all
+// impressions.
 // ---------------------------------------------------------------------------
 
 export type BannerVariant = "full" | "minimal";
 
-/** Probability (0–1) that a new user is assigned the "minimal" variant. */
+/** Probability (0–1) that any given show uses the "minimal" variant. */
 export const AB_SPLIT_MINIMAL = 0.5;
 
 /**

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
@@ -93,27 +93,21 @@ const CDN_CROP = "?nf_resize=smartcrop&w=680&h=280";
 export const BLOG_POSTS: BlogPost[] = [
   {
     slug: "aqi-colored-dots",
-    url: "https://www.habitatmap.org/blog/what-do-those-colored-circles-mean-understanding-air-quality-on-the-aircasting-map",
+    url: "https://deploy-preview-244--habitatmap.netlify.app/blog/what-do-those-colored-circles-mean-understanding-air-quality-on-the-aircasting-map",
     title: "What do those colored dots mean? Understanding the Air Quality Index",
     image: `https://www.habitatmap.org/images/uploads/aircastingmapdots.png${CDN_CROP}`,
   },
   {
     slug: "candles-incense",
-    url: "https://www.habitatmap.org/blog/when-fresh-scents-turn-toxic-how-candles-and-incense-impact-your-health",
+    url: "https://deploy-preview-244--habitatmap.netlify.app/blog/when-fresh-scents-turn-toxic-how-candles-and-incense-impact-your-health",
     title:
       "When fresh scents turn toxic: how candles and incense impact your health",
     image: `https://www.habitatmap.org/images/uploads/burning-candles-zz-230419-5dd288.avif${CDN_CROP}`,
   },
   {
     slug: "green-spaces-jordan",
-    url: "https://www.habitatmap.org/blog/breathing-easier-how-green-spaces-shape-air-quality-in-jordan-s-cities",
-    title: "Breathing easier: how green spaces shape air quality in Jordan's cities",
-    image: `https://www.habitatmap.org/images/uploads/1000013028.jpg${CDN_CROP}`,
-  },
-  {
-    slug: "citizen-science-brussels",
-    url: "https://www.habitatmap.org/blog/the-empowering-virtues-of-citizen-science-claiming-clean-air-in-brussels",
-    title: "The empowering virtues of citizen science: claiming clean air in Brussels",
-    // image: `https://www.habitatmap.org/images/uploads/radiographie.jpg${CDN_CROP}`,
+    url: "https://deploy-preview-244--habitatmap.netlify.app/blog/nyc-community-organizations-use-aircasting-to-study-hyperlocal-air-quality-1",
+    title: "NYC Community Organizations Use AirCasting to Study Hyperlocal Air Quality",
+    image: `https://www.habitatmap.org/images/uploads/williamsburghexagonmap.png${CDN_CROP}`,
   },
 ];

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
@@ -49,6 +49,19 @@ export type BannerVariant = "full" | "minimal";
 /** Probability (0–1) that a new user is assigned the "minimal" variant. */
 export const AB_SPLIT_MINIMAL = 0.5;
 
+/**
+ * Attribution params appended to the outbound blog link so HabitatMap's GTM /
+ * GA4 can trace the visit (and any resulting AirBeam purchase) back to the
+ * banner. `utm_content` carries the variant and `ac_post` the post slug — both
+ * are persisted into HabitatMap's `ac_ref` cookie downstream. See
+ * INFO_BANNER_TRACKING_SPEC.md §3b / §4b.
+ */
+export const LINK_REF = {
+  utmSource: "aircasting",
+  utmMedium: "info_banner",
+  utmCampaign: "blog_promo",
+} as const;
+
 export interface BlogPost {
   /** Stable id used to avoid showing the same post twice in a row. */
   slug: string;

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------
+// InfoBanner configuration — the ONE place to tune everything.
+//
+// The InfoBanner surfaces a HabitatMap blog post on the map, occasionally and
+// non-intrusively. Adjust the numbers below to change how often it appears and
+// edit BLOG_POSTS to change what it links to. No other file needs touching.
+// ---------------------------------------------------------------------------
+
+/**
+ * Chance (0–1) that the banner is eligible to appear on any given page load,
+ * assuming no cooldown/dismiss/click suppression is active. Lower = rarer.
+ * "Gentle" default: ~1 in 3 loads.
+ */
+export const SHOW_PROBABILITY = 1;//0.35;
+
+/**
+ * After the banner is shown, don't show it again for this many days
+ * (even across page loads where the probability roll would pass).
+ */
+export const COOLDOWN_DAYS = 0;//7;
+
+/** After the user closes (✕) the banner, suppress it for this many days. */
+export const DISMISS_DAYS = 0;//30;
+
+/** After the user clicks through to an article, suppress it for this many days. */
+export const CLICKED_DAYS = 0;//60;
+
+/** localStorage keys — namespaced to avoid clashes with other features. */
+export const STORAGE_KEYS = {
+  lastShown: "ac_blog_last_shown",
+  dismissedAt: "ac_blog_dismissed_at",
+  clickedAt: "ac_blog_clicked_at",
+  lastSlug: "ac_blog_last_slug",
+} as const;
+
+export interface BlogPost {
+  /** Stable id used to avoid showing the same post twice in a row. */
+  slug: string;
+  /** Full HabitatMap blog URL. */
+  url: string;
+  /** Post title shown in the banner. */
+  title: string;
+  /**
+   * Optional hero thumbnail. Either a HabitatMap image URL (values below) or a
+   * locally bundled asset (import it at the top of this file and reference it).
+   * Posts without an image render the lighter, text-only variant automatically.
+   */
+  image?: string;
+}
+
+// How the image URLs below were found: each HabitatMap blog post exposes its
+// hero image in the page's <meta property="og:image"> tag. Grab it with:
+//   curl -sL <post-url> | grep -oiE '<meta property="og:image"[^>]*content="[^"]*"'
+// The `?nf_resize=smartcrop&w=680&h=280` suffix is HabitatMap's (Netlify) image
+// CDN resizing it to a banner-sized crop so we don't pull the full-res original.
+//
+// Prefer to bundle assets instead of hotlinking? Download each image into
+// assets/images/blog/, import it here, and set `image` to the import.
+const CDN_CROP = "?nf_resize=smartcrop&w=680&h=280";
+
+/**
+ * Hardcoded list of posts. Keep it to ~3–5. One is chosen at random on each
+ * real show (never repeating the previous one).
+ */
+export const BLOG_POSTS: BlogPost[] = [
+  {
+    slug: "aqi-colored-dots",
+    url: "https://www.habitatmap.org/blog/what-do-those-colored-circles-mean-understanding-air-quality-on-the-aircasting-map",
+    title: "What do those colored dots mean? Understanding the Air Quality Index",
+    image: `https://www.habitatmap.org/images/uploads/aircastingmapdots.png${CDN_CROP}`,
+  },
+  {
+    slug: "candles-incense",
+    url: "https://www.habitatmap.org/blog/when-fresh-scents-turn-toxic-how-candles-and-incense-impact-your-health",
+    title:
+      "When fresh scents turn toxic: how candles and incense impact your health",
+    image: `https://www.habitatmap.org/images/uploads/burning-candles-zz-230419-5dd288.avif${CDN_CROP}`,
+  },
+  {
+    slug: "green-spaces-jordan",
+    url: "https://www.habitatmap.org/blog/breathing-easier-how-green-spaces-shape-air-quality-in-jordan-s-cities",
+    title: "Breathing easier: how green spaces shape air quality in Jordan's cities",
+    image: `https://www.habitatmap.org/images/uploads/1000013028.jpg${CDN_CROP}`,
+  },
+  {
+    slug: "citizen-science-brussels",
+    url: "https://www.habitatmap.org/blog/the-empowering-virtues-of-citizen-science-claiming-clean-air-in-brussels",
+    title: "The empowering virtues of citizen science: claiming clean air in Brussels",
+    // image: `https://www.habitatmap.org/images/uploads/radiographie.jpg${CDN_CROP}`,
+  },
+];

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
@@ -30,7 +30,7 @@ export const STORAGE_KEYS = {
   lastShown: "ac_blog_last_shown",
   dismissedAt: "ac_blog_dismissed_at",
   clickedAt: "ac_blog_clicked_at",
-  lastSlug: "ac_blog_last_slug",
+  lastPostSlug: "ac_blog_last_post_slug",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -48,22 +48,39 @@ export type BannerVariant = "full" | "minimal";
 /** Probability (0–1) that any given show uses the "minimal" variant. */
 export const AB_SPLIT_MINIMAL = 0.5;
 
+// ---------------------------------------------------------------------------
+// Shared analytics schema — MUST stay identical to HabitatMap.
+// Source of truth: HabitatMap/docs/analytics-tracking.md §1.3.
+// This banner is Test A: banner_source "aircasting", banner_campaign "blog_promo".
+// ---------------------------------------------------------------------------
+
+/** `banner_source` — which property shows the banner. */
+export const BANNER_SOURCE = "aircasting";
+
+/** `banner_campaign` — the experiment id (Test A). */
+export const BANNER_CAMPAIGN = "blog_promo";
+
 /**
  * Attribution params appended to the outbound blog link so HabitatMap's GTM /
  * GA4 can trace the visit (and any resulting AirBeam purchase) back to the
- * banner. `utm_content` carries the variant and `ac_post` the post slug — both
- * are persisted into HabitatMap's `ac_ref` cookie downstream. See
- * INFO_BANNER_TRACKING_SPEC.md §3b / §4b.
+ * banner. `utm_content` carries the variant and `ac_post` the post slug (= the
+ * HM post's URL slug). See HabitatMap/docs/analytics-tracking.md §3.3.
  */
 export const LINK_REF = {
-  utmSource: "aircasting",
+  utmSource: BANNER_SOURCE,
   utmMedium: "info_banner",
-  utmCampaign: "blog_promo",
+  utmCampaign: BANNER_CAMPAIGN,
 } as const;
 
 export interface BlogPost {
-  /** Stable id used to avoid showing the same post twice in a row. */
-  slug: string;
+  /**
+   * The HabitatMap post's URL slug (= their `page.slug`, the last path segment
+   * of `url`). This is the canonical id: it's the analytics join key shared with
+   * HabitatMap (sent as `post_slug` + `ac_post`) AND the local dedup key. MUST
+   * match HM exactly — set it explicitly, don't derive. See
+   * HabitatMap/docs/analytics-tracking.md §1.3.
+   */
+  postSlug: string;
   /** Full HabitatMap blog URL. */
   url: string;
   /** Post title shown in the banner. */
@@ -92,20 +109,20 @@ const CDN_CROP = "?nf_resize=smartcrop&w=680&h=280";
  */
 export const BLOG_POSTS: BlogPost[] = [
   {
-    slug: "aqi-colored-dots",
+    postSlug: "what-do-those-colored-circles-mean-understanding-air-quality-on-the-aircasting-map",
     url: "https://deploy-preview-244--habitatmap.netlify.app/blog/what-do-those-colored-circles-mean-understanding-air-quality-on-the-aircasting-map",
     title: "What do those colored dots mean? Understanding the Air Quality Index",
     image: `https://www.habitatmap.org/images/uploads/aircastingmapdots.png${CDN_CROP}`,
   },
   {
-    slug: "candles-incense",
+    postSlug: "when-fresh-scents-turn-toxic-how-candles-and-incense-impact-your-health",
     url: "https://deploy-preview-244--habitatmap.netlify.app/blog/when-fresh-scents-turn-toxic-how-candles-and-incense-impact-your-health",
     title:
       "When fresh scents turn toxic: how candles and incense impact your health",
     image: `https://www.habitatmap.org/images/uploads/burning-candles-zz-230419-5dd288.avif${CDN_CROP}`,
   },
   {
-    slug: "green-spaces-jordan",
+    postSlug: "nyc-community-organizations-use-aircasting-to-study-hyperlocal-air-quality-1",
     url: "https://deploy-preview-244--habitatmap.netlify.app/blog/nyc-community-organizations-use-aircasting-to-study-hyperlocal-air-quality-1",
     title: "NYC Community Organizations Use AirCasting to Study Hyperlocal Air Quality",
     image: `https://www.habitatmap.org/images/uploads/williamsburghexagonmap.png${CDN_CROP}`,

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/config.ts
@@ -11,19 +11,19 @@
  * assuming no cooldown/dismiss/click suppression is active. Lower = rarer.
  * "Gentle" default: ~1 in 3 loads.
  */
-export const SHOW_PROBABILITY = 1;//0.35;
+export const SHOW_PROBABILITY = 0.3;
 
 /**
  * After the banner is shown, don't show it again for this many days
  * (even across page loads where the probability roll would pass).
  */
-export const COOLDOWN_DAYS = 0;//7;
+export const COOLDOWN_DAYS = 1;
 
 /** After the user closes (✕) the banner, suppress it for this many days. */
-export const DISMISS_DAYS = 0;//30;
+export const DISMISS_DAYS = 7;
 
 /** After the user clicks through to an article, suppress it for this many days. */
-export const CLICKED_DAYS = 0;//60;
+export const CLICKED_DAYS = 1;
 
 /** localStorage keys — namespaced to avoid clashes with other features. */
 export const STORAGE_KEYS = {
@@ -110,20 +110,20 @@ const CDN_CROP = "?nf_resize=smartcrop&w=680&h=280";
 export const BLOG_POSTS: BlogPost[] = [
   {
     postSlug: "what-do-those-colored-circles-mean-understanding-air-quality-on-the-aircasting-map",
-    url: "https://deploy-preview-244--habitatmap.netlify.app/blog/what-do-those-colored-circles-mean-understanding-air-quality-on-the-aircasting-map",
+    url: "https://www.habitatmap.org/blog/what-do-those-colored-circles-mean-understanding-air-quality-on-the-aircasting-map",
     title: "What do those colored dots mean? Understanding the Air Quality Index",
     image: `https://www.habitatmap.org/images/uploads/aircastingmapdots.png${CDN_CROP}`,
   },
   {
     postSlug: "when-fresh-scents-turn-toxic-how-candles-and-incense-impact-your-health",
-    url: "https://deploy-preview-244--habitatmap.netlify.app/blog/when-fresh-scents-turn-toxic-how-candles-and-incense-impact-your-health",
+    url: "https://www.habitatmap.org/blog/when-fresh-scents-turn-toxic-how-candles-and-incense-impact-your-health",
     title:
       "When fresh scents turn toxic: how candles and incense impact your health",
     image: `https://www.habitatmap.org/images/uploads/burning-candles-zz-230419-5dd288.avif${CDN_CROP}`,
   },
   {
     postSlug: "nyc-community-organizations-use-aircasting-to-study-hyperlocal-air-quality-1",
-    url: "https://deploy-preview-244--habitatmap.netlify.app/blog/nyc-community-organizations-use-aircasting-to-study-hyperlocal-air-quality-1",
+    url: "https://www.habitatmap.org/blog/nyc-community-organizations-use-aircasting-to-study-hyperlocal-air-quality-1",
     title: "NYC Community Organizations Use AirCasting to Study Hyperlocal Air Quality",
     image: `https://www.habitatmap.org/images/uploads/williamsburghexagonmap.png${CDN_CROP}`,
   },

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/index.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/index.ts
@@ -1,0 +1,1 @@
+export { InfoBanner } from "./InfoBanner";

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
@@ -1,0 +1,75 @@
+import {
+  BLOG_POSTS,
+  BlogPost,
+  CLICKED_DAYS,
+  COOLDOWN_DAYS,
+  DISMISS_DAYS,
+  SHOW_PROBABILITY,
+  STORAGE_KEYS,
+} from "./config";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// localStorage may be disabled (private mode, quota, SSR) — never throw.
+const safeGet = (key: string): string | null => {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const safeSet = (key: string, value: string): void => {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* storage disabled / quota — ignore */
+  }
+};
+
+/** True if `key` holds a timestamp newer than `days` ago (i.e. still suppressing). */
+const isWithin = (key: string, days: number): boolean => {
+  const raw = safeGet(key);
+  if (!raw) return false;
+  const ts = Number(raw);
+  if (!Number.isFinite(ts)) return false;
+  return Date.now() - ts < days * DAY_MS;
+};
+
+/**
+ * Decide whether the banner should appear on this page load.
+ * Suppressed by an active cooldown / dismissal / click-through; otherwise
+ * gated by a random probability so it stays occasional.
+ */
+export const shouldShow = (): boolean => {
+  if (BLOG_POSTS.length === 0) return false;
+  if (isWithin(STORAGE_KEYS.clickedAt, CLICKED_DAYS)) return false;
+  if (isWithin(STORAGE_KEYS.dismissedAt, DISMISS_DAYS)) return false;
+  if (isWithin(STORAGE_KEYS.lastShown, COOLDOWN_DAYS)) return false;
+  return Math.random() < SHOW_PROBABILITY;
+};
+
+/** Pick a random post, avoiding the one shown last time when possible. */
+export const pickPost = (): BlogPost => {
+  const lastSlug = safeGet(STORAGE_KEYS.lastSlug);
+  const candidates =
+    BLOG_POSTS.length > 1
+      ? BLOG_POSTS.filter((p) => p.slug !== lastSlug)
+      : BLOG_POSTS;
+  const pool = candidates.length > 0 ? candidates : BLOG_POSTS;
+  return pool[Math.floor(Math.random() * pool.length)];
+};
+
+/** Record that the banner was actually shown (starts the cooldown). */
+export const recordShown = (post: BlogPost): void => {
+  safeSet(STORAGE_KEYS.lastShown, String(Date.now()));
+  safeSet(STORAGE_KEYS.lastSlug, post.slug);
+};
+
+export const recordDismissed = (): void => {
+  safeSet(STORAGE_KEYS.dismissedAt, String(Date.now()));
+};
+
+export const recordClicked = (): void => {
+  safeSet(STORAGE_KEYS.clickedAt, String(Date.now()));
+};

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
@@ -67,7 +67,7 @@ export const pickVariant = (): BannerVariant =>
 export const withRef = (
   url: string,
   variant: BannerVariant,
-  slug: string
+  postSlug: string
 ): string => {
   try {
     const u = new URL(url);
@@ -75,7 +75,7 @@ export const withRef = (
     u.searchParams.set("utm_medium", LINK_REF.utmMedium);
     u.searchParams.set("utm_campaign", LINK_REF.utmCampaign);
     u.searchParams.set("utm_content", variant);
-    u.searchParams.set("ac_post", slug);
+    u.searchParams.set("ac_post", postSlug);
     return u.toString();
   } catch {
     return url;
@@ -84,10 +84,10 @@ export const withRef = (
 
 /** Pick a random post, avoiding the one shown last time when possible. */
 export const pickPost = (): BlogPost => {
-  const lastSlug = safeGet(STORAGE_KEYS.lastSlug);
+  const lastPostSlug = safeGet(STORAGE_KEYS.lastPostSlug);
   const candidates =
     BLOG_POSTS.length > 1
-      ? BLOG_POSTS.filter((p) => p.slug !== lastSlug)
+      ? BLOG_POSTS.filter((p) => p.postSlug !== lastPostSlug)
       : BLOG_POSTS;
   const pool = candidates.length > 0 ? candidates : BLOG_POSTS;
   return pool[Math.floor(Math.random() * pool.length)];
@@ -96,7 +96,7 @@ export const pickPost = (): BlogPost => {
 /** Record that the banner was actually shown (starts the cooldown). */
 export const recordShown = (post: BlogPost): void => {
   safeSet(STORAGE_KEYS.lastShown, String(Date.now()));
-  safeSet(STORAGE_KEYS.lastSlug, post.slug);
+  safeSet(STORAGE_KEYS.lastPostSlug, post.postSlug);
 };
 
 export const recordDismissed = (): void => {

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
@@ -5,6 +5,7 @@ import {
   CLICKED_DAYS,
   COOLDOWN_DAYS,
   DISMISS_DAYS,
+  LINK_REF,
   SHOW_PROBABILITY,
   STORAGE_KEYS,
   BlogPost,
@@ -62,6 +63,29 @@ export const pickVariant = (): BannerVariant => {
     Math.random() < AB_SPLIT_MINIMAL ? "minimal" : "full";
   safeSet(STORAGE_KEYS.variant, variant);
   return variant;
+};
+
+/**
+ * Append attribution params to a blog URL so the click can be traced through to
+ * a HabitatMap purchase. Preserves any existing query string; falls back to the
+ * raw URL if it can't be parsed.
+ */
+export const withRef = (
+  url: string,
+  variant: BannerVariant,
+  slug: string
+): string => {
+  try {
+    const u = new URL(url);
+    u.searchParams.set("utm_source", LINK_REF.utmSource);
+    u.searchParams.set("utm_medium", LINK_REF.utmMedium);
+    u.searchParams.set("utm_campaign", LINK_REF.utmCampaign);
+    u.searchParams.set("utm_content", variant);
+    u.searchParams.set("ac_post", slug);
+    return u.toString();
+  } catch {
+    return url;
+  }
 };
 
 /** Pick a random post, avoiding the one shown last time when possible. */

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
@@ -1,11 +1,13 @@
 import {
+  AB_SPLIT_MINIMAL,
   BLOG_POSTS,
-  BlogPost,
+  BannerVariant,
   CLICKED_DAYS,
   COOLDOWN_DAYS,
   DISMISS_DAYS,
   SHOW_PROBABILITY,
   STORAGE_KEYS,
+  BlogPost,
 } from "./config";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -47,6 +49,19 @@ export const shouldShow = (): boolean => {
   if (isWithin(STORAGE_KEYS.dismissedAt, DISMISS_DAYS)) return false;
   if (isWithin(STORAGE_KEYS.lastShown, COOLDOWN_DAYS)) return false;
   return Math.random() < SHOW_PROBABILITY;
+};
+
+/**
+ * Return the user's A/B variant, assigning (and persisting) one on first call.
+ * Sticky: once rolled, the same variant is returned for every future show.
+ */
+export const pickVariant = (): BannerVariant => {
+  const stored = safeGet(STORAGE_KEYS.variant);
+  if (stored === "full" || stored === "minimal") return stored;
+  const variant: BannerVariant =
+    Math.random() < AB_SPLIT_MINIMAL ? "minimal" : "full";
+  safeSet(STORAGE_KEYS.variant, variant);
+  return variant;
 };
 
 /** Pick a random post, avoiding the one shown last time when possible. */

--- a/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
+++ b/app/javascript/react/components/organisms/Modals/InfoBanner/logic.ts
@@ -53,17 +53,11 @@ export const shouldShow = (): boolean => {
 };
 
 /**
- * Return the user's A/B variant, assigning (and persisting) one on first call.
- * Sticky: once rolled, the same variant is returned for every future show.
+ * Roll the A/B variant fresh on every show (not persisted), so the split stays
+ * ~50/50 across all impressions and a returning user may see either version.
  */
-export const pickVariant = (): BannerVariant => {
-  const stored = safeGet(STORAGE_KEYS.variant);
-  if (stored === "full" || stored === "minimal") return stored;
-  const variant: BannerVariant =
-    Math.random() < AB_SPLIT_MINIMAL ? "minimal" : "full";
-  safeSet(STORAGE_KEYS.variant, variant);
-  return variant;
-};
+export const pickVariant = (): BannerVariant =>
+  Math.random() < AB_SPLIT_MINIMAL ? "minimal" : "full";
 
 /**
  * Append attribution params to a blog URL so the click can be traced through to

--- a/app/javascript/react/locales/en/translation.json
+++ b/app/javascript/react/locales/en/translation.json
@@ -295,5 +295,12 @@
     "acceptAll": "Accept All",
     "rejectAll": "Reject All",
     "save": "Save Preferences"
+  },
+  "infoBanner": {
+    "ariaLabel": "Featured article from HabitatMap",
+    "habitatMapAlt": "HabitatMap logo",
+    "kicker": "Learn more about air quality",
+    "readMore": "Read on the blog →",
+    "dismiss": "Dismiss"
   }
 }

--- a/app/javascript/react/pages/MapPage/MapPage.tsx
+++ b/app/javascript/react/pages/MapPage/MapPage.tsx
@@ -15,6 +15,12 @@ const SurveyBanner = lazy(() =>
   )
 );
 
+const InfoBanner = lazy(() =>
+  import("../../components/organisms/Modals/InfoBanner/InfoBanner").then(
+    (m) => ({ default: m.InfoBanner })
+  )
+);
+
 const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY || "";
 
 interface MapPageProps {
@@ -51,6 +57,9 @@ const MapPage: React.FC<MapPageProps> = ({ children }) => {
       />
       <Suspense fallback={null}>
         <SurveyBanner />
+      </Suspense>
+      <Suspense fallback={null}>
+        <InfoBanner />
       </Suspense>
     </APIProvider>
   );

--- a/app/javascript/react/pages/MapPage/MapPage.tsx
+++ b/app/javascript/react/pages/MapPage/MapPage.tsx
@@ -58,9 +58,11 @@ const MapPage: React.FC<MapPageProps> = ({ children }) => {
       <Suspense fallback={null}>
         <SurveyBanner />
       </Suspense>
-      <Suspense fallback={null}>
-        <InfoBanner />
-      </Suspense>
+      {!isMobile && (
+        <Suspense fallback={null}>
+          <InfoBanner />
+        </Suspense>
+      )}
     </APIProvider>
   );
 };

--- a/app/javascript/react/tests/unit/InfoBanner.test.tsx
+++ b/app/javascript/react/tests/unit/InfoBanner.test.tsx
@@ -13,6 +13,7 @@ jest.mock("react-i18next", () => ({
 jest.mock("../../components/organisms/Modals/InfoBanner/logic", () => ({
   shouldShow: jest.fn(),
   pickPost: jest.fn(),
+  pickVariant: jest.fn(),
   recordShown: jest.fn(),
   recordDismissed: jest.fn(),
   recordClicked: jest.fn(),
@@ -35,6 +36,9 @@ const POST_NO_IMAGE = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // Default to the "full" variant so existing image/button expectations hold;
+  // the minimal-variant test overrides this.
+  mocked.pickVariant.mockReturnValue("full");
 });
 
 describe("InfoBanner", () => {
@@ -107,5 +111,63 @@ describe("InfoBanner", () => {
     );
 
     expect(mocked.recordClicked).toHaveBeenCalledTimes(1);
+  });
+
+  describe("minimal variant", () => {
+    it("renders no hero image and no read-more button, just a clickable title", () => {
+      mocked.shouldShow.mockReturnValue(true);
+      mocked.pickVariant.mockReturnValue("minimal");
+      mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+      const { container } = render(<InfoBanner />);
+
+      // No hero image even though the post has one — logo + close icon only.
+      expect(
+        container.querySelector(`img[src="${POST_WITH_IMAGE.image}"]`)
+      ).not.toBeInTheDocument();
+      expect(container.querySelectorAll("img")).toHaveLength(2);
+
+      // No "read more" button — the title itself is the link.
+      expect(
+        screen.queryByRole("link", { name: "infoBanner.readMore" })
+      ).not.toBeInTheDocument();
+
+      const link = screen.getByRole("link", { name: POST_WITH_IMAGE.title });
+      expect(link).toHaveAttribute("href", POST_WITH_IMAGE.url);
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+
+    it("records a click-through when the card link is clicked", () => {
+      mocked.shouldShow.mockReturnValue(true);
+      mocked.pickVariant.mockReturnValue("minimal");
+      mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+      render(<InfoBanner />);
+
+      fireEvent.click(
+        screen.getByRole("link", { name: POST_WITH_IMAGE.title })
+      );
+
+      expect(mocked.recordClicked).toHaveBeenCalledTimes(1);
+    });
+
+    it("dismisses on close click without following the card link", () => {
+      mocked.shouldShow.mockReturnValue(true);
+      mocked.pickVariant.mockReturnValue("minimal");
+      mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+      render(<InfoBanner />);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "infoBanner.dismiss" })
+      );
+
+      expect(mocked.recordDismissed).toHaveBeenCalledTimes(1);
+      expect(mocked.recordClicked).not.toHaveBeenCalled();
+      expect(
+        screen.queryByText(POST_WITH_IMAGE.title)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/app/javascript/react/tests/unit/InfoBanner.test.tsx
+++ b/app/javascript/react/tests/unit/InfoBanner.test.tsx
@@ -25,14 +25,14 @@ jest.mock("../../components/organisms/Modals/InfoBanner/logic", () => ({
 const mocked = logic as jest.Mocked<typeof logic>;
 
 const POST_WITH_IMAGE = {
-  slug: "candles",
+  postSlug: "candles",
   url: "https://example.com/candles",
   title: "Candles and your health",
   image: "https://cdn.example.com/candles.jpg",
 };
 
 const POST_NO_IMAGE = {
-  slug: "brussels",
+  postSlug: "brussels",
   url: "https://example.com/brussels",
   title: "Clean air in Brussels",
 };
@@ -182,22 +182,24 @@ describe("InfoBanner", () => {
   });
 
   describe("GA4 / dataLayer tracking", () => {
-    it("pushes info_banner_shown once on mount with variant + slug", () => {
+    it("pushes banner_shown once on mount with the shared schema", () => {
       mocked.shouldShow.mockReturnValue(true);
       mocked.pickVariant.mockReturnValue("minimal");
       mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
 
       render(<InfoBanner />);
 
-      const shown = eventsOf("info_banner_shown");
+      const shown = eventsOf("banner_shown");
       expect(shown).toHaveLength(1);
       expect(shown[0]).toMatchObject({
+        banner_source: "aircasting",
+        banner_campaign: "blog_promo",
         banner_variant: "minimal",
-        post_slug: POST_WITH_IMAGE.slug,
+        post_slug: POST_WITH_IMAGE.postSlug,
       });
     });
 
-    it("pushes info_banner_clicked on click-through", () => {
+    it("pushes banner_clicked on click-through", () => {
       mocked.shouldShow.mockReturnValue(true);
       mocked.pickVariant.mockReturnValue("full");
       mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
@@ -207,12 +209,12 @@ describe("InfoBanner", () => {
         screen.getByRole("link", { name: "infoBanner.readMore" })
       );
 
-      expect(eventsOf("info_banner_clicked")).toMatchObject([
-        { banner_variant: "full", post_slug: POST_WITH_IMAGE.slug },
+      expect(eventsOf("banner_clicked")).toMatchObject([
+        { banner_variant: "full", post_slug: POST_WITH_IMAGE.postSlug },
       ]);
     });
 
-    it("pushes info_banner_dismissed on close", () => {
+    it("pushes banner_dismissed on close", () => {
       mocked.shouldShow.mockReturnValue(true);
       mocked.pickVariant.mockReturnValue("full");
       mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
@@ -222,8 +224,8 @@ describe("InfoBanner", () => {
         screen.getByRole("button", { name: "infoBanner.dismiss" })
       );
 
-      expect(eventsOf("info_banner_dismissed")).toMatchObject([
-        { banner_variant: "full", post_slug: POST_WITH_IMAGE.slug },
+      expect(eventsOf("banner_dismissed")).toMatchObject([
+        { banner_variant: "full", post_slug: POST_WITH_IMAGE.postSlug },
       ]);
     });
 
@@ -238,7 +240,7 @@ describe("InfoBanner", () => {
       expect(mocked.withRef).toHaveBeenCalledWith(
         POST_WITH_IMAGE.url,
         "full",
-        POST_WITH_IMAGE.slug
+        POST_WITH_IMAGE.postSlug
       );
       expect(
         screen.getByRole("link", { name: "infoBanner.readMore" })

--- a/app/javascript/react/tests/unit/InfoBanner.test.tsx
+++ b/app/javascript/react/tests/unit/InfoBanner.test.tsx
@@ -17,6 +17,9 @@ jest.mock("../../components/organisms/Modals/InfoBanner/logic", () => ({
   recordShown: jest.fn(),
   recordDismissed: jest.fn(),
   recordClicked: jest.fn(),
+  // Identity by default so href assertions read the raw post URL; the dedicated
+  // withRef unit tests (InfoBannerLogic) cover param building.
+  withRef: jest.fn((url: string) => url),
 }));
 
 const mocked = logic as jest.Mocked<typeof logic>;
@@ -39,7 +42,14 @@ beforeEach(() => {
   // Default to the "full" variant so existing image/button expectations hold;
   // the minimal-variant test overrides this.
   mocked.pickVariant.mockReturnValue("full");
+  mocked.withRef.mockImplementation((url: string) => url);
+  (window as any).dataLayer = [];
 });
+
+const eventsOf = (name: string) =>
+  ((window as any).dataLayer as Array<Record<string, unknown>>).filter(
+    (e) => e.event === name
+  );
 
 describe("InfoBanner", () => {
   it("renders nothing when shouldShow is false", () => {
@@ -168,6 +178,71 @@ describe("InfoBanner", () => {
       expect(
         screen.queryByText(POST_WITH_IMAGE.title)
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("GA4 / dataLayer tracking", () => {
+    it("pushes info_banner_shown once on mount with variant + slug", () => {
+      mocked.shouldShow.mockReturnValue(true);
+      mocked.pickVariant.mockReturnValue("minimal");
+      mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+      render(<InfoBanner />);
+
+      const shown = eventsOf("info_banner_shown");
+      expect(shown).toHaveLength(1);
+      expect(shown[0]).toMatchObject({
+        banner_variant: "minimal",
+        post_slug: POST_WITH_IMAGE.slug,
+      });
+    });
+
+    it("pushes info_banner_clicked on click-through", () => {
+      mocked.shouldShow.mockReturnValue(true);
+      mocked.pickVariant.mockReturnValue("full");
+      mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+      render(<InfoBanner />);
+      fireEvent.click(
+        screen.getByRole("link", { name: "infoBanner.readMore" })
+      );
+
+      expect(eventsOf("info_banner_clicked")).toMatchObject([
+        { banner_variant: "full", post_slug: POST_WITH_IMAGE.slug },
+      ]);
+    });
+
+    it("pushes info_banner_dismissed on close", () => {
+      mocked.shouldShow.mockReturnValue(true);
+      mocked.pickVariant.mockReturnValue("full");
+      mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+      render(<InfoBanner />);
+      fireEvent.click(
+        screen.getByRole("button", { name: "infoBanner.dismiss" })
+      );
+
+      expect(eventsOf("info_banner_dismissed")).toMatchObject([
+        { banner_variant: "full", post_slug: POST_WITH_IMAGE.slug },
+      ]);
+    });
+
+    it("builds the outbound href via withRef", () => {
+      mocked.shouldShow.mockReturnValue(true);
+      mocked.pickVariant.mockReturnValue("full");
+      mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+      mocked.withRef.mockReturnValue("https://example.com/tagged");
+
+      render(<InfoBanner />);
+
+      expect(mocked.withRef).toHaveBeenCalledWith(
+        POST_WITH_IMAGE.url,
+        "full",
+        POST_WITH_IMAGE.slug
+      );
+      expect(
+        screen.getByRole("link", { name: "infoBanner.readMore" })
+      ).toHaveAttribute("href", "https://example.com/tagged");
     });
   });
 });

--- a/app/javascript/react/tests/unit/InfoBanner.test.tsx
+++ b/app/javascript/react/tests/unit/InfoBanner.test.tsx
@@ -1,0 +1,111 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+import { InfoBanner } from "../../components/organisms/Modals/InfoBanner/InfoBanner";
+import * as logic from "../../components/organisms/Modals/InfoBanner/logic";
+
+// t() echoes the key so we can assert on it.
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("../../components/organisms/Modals/InfoBanner/logic", () => ({
+  shouldShow: jest.fn(),
+  pickPost: jest.fn(),
+  recordShown: jest.fn(),
+  recordDismissed: jest.fn(),
+  recordClicked: jest.fn(),
+}));
+
+const mocked = logic as jest.Mocked<typeof logic>;
+
+const POST_WITH_IMAGE = {
+  slug: "candles",
+  url: "https://example.com/candles",
+  title: "Candles and your health",
+  image: "https://cdn.example.com/candles.jpg",
+};
+
+const POST_NO_IMAGE = {
+  slug: "brussels",
+  url: "https://example.com/brussels",
+  title: "Clean air in Brussels",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("InfoBanner", () => {
+  it("renders nothing when shouldShow is false", () => {
+    mocked.shouldShow.mockReturnValue(false);
+    const { container } = render(<InfoBanner />);
+    expect(container).toBeEmptyDOMElement();
+    expect(mocked.recordShown).not.toHaveBeenCalled();
+  });
+
+  it("renders the image variant and records the show", () => {
+    mocked.shouldShow.mockReturnValue(true);
+    mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+    const { container } = render(<InfoBanner />);
+
+    expect(screen.getByText(POST_WITH_IMAGE.title)).toBeInTheDocument();
+    expect(
+      container.querySelector(`img[src="${POST_WITH_IMAGE.image}"]`)
+    ).toBeInTheDocument();
+    expect(mocked.recordShown).toHaveBeenCalledWith(POST_WITH_IMAGE);
+  });
+
+  it("points the read link at the post URL and opens a new tab", () => {
+    mocked.shouldShow.mockReturnValue(true);
+    mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+    render(<InfoBanner />);
+
+    const link = screen.getByRole("link", { name: "infoBanner.readMore" });
+    expect(link).toHaveAttribute("href", POST_WITH_IMAGE.url);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders the compact variant (no hero image) when the post has no image", () => {
+    mocked.shouldShow.mockReturnValue(true);
+    mocked.pickPost.mockReturnValue(POST_NO_IMAGE);
+
+    const { container } = render(<InfoBanner />);
+
+    expect(screen.getByText(POST_NO_IMAGE.title)).toBeInTheDocument();
+    // Only the HabitatMap logo img — no post hero image.
+    const imgs = container.querySelectorAll("img");
+    expect(imgs).toHaveLength(2); // logo + close icon, no hero
+  });
+
+  it("dismisses on close click and hides the banner", () => {
+    mocked.shouldShow.mockReturnValue(true);
+    mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+    render(<InfoBanner />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "infoBanner.dismiss" })
+    );
+
+    expect(mocked.recordDismissed).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(POST_WITH_IMAGE.title)).not.toBeInTheDocument();
+  });
+
+  it("records a click-through when the article link is clicked", () => {
+    mocked.shouldShow.mockReturnValue(true);
+    mocked.pickPost.mockReturnValue(POST_WITH_IMAGE);
+
+    render(<InfoBanner />);
+
+    fireEvent.click(
+      screen.getByRole("link", { name: "infoBanner.readMore" })
+    );
+
+    expect(mocked.recordClicked).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
+++ b/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
@@ -24,6 +24,11 @@ jest.mock(
     DISMISS_DAYS: 30,
     CLICKED_DAYS: 60,
     AB_SPLIT_MINIMAL: 0.5,
+    LINK_REF: {
+      utmSource: "aircasting",
+      utmMedium: "info_banner",
+      utmCampaign: "blog_promo",
+    },
     STORAGE_KEYS,
     BLOG_POSTS: MOCK_POSTS,
   }),
@@ -37,6 +42,7 @@ import {
   recordDismissed,
   recordShown,
   shouldShow,
+  withRef,
 } from "../../components/organisms/Modals/InfoBanner/logic";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -144,6 +150,29 @@ describe("pickVariant", () => {
     window.localStorage.setItem(STORAGE_KEYS.variant, "garbage");
     jest.spyOn(Math, "random").mockReturnValue(0.1);
     expect(pickVariant()).toBe("minimal");
+  });
+});
+
+describe("withRef", () => {
+  it("appends utm params, variant (utm_content) and ac_post slug", () => {
+    const out = withRef("https://example.com/a", "minimal", "a");
+    const u = new URL(out);
+    expect(u.searchParams.get("utm_source")).toBe("aircasting");
+    expect(u.searchParams.get("utm_medium")).toBe("info_banner");
+    expect(u.searchParams.get("utm_campaign")).toBe("blog_promo");
+    expect(u.searchParams.get("utm_content")).toBe("minimal");
+    expect(u.searchParams.get("ac_post")).toBe("a");
+  });
+
+  it("preserves an existing query string on the post URL", () => {
+    const out = withRef("https://example.com/a?foo=bar", "full", "a");
+    const u = new URL(out);
+    expect(u.searchParams.get("foo")).toBe("bar");
+    expect(u.searchParams.get("utm_content")).toBe("full");
+  });
+
+  it("falls back to the raw URL when it can't be parsed", () => {
+    expect(withRef("not a url", "full", "a")).toBe("not a url");
   });
 });
 

--- a/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
+++ b/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
@@ -3,16 +3,16 @@
 // config.ts (probability / cooldown windows / post list).
 
 const MOCK_POSTS = [
-  { slug: "a", url: "https://example.com/a", title: "A", image: "a.jpg" },
-  { slug: "b", url: "https://example.com/b", title: "B" },
-  { slug: "c", url: "https://example.com/c", title: "C" },
+  { postSlug: "a", url: "https://example.com/a", title: "A", image: "a.jpg" },
+  { postSlug: "b", url: "https://example.com/b", title: "B" },
+  { postSlug: "c", url: "https://example.com/c", title: "C" },
 ];
 
 const STORAGE_KEYS = {
   lastShown: "ac_blog_last_shown",
   dismissedAt: "ac_blog_dismissed_at",
   clickedAt: "ac_blog_clicked_at",
-  lastSlug: "ac_blog_last_slug",
+  lastPostSlug: "ac_blog_last_post_slug",
 };
 
 jest.mock(
@@ -116,11 +116,11 @@ describe("pickPost", () => {
   });
 
   it("never repeats the last shown slug", () => {
-    window.localStorage.setItem(STORAGE_KEYS.lastSlug, "a");
+    window.localStorage.setItem(STORAGE_KEYS.lastPostSlug, "a");
     // Sweep the random space; "a" must never be chosen.
     for (let r = 0; r < 1; r += 0.05) {
       jest.spyOn(Math, "random").mockReturnValue(r);
-      expect(pickPost().slug).not.toBe("a");
+      expect(pickPost().postSlug).not.toBe("a");
     }
   });
 });
@@ -176,12 +176,12 @@ describe("withRef", () => {
 });
 
 describe("recorders", () => {
-  it("recordShown stamps lastShown (now) and lastSlug", () => {
+  it("recordShown stamps lastShown (now) and lastPostSlug", () => {
     recordShown(MOCK_POSTS[1]);
     expect(window.localStorage.getItem(STORAGE_KEYS.lastShown)).toBe(
       String(NOW)
     );
-    expect(window.localStorage.getItem(STORAGE_KEYS.lastSlug)).toBe("b");
+    expect(window.localStorage.getItem(STORAGE_KEYS.lastPostSlug)).toBe("b");
   });
 
   it("recordDismissed stamps dismissedAt", () => {

--- a/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
+++ b/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
@@ -1,0 +1,149 @@
+// Logic tests for the InfoBanner display gate. The ./config module is mocked
+// with fixed values so these tests are independent of the live tuning in
+// config.ts (probability / cooldown windows / post list).
+
+const MOCK_POSTS = [
+  { slug: "a", url: "https://example.com/a", title: "A", image: "a.jpg" },
+  { slug: "b", url: "https://example.com/b", title: "B" },
+  { slug: "c", url: "https://example.com/c", title: "C" },
+];
+
+const STORAGE_KEYS = {
+  lastShown: "ac_blog_last_shown",
+  dismissedAt: "ac_blog_dismissed_at",
+  clickedAt: "ac_blog_clicked_at",
+  lastSlug: "ac_blog_last_slug",
+};
+
+jest.mock(
+  "../../components/organisms/Modals/InfoBanner/config",
+  () => ({
+    SHOW_PROBABILITY: 0.5,
+    COOLDOWN_DAYS: 7,
+    DISMISS_DAYS: 30,
+    CLICKED_DAYS: 60,
+    STORAGE_KEYS,
+    BLOG_POSTS: MOCK_POSTS,
+  }),
+  { virtual: false }
+);
+
+import {
+  pickPost,
+  recordClicked,
+  recordDismissed,
+  recordShown,
+  shouldShow,
+} from "../../components/organisms/Modals/InfoBanner/logic";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = 1_700_000_000_000; // fixed "now"
+
+beforeEach(() => {
+  window.localStorage.clear();
+  jest.spyOn(Date, "now").mockReturnValue(NOW);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const daysAgo = (n: number) => String(NOW - n * DAY_MS);
+
+describe("shouldShow", () => {
+  it("returns true when nothing suppresses and the roll passes", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.1); // < 0.5
+    expect(shouldShow()).toBe(true);
+  });
+
+  it("returns false when the probability roll fails", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.9); // >= 0.5
+    expect(shouldShow()).toBe(false);
+  });
+
+  it("is suppressed during the cooldown after being shown", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    window.localStorage.setItem(STORAGE_KEYS.lastShown, daysAgo(3)); // < 7d
+    expect(shouldShow()).toBe(false);
+  });
+
+  it("shows again once the cooldown has elapsed", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    window.localStorage.setItem(STORAGE_KEYS.lastShown, daysAgo(8)); // > 7d
+    expect(shouldShow()).toBe(true);
+  });
+
+  it("is suppressed for the dismiss window after being closed", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    window.localStorage.setItem(STORAGE_KEYS.dismissedAt, daysAgo(10)); // < 30d
+    expect(shouldShow()).toBe(false);
+  });
+
+  it("is suppressed for the clicked window after a click-through", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    window.localStorage.setItem(STORAGE_KEYS.clickedAt, daysAgo(40)); // < 60d
+    expect(shouldShow()).toBe(false);
+  });
+
+  it("ignores a non-numeric stored timestamp (treats as not suppressing)", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    window.localStorage.setItem(STORAGE_KEYS.lastShown, "garbage");
+    expect(shouldShow()).toBe(true);
+  });
+
+  it("does not throw when localStorage.getItem is unavailable", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => shouldShow()).not.toThrow();
+    expect(shouldShow()).toBe(true);
+  });
+});
+
+describe("pickPost", () => {
+  it("returns a post from the list", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    expect(MOCK_POSTS).toContainEqual(pickPost());
+  });
+
+  it("never repeats the last shown slug", () => {
+    window.localStorage.setItem(STORAGE_KEYS.lastSlug, "a");
+    // Sweep the random space; "a" must never be chosen.
+    for (let r = 0; r < 1; r += 0.05) {
+      jest.spyOn(Math, "random").mockReturnValue(r);
+      expect(pickPost().slug).not.toBe("a");
+    }
+  });
+});
+
+describe("recorders", () => {
+  it("recordShown stamps lastShown (now) and lastSlug", () => {
+    recordShown(MOCK_POSTS[1]);
+    expect(window.localStorage.getItem(STORAGE_KEYS.lastShown)).toBe(
+      String(NOW)
+    );
+    expect(window.localStorage.getItem(STORAGE_KEYS.lastSlug)).toBe("b");
+  });
+
+  it("recordDismissed stamps dismissedAt", () => {
+    recordDismissed();
+    expect(window.localStorage.getItem(STORAGE_KEYS.dismissedAt)).toBe(
+      String(NOW)
+    );
+  });
+
+  it("recordClicked stamps clickedAt", () => {
+    recordClicked();
+    expect(window.localStorage.getItem(STORAGE_KEYS.clickedAt)).toBe(
+      String(NOW)
+    );
+  });
+
+  it("does not throw when localStorage.setItem rejects (quota)", () => {
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => recordShown(MOCK_POSTS[0])).not.toThrow();
+  });
+});

--- a/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
+++ b/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
@@ -13,7 +13,6 @@ const STORAGE_KEYS = {
   dismissedAt: "ac_blog_dismissed_at",
   clickedAt: "ac_blog_clicked_at",
   lastSlug: "ac_blog_last_slug",
-  variant: "ac_blog_ab_variant",
 };
 
 jest.mock(
@@ -130,26 +129,26 @@ describe("pickVariant", () => {
   it("rolls 'minimal' when the random draw is below the split", () => {
     jest.spyOn(Math, "random").mockReturnValue(0.1); // < 0.5
     expect(pickVariant()).toBe("minimal");
-    expect(window.localStorage.getItem(STORAGE_KEYS.variant)).toBe("minimal");
   });
 
   it("rolls 'full' when the random draw is at/above the split", () => {
     jest.spyOn(Math, "random").mockReturnValue(0.9); // >= 0.5
     expect(pickVariant()).toBe("full");
-    expect(window.localStorage.getItem(STORAGE_KEYS.variant)).toBe("full");
   });
 
-  it("is sticky: returns the persisted variant regardless of the roll", () => {
-    window.localStorage.setItem(STORAGE_KEYS.variant, "minimal");
-    // Roll would pick 'full', but the stored value wins.
-    jest.spyOn(Math, "random").mockReturnValue(0.9);
-    expect(pickVariant()).toBe("minimal");
-  });
-
-  it("ignores a corrupt stored value and re-rolls", () => {
-    window.localStorage.setItem(STORAGE_KEYS.variant, "garbage");
+  it("does not persist the variant (fresh roll every call)", () => {
+    const setItem = jest.spyOn(Storage.prototype, "setItem");
     jest.spyOn(Math, "random").mockReturnValue(0.1);
+    pickVariant();
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("can return different variants across calls", () => {
+    const random = jest.spyOn(Math, "random");
+    random.mockReturnValueOnce(0.1); // minimal
+    random.mockReturnValueOnce(0.9); // full
     expect(pickVariant()).toBe("minimal");
+    expect(pickVariant()).toBe("full");
   });
 });
 

--- a/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
+++ b/app/javascript/react/tests/unit/InfoBannerLogic.test.tsx
@@ -13,6 +13,7 @@ const STORAGE_KEYS = {
   dismissedAt: "ac_blog_dismissed_at",
   clickedAt: "ac_blog_clicked_at",
   lastSlug: "ac_blog_last_slug",
+  variant: "ac_blog_ab_variant",
 };
 
 jest.mock(
@@ -22,6 +23,7 @@ jest.mock(
     COOLDOWN_DAYS: 7,
     DISMISS_DAYS: 30,
     CLICKED_DAYS: 60,
+    AB_SPLIT_MINIMAL: 0.5,
     STORAGE_KEYS,
     BLOG_POSTS: MOCK_POSTS,
   }),
@@ -30,6 +32,7 @@ jest.mock(
 
 import {
   pickPost,
+  pickVariant,
   recordClicked,
   recordDismissed,
   recordShown,
@@ -114,6 +117,33 @@ describe("pickPost", () => {
       jest.spyOn(Math, "random").mockReturnValue(r);
       expect(pickPost().slug).not.toBe("a");
     }
+  });
+});
+
+describe("pickVariant", () => {
+  it("rolls 'minimal' when the random draw is below the split", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.1); // < 0.5
+    expect(pickVariant()).toBe("minimal");
+    expect(window.localStorage.getItem(STORAGE_KEYS.variant)).toBe("minimal");
+  });
+
+  it("rolls 'full' when the random draw is at/above the split", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.9); // >= 0.5
+    expect(pickVariant()).toBe("full");
+    expect(window.localStorage.getItem(STORAGE_KEYS.variant)).toBe("full");
+  });
+
+  it("is sticky: returns the persisted variant regardless of the roll", () => {
+    window.localStorage.setItem(STORAGE_KEYS.variant, "minimal");
+    // Roll would pick 'full', but the stored value wins.
+    jest.spyOn(Math, "random").mockReturnValue(0.9);
+    expect(pickVariant()).toBe("minimal");
+  });
+
+  it("ignores a corrupt stored value and re-rolls", () => {
+    window.localStorage.setItem(STORAGE_KEYS.variant, "garbage");
+    jest.spyOn(Math, "random").mockReturnValue(0.1);
+    expect(pickVariant()).toBe("minimal");
   });
 });
 

--- a/app/javascript/react/tests/unit/trackBannerEvent.test.tsx
+++ b/app/javascript/react/tests/unit/trackBannerEvent.test.tsx
@@ -5,53 +5,53 @@ describe("trackBannerEvent", () => {
     (window as any).dataLayer = [];
   });
 
-  it("pushes info_banner_shown with variant + slug", () => {
+  it("pushes banner_shown with the shared schema (source + campaign + variant + slug)", () => {
     trackBannerEvent({
-      event: "info_banner_shown",
+      event: "banner_shown",
       variant: "minimal",
       postSlug: "candles-incense",
     });
 
     expect(window.dataLayer).toEqual([
       {
-        event: "info_banner_shown",
+        event: "banner_shown",
+        banner_source: "aircasting",
+        banner_campaign: "blog_promo",
         banner_variant: "minimal",
         post_slug: "candles-incense",
       },
     ]);
   });
 
-  it("pushes info_banner_clicked and info_banner_dismissed", () => {
+  it("pushes banner_clicked and banner_dismissed", () => {
     trackBannerEvent({
-      event: "info_banner_clicked",
+      event: "banner_clicked",
       variant: "full",
       postSlug: "aqi-colored-dots",
     });
     trackBannerEvent({
-      event: "info_banner_dismissed",
+      event: "banner_dismissed",
       variant: "full",
       postSlug: "aqi-colored-dots",
     });
 
-    expect(window.dataLayer).toEqual([
-      {
-        event: "info_banner_clicked",
-        banner_variant: "full",
-        post_slug: "aqi-colored-dots",
-      },
-      {
-        event: "info_banner_dismissed",
-        banner_variant: "full",
-        post_slug: "aqi-colored-dots",
-      },
+    expect(window.dataLayer!.map((e) => e.event)).toEqual([
+      "banner_clicked",
+      "banner_dismissed",
     ]);
+    expect(window.dataLayer![0]).toMatchObject({
+      banner_source: "aircasting",
+      banner_campaign: "blog_promo",
+      banner_variant: "full",
+      post_slug: "aqi-colored-dots",
+    });
   });
 
   it("initializes dataLayer if undefined", () => {
     delete (window as any).dataLayer;
 
     trackBannerEvent({
-      event: "info_banner_shown",
+      event: "banner_shown",
       variant: "full",
       postSlug: "x",
     });

--- a/app/javascript/react/tests/unit/trackBannerEvent.test.tsx
+++ b/app/javascript/react/tests/unit/trackBannerEvent.test.tsx
@@ -1,0 +1,62 @@
+import { trackBannerEvent } from "../../utils/trackBannerEvent";
+
+describe("trackBannerEvent", () => {
+  beforeEach(() => {
+    (window as any).dataLayer = [];
+  });
+
+  it("pushes info_banner_shown with variant + slug", () => {
+    trackBannerEvent({
+      event: "info_banner_shown",
+      variant: "minimal",
+      postSlug: "candles-incense",
+    });
+
+    expect(window.dataLayer).toEqual([
+      {
+        event: "info_banner_shown",
+        banner_variant: "minimal",
+        post_slug: "candles-incense",
+      },
+    ]);
+  });
+
+  it("pushes info_banner_clicked and info_banner_dismissed", () => {
+    trackBannerEvent({
+      event: "info_banner_clicked",
+      variant: "full",
+      postSlug: "aqi-colored-dots",
+    });
+    trackBannerEvent({
+      event: "info_banner_dismissed",
+      variant: "full",
+      postSlug: "aqi-colored-dots",
+    });
+
+    expect(window.dataLayer).toEqual([
+      {
+        event: "info_banner_clicked",
+        banner_variant: "full",
+        post_slug: "aqi-colored-dots",
+      },
+      {
+        event: "info_banner_dismissed",
+        banner_variant: "full",
+        post_slug: "aqi-colored-dots",
+      },
+    ]);
+  });
+
+  it("initializes dataLayer if undefined", () => {
+    delete (window as any).dataLayer;
+
+    trackBannerEvent({
+      event: "info_banner_shown",
+      variant: "full",
+      postSlug: "x",
+    });
+
+    expect(Array.isArray(window.dataLayer)).toBe(true);
+    expect(window.dataLayer).toHaveLength(1);
+  });
+});

--- a/app/javascript/react/utils/trackBannerEvent.ts
+++ b/app/javascript/react/utils/trackBannerEvent.ts
@@ -1,4 +1,8 @@
-import { BannerVariant } from "../components/organisms/Modals/InfoBanner/config";
+import {
+  BANNER_CAMPAIGN,
+  BANNER_SOURCE,
+  BannerVariant,
+} from "../components/organisms/Modals/InfoBanner/config";
 
 declare global {
   interface Window {
@@ -6,21 +10,25 @@ declare global {
   }
 }
 
+// Event names + params are the SHARED schema used by both AirCasting and
+// HabitatMap. Keep identical to HabitatMap/docs/analytics-tracking.md §1.3 so a
+// single set of GTM tags covers both sites.
 export type BannerEventName =
-  | "info_banner_shown"
-  | "info_banner_dismissed"
-  | "info_banner_clicked";
+  | "banner_shown"
+  | "banner_dismissed"
+  | "banner_clicked";
 
 interface TrackBannerEventParams {
   event: BannerEventName;
   variant: BannerVariant;
+  /** The HM post's URL slug — the join key shared across AC & HM. */
   postSlug: string;
 }
 
 /**
  * Push an InfoBanner A/B event to the GTM dataLayer. Fire-and-forget: if GTM is
  * not loaded (no cookie consent) the push is harmless and simply never forwarded.
- * Mirrors the trackCityEvent util.
+ * Mirrors HabitatMap's airbeam-ab.js push shape.
  */
 export const trackBannerEvent = ({
   event,
@@ -30,6 +38,8 @@ export const trackBannerEvent = ({
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
     event,
+    banner_source: BANNER_SOURCE,
+    banner_campaign: BANNER_CAMPAIGN,
     banner_variant: variant,
     post_slug: postSlug,
   });

--- a/app/javascript/react/utils/trackBannerEvent.ts
+++ b/app/javascript/react/utils/trackBannerEvent.ts
@@ -1,0 +1,36 @@
+import { BannerVariant } from "../components/organisms/Modals/InfoBanner/config";
+
+declare global {
+  interface Window {
+    dataLayer?: Record<string, unknown>[];
+  }
+}
+
+export type BannerEventName =
+  | "info_banner_shown"
+  | "info_banner_dismissed"
+  | "info_banner_clicked";
+
+interface TrackBannerEventParams {
+  event: BannerEventName;
+  variant: BannerVariant;
+  postSlug: string;
+}
+
+/**
+ * Push an InfoBanner A/B event to the GTM dataLayer. Fire-and-forget: if GTM is
+ * not loaded (no cookie consent) the push is harmless and simply never forwarded.
+ * Mirrors the trackCityEvent util.
+ */
+export const trackBannerEvent = ({
+  event,
+  variant,
+  postSlug,
+}: TrackBannerEventParams): void => {
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    event,
+    banner_variant: variant,
+    post_slug: postSlug,
+  });
+};


### PR DESCRIPTION
Adds a banner featuring HabitatMap's blog post with options to configure how often it should be displayed to users

**CURRENT SETTINGS** -> make info banner displayed every time, should be adjusted before production deploy