### PR TITLE
Fix: font fallback to prevent serif flash

### DIFF
--- a/app/javascript/react/assets/styles/global-styles.ts
+++ b/app/javascript/react/assets/styles/global-styles.ts
@@ -32,7 +32,7 @@ const GlobalStyles = createGlobalStyle`
 
   body, button {
     box-sizing: border-box;
-    font-family: 'Roboto';
+    font-family: 'Roboto', sans-serif;
     line-height: 1;
   }
 

--- a/app/javascript/react/assets/styles/typography.css
+++ b/app/javascript/react/assets/styles/typography.css
@@ -2,7 +2,7 @@
   font-family: "Roboto";
   font-weight: 400;
   font-style: normal;
-  font-display: auto;
+  font-display: swap;
   src: url("../fonts/Roboto-400.woff2") format("woff2");
   unicode-range: U+000-5FF;
 }
@@ -11,7 +11,7 @@
   font-family: "Roboto";
   font-weight: 500;
   font-style: normal;
-  font-display: auto;
+  font-display: swap;
   src: url("../fonts/Roboto-500.woff2") format("woff2");
   unicode-range: U+000-5FF;
 }
@@ -20,7 +20,7 @@
   font-family: "Roboto";
   font-weight: 600;
   font-style: normal;
-  font-display: auto;
+  font-display: swap;
   src: url("../fonts/Roboto-600.woff2") format("woff2");
     unicode-range: U+000-5FF;
 }
@@ -29,7 +29,7 @@
   font-family: "Moderat";
   font-weight: normal;
   font-style: normal;
-  font-display: auto;
+  font-display: swap;
   src: url("../fonts/Moderat-Bold.woff2") format("woff2"),
   url("../fonts/Moderat-Bold.woff") format("woff"),
   url("../fonts/Moderat-Bold.ttf") format("truetype");

--- a/app/javascript/react/components/organisms/ThresholdConfigurator/ThresholdConfigurator.style.tsx
+++ b/app/javascript/react/components/organisms/ThresholdConfigurator/ThresholdConfigurator.style.tsx
@@ -410,7 +410,7 @@ const NumberInput = styled.input<{
   $isActive?: boolean;
   $isMin?: boolean;
 }>`
-  font-family: Roboto;
+  font-family: Roboto, sans-serif;
   font-weight: 400;
   font-size: 16px;
   text-align: center;


### PR DESCRIPTION
Text sometimes rendered in the browser's default serif font (e.g. the info banner and map controls) when the Roboto/Moderat web fonts failed or loaded slowly. CSS-only fix, no logic change:

- Added `sans-serif` generic fallback to the global `body, button` stack and the ThresholdConfigurator number input (so a failed/slow font load falls back to system sans-serif, not serif).
- Changed all `@font-face` `font-display: auto` → `swap` so the fallback renders immediately and swaps in the web font once loaded.