### PR TITLE
fix: add advisory lock on session uuid

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -19,6 +19,39 @@ class Session < ApplicationRecord
   validates :type, presence: :true
   validates :url_token, :uuid, uniqueness: { case_sensitive: false }
 
+  # Serialises session creation per uuid.
+  #
+  # Both the API contracts and the uniqueness validation ask "does this uuid
+  # exist?" with a SELECT before the INSERT, so two requests arriving in the same
+  # second both hear "no" and both insert — which is exactly how the duplicates in
+  # production were created (identical copies, created_at 0-1s apart). An advisory
+  # lock makes the second request wait for the first to finish, so its check sees
+  # the committed row and it takes the normal "uuid taken" path.
+  #
+  # `pg_advisory_xact_lock` is released automatically when the transaction ends,
+  # so nothing can leak a lock, and it works under transaction-pooling connection
+  # poolers. It locks no table and no row: measurement inserts happen outside this
+  # transaction, so the lock is held for milliseconds.
+  #
+  # `hashtextextended` gives a 64-bit key (Postgres 11+), so unrelated uuids do
+  # not collide the way they can with the 32-bit `hashtext`.
+  #
+  # This is a guard, not a guarantee: only code paths that call it are protected,
+  # so a rake task or console insert bypasses it. The permanent fix is a unique
+  # index on `sessions.uuid`, which needs the existing duplicates resolved first.
+  UUID_LOCK_TIMEOUT = '3s'.freeze
+
+  def self.with_uuid_lock(uuid)
+    transaction do
+      connection.execute("SET LOCAL lock_timeout = '#{UUID_LOCK_TIMEOUT}'")
+      connection.execute(
+        sanitize_sql_array(['SELECT pg_advisory_xact_lock(hashtextextended(?, 0))', uuid.to_s]),
+      )
+
+      yield
+    end
+  end
+
   accepts_nested_attributes_for :notes, :streams
 
   before_validation :set_url_token, unless: :url_token

--- a/app/services/fixed_sessions/creator.rb
+++ b/app/services/fixed_sessions/creator.rb
@@ -3,12 +3,21 @@ module FixedSessions
     UnknownStreamTypeError = Class.new(StandardError)
 
     def call(data:, user:)
-      ActiveRecord::Base.transaction do
+      # Serialised per uuid: two creates arriving at once would otherwise both
+      # pass the uniqueness validation's SELECT and both insert. The loser now
+      # waits, then fails validation as it would have on any later attempt.
+      Session.with_uuid_lock(data[:uuid]) do
         device = find_or_create_device(data[:airbeam])
         session = create_session(data, user, device)
         streams = create_streams(data, session)
         Success.new(session: session, session_token: session.session_token, streams: streams)
       end
+    rescue ActiveRecord::LockWaitTimeout
+      # Another create for this uuid is still running; the client should retry.
+      Failure.new(
+        error_code: BinaryProtocol::ErrorCodes::INTERNAL_ERROR,
+        message: 'Could not acquire a lock for this session, please retry',
+      )
     rescue UnknownStreamTypeError => e
       Failure.new(error_code: BinaryProtocol::ErrorCodes::UNSUPPORTED_SENSOR_TYPE, message: e.message)
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e

--- a/lib/session_builder.rb
+++ b/lib/session_builder.rb
@@ -24,7 +24,10 @@ class SessionBuilder
     allowed = Session.attribute_names + %w[notes_attributes tag_list user]
     filtered = data.select { |k, _| allowed.include?(k.to_s) }
 
-    Session.transaction do
+    # Serialised per uuid so two concurrent uploads of the same session cannot
+    # both pass the uniqueness check and insert (see Session.with_uuid_lock).
+    # Measurements are created after this block, so the lock is short-lived.
+    Session.with_uuid_lock(data[:uuid]) do
       session = Session.create!(filtered)
 
       stream_data.values.each do |a_stream|
@@ -44,6 +47,11 @@ class SessionBuilder
   rescue ActiveRecord::RecordInvalid => invalid
     Rails.logger.warn("[SessionBuilder] data: #{data}")
     Rails.logger.warn(invalid.record.errors.full_messages)
+    nil
+  rescue ActiveRecord::LockWaitTimeout
+    # Another upload of this uuid is still in flight. Same outcome as an invalid
+    # session: the controller answers 400 and the app retries on its next sync.
+    Rails.logger.warn("[SessionBuilder] uuid lock timeout for #{data[:uuid]}")
     nil
   end
 

--- a/spec/models/session_uuid_lock_spec.rb
+++ b/spec/models/session_uuid_lock_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+# The point of the lock is what happens when two requests race, which a
+# transactional example cannot show — the second connection would not see the
+# first one's uncommitted rows. These examples therefore manage their own data.
+RSpec.describe 'Session uuid locking', type: :model do
+  self.use_transactional_tests = false
+
+  let(:uuid) { SecureRandom.uuid }
+  let!(:user) { create(:user) }
+
+  before do
+    allow(TimeZoneFinderWrapper.instance).to receive(:time_zone_at).and_return('UTC')
+    create(:threshold_set, :air_beam_pm2_5, :default)
+  end
+
+  after do
+    # Nothing here is rolled back for us, and destroying a session writes a
+    # `deleted_sessions` tombstone that other examples read — clear it too.
+    Session.where(uuid: uuid).destroy_all
+    DeletedSession.where(uuid: uuid).delete_all
+    Device.where(mac_address: 'AA:BB:CC:DD:EE:FF').delete_all
+    ThresholdSet.where(sensor_name: 'AirBeam-PM2.5').delete_all
+    user.destroy
+  end
+
+  def create_params
+    {
+      uuid: uuid,
+      title: 'Roof Session',
+      latitude: 40.7128,
+      longitude: -74.0060,
+      contribute: true,
+      airbeam: { mac_address: 'AA:BB:CC:DD:EE:FF', model: 'AirBeamMini' },
+      streams: [{ sensor_name: 'AirBeamMini-PM2.5', unit_symbol: 'µg/m³' }],
+    }
+  end
+
+  it 'lets only one of two simultaneous creates through' do
+    results = []
+    mutex = Mutex.new
+    barrier = Concurrent::CountDownLatch.new(2)
+
+    threads = 2.times.map do
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          barrier.count_down
+          barrier.wait(5)
+          result = FixedSessions::Creator.new.call(data: create_params, user: user)
+          mutex.synchronize { results << result }
+        end
+      end
+    end
+    threads.each(&:join)
+
+    expect(Session.where(uuid: uuid).count).to eq(1)
+    expect(results.count(&:success?)).to eq(1)
+    expect(results.count(&:failure?)).to eq(1)
+  end
+
+  it 'still creates the session when nothing competes for the lock' do
+    result = FixedSessions::Creator.new.call(data: create_params, user: user)
+
+    expect(result).to be_success
+    expect(Session.where(uuid: uuid).count).to eq(1)
+  end
+
+  it 'serialises the legacy upload path too' do
+    session_data = {
+      uuid: uuid,
+      # the legacy controller forces this before calling the builder
+      type: 'MobileSession',
+      contribute: true,
+      title: 'Legacy upload',
+      start_time: '2026-08-01T10:00:00.000Z',
+      end_time: '2026-08-01T10:30:00.000Z',
+      notes: [],
+      streams: {},
+    }
+
+    results = []
+    mutex = Mutex.new
+    barrier = Concurrent::CountDownLatch.new(2)
+
+    threads = 2.times.map do
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          barrier.count_down
+          barrier.wait(5)
+          built = SessionBuilder.new(session_data.dup, [], user).build!
+          mutex.synchronize { results << built }
+        end
+      end
+    end
+    threads.each(&:join)
+
+    expect(Session.where(uuid: uuid).count).to eq(1)
+    expect(results.compact.size).to eq(1)
+  end
+end


### PR DESCRIPTION
Before adding unique index on session uuid additional guard and duplicated data cleanup is needed