### PR TITLE
chore: sessions deduplication tasks

### DIFF
--- a/lib/tasks/deduplicate_mobile_sessions.rake
+++ b/lib/tasks/deduplicate_mobile_sessions.rake
@@ -1,0 +1,340 @@
+# Removes MOBILE sessions that share a uuid with another session of the same user.
+#
+# Background: until Session.with_uuid_lock, two uploads arriving in the same
+# second could both pass the uniqueness check and insert, producing identical
+# copies of one recording. A unique index on sessions.uuid cannot be added while
+# those copies exist.
+#
+# Mobile only, deliberately. Fixed sessions store their data in
+# `fixed_measurements` and can carry a `session_token` that is flashed into
+# AirBeam firmware, so deleting one is a different problem with different risks —
+# see sessions:delete_empty_fixed_duplicates.
+#
+# Safety rules:
+#   * a group is skipped unless every copy belongs to one user;
+#   * a copy is deleted only when it is provably identical to the keeper: same
+#     editable fields, same streams, same measurement count (COUNT(*), not the
+#     counter cache, which is known to drift), and the same md5 over every
+#     measurement's time and value;
+#   * recent sessions are left alone, because mobile measurements are inserted by
+#     Sidekiq after the upload responds — fingerprinting one mid-flight would
+#     compare an incomplete session;
+#   * a tombstone means the user deleted the session and a sync re-uploaded it, so
+#     every copy goes and the tombstone stays — but only when all copies post-date
+#     it. Otherwise the group is reported, not guessed at;
+#   * each group is handled under the same advisory lock the API uses, so a create
+#     racing the cleanup waits instead of slipping a fresh copy behind it.
+#
+# Two known races, both left alone deliberately:
+#   * the fingerprint and both md5 digests run while the lock is held. Measured on
+#     production: median duplicate session 3.3k measurements (~20 ms), the single
+#     worst 197k across its streams (~2 s). SessionBuilder waits 3 s before giving
+#     up, so only that outlier could push a concurrent upload of the same uuid to a
+#     400 — and the app retries on its next sync. Computing the digests before
+#     taking the lock would halve nothing and double the reads;
+#   * Api::ToUserSessionsHash2#delete_sessions writes tombstones without taking
+#     this lock, so a user deleting a session in the same instant a group is being
+#     processed could have their tombstone removed by the delete_all below, leaving
+#     the phone holding a session they deleted. Their next delete fixes it. Closing
+#     it means putting a lock in the legacy sync path, which is out of scope here.
+#
+# Cost on the apps: the keeper's version is bumped, which puts it in that user's
+# next sync `download` list — one empty.json request per deduped uuid, sequential
+# in both apps. A user with many groups therefore pays for all of them on one
+# sync, so work through production in LIMIT batches rather than a single sweep.
+#
+# Usage:
+#   bundle exec rake sessions:deduplicate_mobile               # dry run
+#   bundle exec rake sessions:deduplicate_mobile APPLY=true    # delete
+#   bundle exec rake sessions:deduplicate_mobile LIMIT=20      # first N groups
+#   bundle exec rake sessions:deduplicate_mobile UUID=<uuid>   # one group
+#   bundle exec rake sessions:deduplicate_mobile MIN_AGE_DAYS=14
+namespace :sessions do
+  desc 'Deduplicate mobile sessions sharing a uuid (dry run unless APPLY=true)'
+  task deduplicate_mobile: :environment do
+    apply = ENV['APPLY'] == 'true'
+    limit = ENV['LIMIT'].presence&.to_i
+    min_age_days = ENV.fetch('MIN_AGE_DAYS', '7').to_i
+    throttle = ENV.fetch('THROTTLE', apply ? '0.1' : '0').to_f
+    cutoff = min_age_days.days.ago
+
+    # Generous, so the initial aggregate and the largest delete both fit, but not
+    # unlimited — a runaway statement should fail rather than sit on the database.
+    ActiveRecord::Base.connection.execute("SET statement_timeout = '300s'")
+
+    scope = ENV['UUID'].present? ? MobileSession.where(uuid: ENV['UUID']) : MobileSession.all
+    # Ordered so LIMIT means the same groups on every run: dry-run a batch, then
+    # apply exactly that batch. Oldest first.
+    groups =
+      scope
+        .group(:uuid, :user_id)
+        .having('count(*) > 1')
+        .order(Arel.sql('min(sessions.id)'))
+        .pluck(:uuid, :user_id)
+    groups = groups.first(limit) if limit
+
+    puts "#{apply ? 'APPLYING' : 'DRY RUN'} — #{groups.size} duplicate mobile group(s), " \
+         "ignoring sessions newer than #{min_age_days} day(s)"
+    puts
+
+    stats = { groups: 0, deleted: 0, measurements_freed: 0, honoured_deletes: 0, skipped: [], failures: 0 }
+
+    skip = lambda do |uuid, ids, reason|
+      stats[:skipped] << { uuid: uuid, ids: ids, reason: reason }
+      puts "SKIP  #{uuid} — #{reason}"
+    end
+
+    groups.each_with_index do |(uuid, user_id), index|
+      puts "  … #{index}/#{groups.size} groups processed" if index.positive? && (index % 50).zero?
+      group_ids = []
+      # Collected inside the lock, added to the totals only after with_uuid_lock
+      # returns — that block IS the transaction, so until it returns nothing is
+      # committed. The inner ActiveRecord::Base.transaction below nests inside it
+      # and opens no savepoint, so counting there would count uncommitted work.
+      delta = nil
+
+      begin
+        Session.with_uuid_lock(uuid) do
+          # Everything with this uuid, not just this user's rows: a uuid shared by
+          # two users is a state nothing here should act on.
+          sessions = Session.where(uuid: uuid).order(:id).to_a
+          group_ids = sessions.map(&:id)
+
+          if sessions.map(&:user_id).uniq.size > 1
+            next skip.call(uuid, group_ids, 'uuid belongs to more than one user')
+          end
+
+          if sessions.any? { |s| !s.is_a?(MobileSession) }
+            next skip.call(uuid, group_ids, 'uuid is shared with a fixed session')
+          end
+
+          next if sessions.size < 2
+
+          if sessions.any? { |s| s.created_at > cutoff }
+            next skip.call(uuid, group_ids,
+                           "created less than #{min_age_days} day(s) ago, measurements may still be arriving")
+          end
+
+          keeper, *copies = sessions
+          tombstone = DeletedSession.find_by(uuid: uuid, user_id: user_id)
+
+          if tombstone
+            if sessions.any? { |s| s.created_at <= tombstone.created_at }
+              next skip.call(uuid, group_ids, 'session(s) predate the tombstone, needs a human')
+            end
+
+            freed = sessions.sum { |s| MobileSessionFingerprint.measurement_count(s) }
+            puts "#{apply ? 'DELETING' : 'WOULD DELETE ALL'} #{uuid}: user #{user_id} deleted this " \
+                 "session, removing #{sessions.map { |s| "##{s.id}" }.join(', ')} (#{freed} measurement(s)); " \
+                 'tombstone kept'
+
+            if apply
+              ActiveRecord::Base.transaction do
+                sessions.each { |s| MobileSessionFingerprint.destroy_session!(s) }
+                raise "sessions remain for #{uuid}" if Session.where(uuid: uuid).exists?
+                raise "tombstone for #{uuid} vanished" unless DeletedSession.exists?(uuid: uuid, user_id: user_id)
+              end
+            end
+
+            delta = { groups: 1, deleted: sessions.size, measurements_freed: freed, honoured_deletes: 1 }
+            next
+          end
+
+          keeper_print = MobileSessionFingerprint.for(keeper)
+          identical, differing = copies.partition { |c| MobileSessionFingerprint.for(c) == keeper_print }
+
+          if differing.any?
+            # Partial deletion helps nothing — the uuid still has two or more rows,
+            # so the unique index stays blocked — and it leaves behind a group
+            # nobody has understood. Leave the whole group alone.
+            next skip.call(uuid, differing.map(&:id), 'copies are not identical to the keeper')
+          end
+
+          # Proof, not just shape: the fingerprint cannot see a difference in the
+          # middle of a stream. Runs in a dry run too, so what an operator approves
+          # is what an apply will actually do.
+          keeper_digest = MobileSessionFingerprint.digest(keeper)
+          unverified = identical.reject { |c| MobileSessionFingerprint.digest(c) == keeper_digest }
+
+          next skip.call(uuid, unverified.map(&:id), 'measurement checksums differ') if unverified.any?
+
+          # The per-stream counts are already in the fingerprint; no need to count
+          # the same rows a third time.
+          freed = identical.size * MobileSessionFingerprint.measurement_total(keeper_print)
+          # The bump is named in the dry run too: the keeper used to be read-only,
+          # and an operator approving a dry run has to be approving what apply does.
+          puts "#{apply ? 'DELETING' : 'WOULD DELETE'} #{uuid}: keeping ##{keeper.id} " \
+               "(version #{keeper.version.to_i} → #{keeper.version.to_i + 1}), removing " \
+               "#{identical.map { |c| "##{c.id}" }.join(', ')} (#{freed} measurement(s), user #{user_id})"
+
+          if apply
+            ActiveRecord::Base.transaction do
+              tombstone_existed = DeletedSession.exists?(uuid: uuid, user_id: user_id)
+
+              identical.each { |c| MobileSessionFingerprint.destroy_session!(c) }
+
+              # Undo the tombstone our own deletion caused, or the next sync tells
+              # every phone that the session we just kept was deleted.
+              DeletedSession.where(uuid: uuid, user_id: user_id).delete_all unless tombstone_existed
+
+              remaining = Session.where(uuid: uuid).count
+              raise "expected 1 session for #{uuid}, found #{remaining}" unless remaining == 1
+
+              # Session.find, not keeper.reload: acts-as-taggable-on memoises
+              # tag_list and reload does not clear it, so a concurrent tag edit
+              # would slip past the check.
+              unless MobileSessionFingerprint.for(Session.find(keeper.id)) == keeper_print
+                raise "keeper ##{keeper.id} changed while the group was being processed"
+              end
+
+              # Last, and only after that assertion — `version` is part of the
+              # fingerprint, so bumping earlier would trip our own check.
+              #
+              # The create response returns `location`, a URL built from
+              # `url_token`, which is per row rather than per uuid. Both phones
+              # store it against the uuid and share from it, and a race gave them
+              # whichever copy answered last — possibly the one just deleted, which
+              # would leave a dead share link. Sync only re-downloads a session
+              # whose server version is ahead of the phone's, so the bump is what
+              # makes the app ask again and pick up the surviving token.
+              # to_i, not +1: `sessions.version` is nullable (default 1 applies to
+              # inserts only), and a NoMethodError here would roll back a perfectly
+              # good delete.
+              keeper.update_column(:version, keeper.version.to_i + 1)
+            end
+          end
+
+          delta = { groups: 1, deleted: identical.size, measurements_freed: freed, honoured_deletes: 0 }
+        end
+
+        delta&.each { |key, value| stats[key] += value }
+      rescue StandardError => e
+        # One unexpected group must not end the run. The transaction has already
+        # rolled back and the lock is released, so this group is untouched, and
+        # `delta` is never applied.
+        stats[:failures] += 1
+        skip.call(uuid, group_ids, "#{e.class}: #{e.message} — nothing was deleted for this group")
+      end
+
+      # Outside the lock: sleeping inside it would hold the advisory lock and the
+      # row locks for everything just deleted.
+      sleep(throttle) if throttle.positive?
+    end
+
+    puts
+    puts '--- summary ---'
+    puts "groups handled:      #{stats[:groups]}"
+    puts "sessions #{apply ? 'deleted' : 'to delete'}:    #{stats[:deleted]}"
+    puts "measurements #{apply ? 'freed' : 'to free'}: #{stats[:measurements_freed]}"
+    puts "deleted outright:    #{stats[:honoured_deletes]} (user had deleted the session)"
+    puts "groups skipped:      #{stats[:skipped].size}"
+    stats[:skipped].each { |s| puts "  #{s[:uuid]} — #{s[:reason]} (ids #{s[:ids].join(', ')})" }
+
+    if stats[:failures].positive?
+      puts
+      puts "WARNING: #{stats[:failures]} group(s) raised and were not processed (see the error classes " \
+           'above) — check the log before treating this run as complete.'
+    end
+    puts
+    puts 'Dry run: nothing was written. Re-run with APPLY=true to delete.' unless apply
+  end
+end
+
+module MobileSessionFingerprint
+  # What a session looks like, including the fields a user can edit. A rename, a
+  # new tag or an extra note makes the copies differ, so the group is reported
+  # instead of silently discarding somebody's edit.
+  def self.for(session)
+    [
+      session.title,
+      session.tag_list.to_s,
+      session.contribute,
+      session.is_indoor,
+      session.start_time_local,
+      session.end_time_local,
+      session.time_zone,
+      session.device_id,
+      # Session#sync bumps this on every edit, and Api::UpdateSession resolves its
+      # target with an unordered find_by_uuid — so an edit lands on an arbitrary
+      # copy. Differing versions is the cheapest signal that one copy was touched,
+      # and it catches edits the field list misses (a note's text changing while
+      # notes.count stays equal).
+      session.version,
+      notes_shape(session),
+      streams_shape(session),
+    ]
+  end
+
+  # Number, text and photo, not just the count. Two copies can carry the same
+  # number of notes with different text, and SessionBuilder attaches photos at
+  # upload time — so one copy can hold the photo and the other not. Comparing
+  # counts alone would call those identical and destroy the only copy of a photo.
+  #
+  # Ordered by (number, text) rather than number alone: `notes.number` is
+  # nullable and Postgres does not order ties among NULLs, so two copies could
+  # pluck the same notes in different orders and falsely mismatch.
+  def self.notes_shape(session)
+    session
+      .notes
+      .includes(s3_photo_attachment: :blob) # otherwise one query per note
+      .sort_by { |note| [note.number ? 0 : 1, note.number.to_i, note.text.to_s] }
+      .map { |note| [note.number, note.text, note.s3_photo.attached? ? note.s3_photo.blob.checksum : nil] }
+  end
+
+  def self.streams_shape(session)
+    session.streams.order(:sensor_name, :sensor_package_name).map do |stream|
+      # COUNT(*) rather than measurements_count: the counter cache is known to
+      # drift (see sync_measurements_counter.rake).
+      count = Measurement.where(stream_id: stream.id).count
+      first_at, last_at =
+        Measurement.where(stream_id: stream.id).reorder(nil).pick(Arel.sql('MIN(time)'), Arel.sql('MAX(time)'))
+
+      # Api::CreateThresholdAlert resolves its stream by uuid and sensor name, so
+      # with duplicates around an alert can be attached to any copy — and
+      # `Stream has_many :threshold_alerts, dependent: :destroy` would take it
+      # down with that copy, silently. Counting them here turns that into a
+      # reported skip. No mobile stream in production carries one today.
+      alerts = ThresholdAlert.where(stream_id: stream.id).count
+
+      [stream.sensor_name, stream.sensor_package_name, stream.unit_symbol, count, first_at, last_at, alerts]
+    end
+  end
+
+  # Total measurements described by a fingerprint — the counts are already there.
+  def self.measurement_total(print)
+    print.last.sum { |stream_tuple| stream_tuple[3] }
+  end
+
+  def self.measurement_count(session)
+    Measurement.where(stream_id: session.streams.select(:id)).count
+  end
+
+  # md5 over every measurement of the session — proof two copies carry the same
+  # data, not merely the same shape.
+  def self.digest(session)
+    session.streams.order(:sensor_name, :sensor_package_name).map do |stream|
+      checksum =
+        ActiveRecord::Base.connection.select_value(
+          ActiveRecord::Base.sanitize_sql_array(
+            [
+              "SELECT md5(coalesce(string_agg(m.time::text || ':' || coalesce(m.value::text, '') || ':' || " \
+              "coalesce(m.latitude::text, '') || ':' || coalesce(m.longitude::text, ''), ',' " \
+              'ORDER BY m.time, m.value, m.latitude, m.longitude), \'\')) ' \
+              'FROM measurements m WHERE m.stream_id = ?',
+              stream.id,
+            ],
+          ),
+        )
+
+      [stream.sensor_name, stream.sensor_package_name, checksum]
+    end
+  end
+
+  # `streams.last_hourly_average_id` has a foreign key with no ON DELETE, and
+  # Stream destroys its hourly averages first — so clear the pointer before the
+  # destroy, exactly as every other delete path in the app does.
+  def self.destroy_session!(session)
+    session.streams.where.not(last_hourly_average_id: nil).update_all(last_hourly_average_id: nil)
+    session.destroy!
+  end
+end

--- a/lib/tasks/delete_empty_fixed_duplicates.rake
+++ b/lib/tasks/delete_empty_fixed_duplicates.rake
@@ -1,0 +1,174 @@
+# Removes duplicate FIXED sessions, but only ones that are provably empty.
+#
+# All 91 duplicate fixed groups in production (202 rows, created 2022-07 to
+# 2025-05) are abandoned setup attempts: no streams, no measurements, no
+# session_token, no device. They exist because someone tapped "create" twice while
+# configuring an AirBeam, and they block the unique index on sessions.uuid.
+#
+# A fixed session that holds anything is a different problem and is never touched
+# here:
+#   * its data lives in `fixed_measurements`, not `measurements`, and
+#     `FixedMeasurement` has no counter cache, so a naive fingerprint reads zero
+#     for both copies and calls them identical;
+#   * a `session_token` is flashed into AirBeam firmware over BLE and is how the
+#     device authenticates every upload. Delete the copy holding the live token
+#     and the hardware needs a physical re-configuration to recover;
+#   * hourly/daily averages and threshold alerts hang off its streams.
+#
+# So the rule is simple and checked per session, not assumed: streams, fixed
+# measurements, measurements, hourly averages, daily averages, threshold alerts,
+# notes and session_token must all be absent. Anything else is reported.
+#
+# Usage:
+#   bundle exec rake sessions:delete_empty_fixed_duplicates             # dry run
+#   bundle exec rake sessions:delete_empty_fixed_duplicates APPLY=true
+#   bundle exec rake sessions:delete_empty_fixed_duplicates LIMIT=20
+#   bundle exec rake sessions:delete_empty_fixed_duplicates UUID=<uuid>
+#   bundle exec rake sessions:delete_empty_fixed_duplicates MIN_AGE_DAYS=14
+namespace :sessions do
+  desc 'Delete duplicate fixed sessions that are provably empty (dry run unless APPLY=true)'
+  task delete_empty_fixed_duplicates: :environment do
+    apply = ENV['APPLY'] == 'true'
+    limit = ENV['LIMIT'].presence&.to_i
+    # A fixed session is empty from creation until its device uploads, so age is
+    # not the safety check here — `contents` is. Kept anyway so both tasks read
+    # the same way, and so a setup still in progress is left alone.
+    min_age_days = ENV.fetch('MIN_AGE_DAYS', '14').to_i
+    cutoff = min_age_days.days.ago
+
+    ActiveRecord::Base.connection.execute("SET statement_timeout = '300s'")
+
+    scope = ENV['UUID'].present? ? FixedSession.where(uuid: ENV['UUID']) : FixedSession.all
+    groups =
+      scope
+      .group(:uuid, :user_id)
+      .having('count(*) > 1')
+      .order(Arel.sql('min(sessions.id)'))
+      .pluck(:uuid, :user_id)
+    groups = groups.first(limit) if limit
+
+    puts "#{apply ? 'APPLYING' : 'DRY RUN'} — #{groups.size} duplicate fixed group(s), " \
+         "ignoring sessions newer than #{min_age_days} day(s)"
+    puts
+
+    stats = { groups: 0, deleted: 0, skipped: [], failures: 0 }
+
+    skip = lambda do |uuid, reason|
+      stats[:skipped] << { uuid: uuid, reason: reason }
+      puts "SKIP  #{uuid} — #{reason}"
+    end
+
+    groups.each do |uuid, user_id|
+      # Applied only after with_uuid_lock returns; see the mobile task for why
+      # counting inside the block would count uncommitted work.
+      delta = nil
+
+      begin
+        Session.with_uuid_lock(uuid) do
+          sessions = Session.where(uuid: uuid).order(:id).to_a
+
+          next skip.call(uuid, 'uuid belongs to more than one user') if sessions.map(&:user_id).uniq.size > 1
+
+          # An empty MobileSession also looks "empty", so without this a mobile
+          # shell sharing the uuid could become the keeper — or be deleted as
+          # though it were a fixed duplicate. Mirrors the mobile task's guard.
+          unless sessions.all? { |s| s.is_a?(FixedSession) }
+            next skip.call(uuid, 'uuid is shared with a mobile session')
+          end
+
+          if sessions.any? { |s| s.created_at > cutoff }
+            next skip.call(uuid, "created less than #{min_age_days} day(s) ago, setup may still be in progress")
+          end
+
+          non_empty = sessions.reject { |s| EmptyFixedSession.empty?(s) }
+
+          if non_empty.any?
+            reasons = non_empty.map { |s| "##{s.id}: #{EmptyFixedSession.contents(s).join(', ')}" }
+            next skip.call(uuid, "not empty — #{reasons.join(' | ')}")
+          end
+
+          keeper, *copies = sessions
+          next if copies.empty?
+
+          puts "#{apply ? 'DELETING' : 'WOULD DELETE'} #{uuid}: keeping ##{keeper.id}, removing " \
+               "#{copies.map { |c| "##{c.id}" }.join(', ')} (all empty, user #{user_id})"
+
+          if apply
+            ActiveRecord::Base.transaction do
+              tombstone_existed = DeletedSession.exists?(uuid: uuid, user_id: user_id)
+
+              copies.each { |c| EmptyFixedSession.destroy_session!(c) }
+
+              # Deleting writes a tombstone, and sync reports tombstoned uuids to
+              # the apps as deleted — which would tell phones to drop the session
+              # we kept.
+              DeletedSession.where(uuid: uuid, user_id: user_id).delete_all unless tombstone_existed
+
+              remaining = Session.where(uuid: uuid).count
+              raise "expected 1 session for #{uuid}, found #{remaining}" unless remaining == 1
+            end
+          end
+
+          delta = { groups: 1, deleted: copies.size }
+        end
+
+        delta&.each { |key, value| stats[key] += value }
+      rescue StandardError => e
+        # One bad group must not end the run, or the summary below never prints
+        # and the record of everything already processed is lost.
+        stats[:failures] += 1
+        skip.call(uuid, "#{e.class}: #{e.message} — nothing was deleted for this group")
+      end
+    end
+
+    puts
+    puts '--- summary ---'
+    puts "groups handled:   #{stats[:groups]}"
+    puts "sessions #{apply ? 'deleted' : 'to delete'}: #{stats[:deleted]}"
+    puts "groups skipped:   #{stats[:skipped].size}"
+    stats[:skipped].each { |s| puts "  #{s[:uuid]} — #{s[:reason]}" }
+
+    if stats[:failures].positive?
+      puts
+      puts "WARNING: #{stats[:failures]} group(s) raised and were not processed — check the log."
+    end
+    puts
+    puts 'Dry run: nothing was written. Re-run with APPLY=true to delete.' unless apply
+  end
+end
+
+# "Empty" is checked, never assumed: every table that can hang off a fixed session
+# is counted, including the ones a fixed session uses but a mobile one does not.
+module EmptyFixedSession
+  def self.empty?(session)
+    contents(session).empty?
+  end
+
+  # `streams.last_hourly_average_id` has a foreign key with no ON DELETE and
+  # Stream destroys its hourly averages first. Unreachable here — these sessions
+  # have no streams — but the reader should not have to re-derive that.
+  def self.destroy_session!(session)
+    session.streams.where.not(last_hourly_average_id: nil).update_all(last_hourly_average_id: nil)
+    session.destroy!
+  end
+
+  def self.contents(session)
+    stream_ids = session.streams.pluck(:id)
+
+    counts = {
+      'streams' => stream_ids.size,
+      'notes' => session.notes.count,
+      'session_token' => session.session_token.present? ? 1 : 0
+    }
+
+    if stream_ids.any?
+      counts['measurements'] = Measurement.where(stream_id: stream_ids).count
+      counts['fixed_measurements'] = FixedMeasurement.where(stream_id: stream_ids).count
+      counts['hourly_averages'] = StreamHourlyAverage.where(stream_id: stream_ids).count
+      counts['daily_averages'] = StreamDailyAverage.where(stream_id: stream_ids).count
+      counts['threshold_alerts'] = ThresholdAlert.where(stream_id: stream_ids).count
+    end
+
+    counts.select { |_, count| count.positive? }.map { |name, count| "#{name}=#{count}" }
+  end
+end

--- a/spec/tasks/deduplicate_mobile_sessions_spec.rb
+++ b/spec/tasks/deduplicate_mobile_sessions_spec.rb
@@ -1,0 +1,452 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'sessions:deduplicate_mobile' do
+  before(:all) do
+    Rake.application.rake_require('tasks/deduplicate_mobile_sessions', [Rails.root.join('lib').to_s])
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task) { Rake::Task['sessions:deduplicate_mobile'] }
+  let(:user) { create(:user) }
+  let(:uuid) { SecureRandom.uuid }
+  let(:times) { [Time.utc(2026, 8, 1, 10, 0, 0), Time.utc(2026, 8, 1, 10, 1, 0)] }
+
+  before { task.reenable }
+  after { ENV.delete('APPLY') }
+
+  # Duplicates cannot be created through validations — that is what the bug was.
+  # Reproduce them the way the race did: two rows with the same uuid.
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  def build_copy(measurement_times, uuid: self.uuid)
+    session = build(
+      :mobile_session,
+      user: user, uuid: uuid, url_token: SecureRandom.hex(5), title: 'Ride',
+      start_time_local: Time.utc(2026, 8, 1, 10, 0, 0), end_time_local: Time.utc(2026, 8, 1, 10, 30, 0)
+    )
+    session.save(validate: false)
+    # older than MIN_AGE_DAYS, so the in-flight-measurements guard lets it through
+    session.update_columns(created_at: 30.days.ago)
+    stream = create(:stream, session: session, sensor_name: 'AirBeam2-PM2.5')
+    measurement_times.each_with_index do |time, i|
+      create(:measurement, stream: stream, time: time, time_with_time_zone: time, value: i)
+    end
+    stream.update!(measurements_count: measurement_times.size)
+    session
+  end
+
+  context 'with identical copies' do
+    it 'reports without deleting during a dry run' do
+      keeper = build_copy(times)
+      copy = build_copy(times)
+
+      expect { task.invoke }.to output(/WOULD DELETE/).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([keeper.id, copy.id])
+    end
+
+    it 'keeps the oldest and deletes the rest when applied' do
+      keeper = build_copy(times)
+      copy = build_copy(times)
+      ENV['APPLY'] = 'true'
+
+      task.invoke
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to eq([keeper.id])
+      expect(Stream.where(session_id: copy.id)).to be_empty
+    end
+
+    it "leaves the surviving session's measurements untouched" do
+      keeper = build_copy(times)
+      build_copy(times)
+      ENV['APPLY'] = 'true'
+
+      task.invoke
+
+      expect(keeper.reload.streams.sum(&:measurements_count)).to eq(2)
+      expect(Measurement.where(stream_id: keeper.streams.pluck(:id)).count).to eq(2)
+    end
+
+    it 'does not leave a tombstone that would make phones delete the survivor' do
+      build_copy(times)
+      build_copy(times)
+      ENV['APPLY'] = 'true'
+
+      task.invoke
+
+      expect(DeletedSession.where(uuid: uuid, user_id: user.id)).to be_empty
+    end
+
+    context 'when the user had already deleted this session' do
+      # A tombstone plus live copies means a concurrent sync re-uploaded the
+      # session right after the delete. The user's deletion wins.
+      # created before the sessions: the delete came first, the re-upload after
+      before { DeletedSession.create!(uuid: uuid, user_id: user.id, created_at: 31.days.ago) }
+
+      it 'removes every copy and keeps the tombstone' do
+        build_copy(times)
+        build_copy(times)
+        ENV['APPLY'] = 'true'
+
+        task.invoke
+
+        expect(Session.where(uuid: uuid)).to be_empty
+        expect(DeletedSession.where(uuid: uuid, user_id: user.id).count).to eq(1)
+      end
+
+      it 'reports it as an outright delete during a dry run' do
+        build_copy(times)
+        build_copy(times)
+
+        expect { task.invoke }.to output(/WOULD DELETE ALL/).to_stdout
+        expect(Session.where(uuid: uuid).count).to eq(2)
+      end
+    end
+  end
+
+  context 'when the copies are not identical' do
+    it 'skips the group and deletes nothing' do
+      keeper = build_copy(times)
+      copy = build_copy(times + [Time.utc(2026, 8, 1, 10, 2, 0)])
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/SKIP/).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([keeper.id, copy.id])
+    end
+  end
+
+  context 'safety guards' do
+    it 'refuses to touch a uuid shared by two users' do
+      # one user has the duplicate pair, a second user shares the uuid
+      mine = build_copy(times)
+      mine_again = build_copy(times)
+      other_user = create(:user)
+      theirs = build(:mobile_session, user: other_user, uuid: uuid, url_token: SecureRandom.hex(5))
+      theirs.save(validate: false)
+      theirs.update_columns(created_at: 30.days.ago)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/belongs to more than one user/).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([mine.id, mine_again.id, theirs.id])
+    end
+
+    it 'skips a group whose sessions predate their tombstone' do
+      first = build_copy(times)
+      build_copy(times)
+      DeletedSession.create!(uuid: uuid, user_id: user.id, created_at: first.created_at + 1.hour)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/predate the tombstone/).to_stdout
+
+      expect(Session.where(uuid: uuid).count).to eq(2)
+    end
+
+    it 'refuses to delete when the measurements differ despite matching counts' do
+      keeper = build_copy(times)
+      copy = build_copy(times)
+      # same count and same first/last timestamp, different value in between
+      Measurement.where(stream_id: copy.streams.first.id).order(:time).last.update!(value: 999)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/checksums differ/).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([keeper.id, copy.id])
+    end
+  end
+
+  context 'groups where only some copies match' do
+    # The earlier version deleted the matching copies and then asserted the group
+    # was down to one row, which raised and killed the whole run.
+    it 'leaves a three-copy group alone when one copy differs in shape' do
+      a = build_copy(times)
+      b = build_copy(times)
+      c = build_copy(times)
+      c.update_columns(title: 'renamed by the user')
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/not identical to the keeper/).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([a.id, b.id, c.id])
+    end
+
+    it 'leaves a three-copy group alone when one copy fails the checksum' do
+      a = build_copy(times)
+      b = build_copy(times)
+      c = build_copy(times)
+      # same shape, same count, same first/last timestamp — different value inside
+      Measurement.where(stream_id: c.streams.first.id).order(:time).last.update!(value: 999)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/checksums differ/).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([a.id, b.id, c.id])
+    end
+
+    it 'deletes all copies of a matching three-copy group' do
+      keeper = build_copy(times)
+      build_copy(times)
+      build_copy(times)
+      ENV['APPLY'] = 'true'
+
+      task.invoke
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to eq([keeper.id])
+    end
+
+    it 'reports the checksum decision during a dry run, not only when applying' do
+      build_copy(times)
+      copy = build_copy(times)
+      Measurement.where(stream_id: copy.streams.first.id).order(:time).last.update!(value: 999)
+
+      expect { task.invoke }.to output(/checksums differ/).to_stdout
+      expect { task.invoke }.not_to output(/WOULD DELETE/).to_stdout
+    end
+
+    it 'keeps going after a group raises, and processes later groups' do
+      # first group blows up inside the transaction, second must still be handled
+      build_copy(times)
+      doomed = build_copy(times)
+      other_uuid = SecureRandom.uuid
+      good_keeper = build_copy(times, uuid: other_uuid)
+      build_copy(times, uuid: other_uuid)
+
+      allow(MobileSessionFingerprint).to receive(:destroy_session!).and_wrap_original do |original, session|
+        raise StandardError, 'boom' if session.id == doomed.id
+
+        original.call(session)
+      end
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/StandardError: boom/).to_stdout
+
+      expect(Session.where(uuid: uuid).count).to eq(2)               # rolled back
+      expect(Session.where(uuid: other_uuid).pluck(:id)).to eq([good_keeper.id]) # still processed
+    end
+
+    it 'does not count a rolled-back group as deleted' do
+      build_copy(times)
+      doomed = build_copy(times)
+      allow(MobileSessionFingerprint).to receive(:destroy_session!).and_raise(StandardError, 'boom')
+      ENV['APPLY'] = 'true'
+
+      output = capture_stdout { task.invoke }
+
+      expect(output).to match(/sessions deleted:\s+0/)
+      expect(output).to match(/measurements freed: 0/)
+      expect(output).to match(/nothing was deleted for this group/)
+      expect(Session.where(uuid: uuid).count).to eq(2)
+      expect(doomed.reload).to be_present
+    end
+  end
+
+  it 'detects an edit that only bumped the version' do
+    a = build_copy(times)
+    b = build_copy(times)
+    b.update_columns(version: 5)
+    ENV['APPLY'] = 'true'
+
+    expect { task.invoke }.to output(/not identical to the keeper/).to_stdout
+
+    expect(Session.where(uuid: uuid).pluck(:id)).to match_array([a.id, b.id])
+  end
+
+  describe 'share link healing' do
+    it "bumps the keeper's version so phones re-download and pick up the surviving url_token" do
+      keeper = build_copy(times)
+      build_copy(times)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to change { keeper.reload.version }.by(1)
+    end
+
+    it 'leaves the version alone on a dry run' do
+      keeper = build_copy(times)
+      build_copy(times)
+
+      expect { task.invoke }.not_to change { keeper.reload.version }
+    end
+
+    it 'does not bump a skipped group' do
+      keeper = build_copy(times)
+      copy = build_copy(times)
+      copy.update_columns(title: 'renamed on the phone')
+
+      ENV['APPLY'] = 'true'
+      expect { task.invoke }.not_to change { keeper.reload.version }
+    end
+  end
+
+  describe 'threshold alerts' do
+    it 'skips a group when a copy carries an alert, instead of destroying it with the copy' do
+      keeper = build_copy(times)
+      copy = build_copy(times)
+      alert = ThresholdAlert.create!(
+        user: user, session_uuid: uuid, sensor_name: 'AirBeam2-PM2.5',
+        stream_id: copy.streams.first.id, threshold_value: 10, frequency: 0, timezone_offset: 0
+      )
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/not identical/).to_stdout
+
+      expect(Session.where(uuid: uuid).count).to eq(2)
+      expect(alert.reload).to be_present
+      expect(keeper.reload).to be_present
+    end
+  end
+
+  describe 'notes' do
+    it 'skips when two copies hold the same number of notes with different text' do
+      keeper = build_copy(times)
+      copy = build_copy(times)
+      Note.create!(session: keeper, number: 0, text: 'windy', date: times.first, latitude: 1, longitude: 1)
+      Note.create!(session: copy, number: 0, text: 'traffic', date: times.first, latitude: 1, longitude: 1)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/not identical/).to_stdout
+
+      expect(Session.where(uuid: uuid).count).to eq(2)
+    end
+  end
+
+  describe 'selection' do
+    it 'skips a group whose sessions are newer than MIN_AGE_DAYS' do
+      build_copy(times)
+      build_copy(times).update_columns(created_at: 1.day.ago)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/measurements may still be arriving/).to_stdout
+
+      expect(Session.where(uuid: uuid).count).to eq(2)
+    end
+
+    it 'honours MIN_AGE_DAYS from the environment' do
+      build_copy(times)
+      build_copy(times)
+      ENV['APPLY'] = 'true'
+      ENV['MIN_AGE_DAYS'] = '90'
+
+      expect { task.invoke }.to output(/measurements may still be arriving/).to_stdout
+
+      expect(Session.where(uuid: uuid).count).to eq(2)
+    ensure
+      ENV.delete('MIN_AGE_DAYS')
+    end
+
+    it 'processes only the first LIMIT groups, oldest first' do
+      build_copy(times)
+      build_copy(times)
+      second_uuid = SecureRandom.uuid
+      build_copy(times, uuid: second_uuid)
+      build_copy(times, uuid: second_uuid)
+      ENV['APPLY'] = 'true'
+      ENV['LIMIT'] = '1'
+
+      task.invoke
+
+      expect(Session.where(uuid: uuid).count).to eq(1)
+      expect(Session.where(uuid: second_uuid).count).to eq(2)
+    ensure
+      ENV.delete('LIMIT')
+    end
+
+    it 'processes only the group named by UUID' do
+      build_copy(times)
+      build_copy(times)
+      other_uuid = SecureRandom.uuid
+      build_copy(times, uuid: other_uuid)
+      build_copy(times, uuid: other_uuid)
+      ENV['APPLY'] = 'true'
+      ENV['UUID'] = other_uuid
+
+      task.invoke
+
+      expect(Session.where(uuid: other_uuid).count).to eq(1)
+      expect(Session.where(uuid: uuid).count).to eq(2)
+    ensure
+      ENV.delete('UUID')
+    end
+
+    it 'refuses a uuid shared with a fixed session' do
+      build_copy(times)
+      build_copy(times)
+      fixed = build(:fixed_session, user: user, uuid: uuid, url_token: SecureRandom.hex(5))
+      fixed.save(validate: false)
+      fixed.update_columns(created_at: 30.days.ago)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/shared with a fixed session/).to_stdout
+
+      expect(Session.where(uuid: uuid).count).to eq(3)
+    end
+  end
+
+  describe 'edge cases the schema allows' do
+    it 'deletes the copy even when the keeper carries a NULL version' do
+      keeper = build_copy(times)
+      copy = build_copy(times)
+      Session.where(id: [keeper.id, copy.id]).update_all(version: nil)
+      ENV['APPLY'] = 'true'
+
+      task.invoke
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to eq([keeper.id])
+      expect(keeper.reload.version).to eq(1) # NULL treated as 0, so the bump still lands
+    end
+
+    it 'skips when one copy holds a note photo and the other does not' do
+      keeper = build_copy(times)
+      copy = build_copy(times)
+      [keeper, copy].each do |session|
+        Note.create!(session: session, number: 0, text: 'same text',
+                     date: times.first, latitude: 1, longitude: 1)
+      end
+      copy.notes.first.s3_photo.attach(
+        io: StringIO.new('photo-bytes'), filename: 'note.jpg', content_type: 'image/jpeg',
+      )
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/not identical/).to_stdout
+
+      expect(Session.where(uuid: uuid).count).to eq(2)
+      expect(copy.notes.first.s3_photo).to be_attached
+    end
+
+    it 'compares notes consistently when number is NULL on every note' do
+      keeper = build_copy(times)
+      copy = build_copy(times)
+      [keeper, copy].each do |session|
+        %w[alpha beta gamma].each do |text|
+          Note.create!(session: session, number: nil, text: text,
+                       date: times.first, latitude: 1, longitude: 1)
+        end
+      end
+      ENV['APPLY'] = 'true'
+
+      task.invoke
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to eq([keeper.id])
+    end
+  end
+
+  describe 'dry run disclosure' do
+    it 'names the version bump, so approving a dry run approves what apply does' do
+      keeper = build_copy(times)
+      build_copy(times)
+
+      output = capture_stdout { task.invoke }
+
+      expect(output).to match(/keeping ##{keeper.id} \(version 1 → 2\)/)
+      expect(keeper.reload.version).to eq(1)
+    end
+  end
+end

--- a/spec/tasks/delete_empty_fixed_duplicates_spec.rb
+++ b/spec/tasks/delete_empty_fixed_duplicates_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'sessions:delete_empty_fixed_duplicates' do
+  before(:all) do
+    Rake.application.rake_require('tasks/delete_empty_fixed_duplicates', [Rails.root.join('lib').to_s])
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task) { Rake::Task['sessions:delete_empty_fixed_duplicates'] }
+  let(:user) { create(:user) }
+  let(:uuid) { SecureRandom.uuid }
+
+  before { task.reenable }
+  after { ENV.delete('APPLY') }
+
+  # Duplicates cannot be made through validations — that is what the bug was.
+  def build_copy(attrs = {})
+    session = build(:fixed_session, { user: user, uuid: uuid, url_token: SecureRandom.hex(5) }.merge(attrs))
+    session.save(validate: false)
+    session.update_columns(created_at: 30.days.ago) # past MIN_AGE_DAYS
+    session
+  end
+
+  context 'when every copy is empty' do
+    it 'keeps the oldest and deletes the rest' do
+      keeper = build_copy
+      build_copy
+      build_copy
+      ENV['APPLY'] = 'true'
+
+      task.invoke
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to eq([keeper.id])
+    end
+
+    it 'writes nothing during a dry run' do
+      build_copy
+      build_copy
+
+      expect { task.invoke }.to output(/WOULD DELETE/).to_stdout
+      expect(Session.where(uuid: uuid).count).to eq(2)
+    end
+
+    it 'does not leave a tombstone that would make phones drop the survivor' do
+      build_copy
+      build_copy
+      ENV['APPLY'] = 'true'
+
+      task.invoke
+
+      expect(DeletedSession.where(uuid: uuid, user_id: user.id)).to be_empty
+    end
+  end
+
+  context 'when a copy holds anything' do
+    it 'skips a group where one copy has a stream' do
+      keeper = build_copy
+      copy = build_copy
+      create(:stream, session: copy)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/not empty.*streams=1/m).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([keeper.id, copy.id])
+    end
+
+    it 'skips a group where a copy carries a session_token' do
+      keeper = build_copy
+      copy = build_copy(session_token: SecureRandom.hex(16))
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/not empty.*session_token=1/m).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([keeper.id, copy.id])
+    end
+
+    it 'skips a group where a copy has notes' do
+      keeper = build_copy
+      copy = build_copy
+      create(:note, session: copy)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/not empty.*notes=1/m).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([keeper.id, copy.id])
+    end
+
+    it 'reports fixed_measurements, which live in their own table' do
+      keeper = build_copy
+      copy = build_copy
+      stream = create(:stream, session: copy)
+      create(:fixed_measurement, stream: stream)
+      ENV['APPLY'] = 'true'
+
+      expect { task.invoke }.to output(/fixed_measurements=1/m).to_stdout
+
+      expect(Session.where(uuid: uuid).pluck(:id)).to match_array([keeper.id, copy.id])
+    end
+  end
+
+  it 'never touches mobile sessions' do
+    mobile = build(:mobile_session, user: user, uuid: uuid, url_token: SecureRandom.hex(5))
+    mobile.save(validate: false)
+    mobile.update_columns(created_at: 30.days.ago)
+    mobile_copy = build(:mobile_session, user: user, uuid: uuid, url_token: SecureRandom.hex(5))
+    mobile_copy.save(validate: false)
+    mobile_copy.update_columns(created_at: 30.days.ago)
+    ENV['APPLY'] = 'true'
+
+    task.invoke
+
+    expect(Session.where(uuid: uuid).count).to eq(2)
+  end
+
+  it 'skips a uuid shared with a mobile session' do
+    fixed_a = build_copy
+    fixed_b = build_copy
+    mobile = build(:mobile_session, user: user, uuid: uuid, url_token: SecureRandom.hex(5))
+    mobile.save(validate: false)
+    mobile.update_columns(created_at: 30.days.ago)
+    ENV['APPLY'] = 'true'
+
+    expect { task.invoke }.to output(/shared with a mobile session/).to_stdout
+
+    expect(Session.where(uuid: uuid).pluck(:id)).to match_array([fixed_a.id, fixed_b.id, mobile.id])
+  end
+
+  it 'survives a failing group, still prints the summary, and counts nothing for it' do
+    build_copy
+    build_copy
+    allow(EmptyFixedSession).to receive(:destroy_session!).and_raise(StandardError, 'boom')
+    ENV['APPLY'] = 'true'
+
+    output = capture_stdout { task.invoke }
+
+    expect(output).to match(/nothing was deleted for this group/)
+    expect(output).to match(/--- summary ---/)
+    expect(output).to match(/sessions deleted: 0/)
+    expect(Session.where(uuid: uuid).count).to eq(2)
+  end
+
+  it 'skips a group whose sessions are newer than MIN_AGE_DAYS' do
+    build_copy
+    build_copy.update_columns(created_at: 1.day.ago)
+    ENV['APPLY'] = 'true'
+
+    expect { task.invoke }.to output(/setup may still be in progress/).to_stdout
+
+    expect(Session.where(uuid: uuid).count).to eq(2)
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+end


### PR DESCRIPTION
Fixed and Mobile sessions happen to have duplicates. 
Rake tasks are to safely clear the data so that unique index on uuid can be added for sessions table